### PR TITLE
Move data output to the telemetry-parquet bucket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ docker push mozdata/telemetry-airflow
 
 ### Testing
 
+When developing and testing a new DAG, it should be configured to write data to the `telemetry-test-bucket` bucket, and **not** the `airflow_bucket` specified in the ansible environment. Only when the new code and data have been validated should it begin writing to the `airflow_bucket`.
+
 A single task, e.g. `spark`, of an Airflow dag, e.g. `example`, can be run with an execution date, e.g. `2016-01-01`, in the `dev` environment with:
 ```bash
 AWS_SECRET_ACCESS_KEY=... AWS_ACCESS_KEY_ID=... \

--- a/ansible/envs/stage.yml
+++ b/ansible/envs/stage.yml
@@ -1,5 +1,5 @@
 region: us-west-2
-airflow_bucket: telemetry-test-bucket
+airflow_bucket: telemetry-parquet
 spark_bucket: telemetry-spark-emr-2
 
 emr_key_name: mozilla_vitillo


### PR DESCRIPTION
This affects all jobs via the location of the airflow.sh script, but
in particular, it also moves the output location for the
`main_summary.py` and `crash_aggregates.py` jobs.

New jobs should be tested by explicitly writing to the test bucket.