### PR TITLE
Reaper should spare ECS instances.

### DIFF
--- a/ansible/provision_aws.yml
+++ b/ansible/provision_aws.yml
@@ -100,3 +100,4 @@
           - Name: telemetry-ecs-instance
           - Type: telemetry-ecs-instance
           - Owner: telemetry@mozilla.com
+          - REAPER_SPARE_ME: true


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/27)
<!-- Reviewable:end -->
