### PR TITLE
Increase timeout to 10 hours (temporarily).

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -23,7 +23,7 @@ t0 = BashOperator(task_id="delayed_start",
 
 t1 = EMRSparkOperator(task_id="main_summary",
                       job_name="Main Summary View",
-                      execution_timeout=timedelta(hours=6),
+                      execution_timeout=timedelta(hours=10),
                       instance_count=10,
                       env = {"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.airflow_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/main_summary_view.sh",


### PR DESCRIPTION
The job is expected to take 3-4 hours, but was intermittently
timing out at 6 hours. Increase to 10 hours while profiling and
debugging the job.