### PR TITLE
Bug 1286825: Set num_runs for scheduler.

### DIFF
--- a/ansible/deploy_aws.yml
+++ b/ansible/deploy_aws.yml
@@ -64,7 +64,7 @@
         SMTP_HOST: "{{ smtp_credentials.host }}"
         SMTP_USER: "{{ smtp_credentials.user }}"
         SMTP_PASSWORD: "{{ smtp_credentials.password }}"
-        COMMAND: scheduler  # https://github.com/aws/amazon-ecs-cli/issues/28
+        COMMAND: scheduler -n 5 # https://github.com/aws/amazon-ecs-cli/issues/28
 
     # TODO: create a new module capable of updating the service with the new definition or ensure that the
     # revision of a new task definition is incremental (for some reason it's not always the case...)

--- a/ansible/deploy_local.yml
+++ b/ansible/deploy_local.yml
@@ -1,7 +1,7 @@
 - name: deploy Airflow containers locally
   hosts: localhost
   vars:
-    command: scheduler
+    command: scheduler -n 5
     compose_conf:
       - ansible/files/docker-compose.yml
       - ansible/files/docker-compose-local.yml


### PR DESCRIPTION
By default the scheduler runs forever. Apparently this causes it
to get jammed up periodically, and the recommended practice is to
restart the scheduler frequently. This change sets the scheduler
to exit after 5 runs. Docker should take care of restarting it for
us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/22)
<!-- Reviewable:end -->
