### PR TITLE
Bug 1275889 - Prepare "Main Summary" job for backfill

### DIFF
--- a/ansible/files/airflow/airflow.cfg
+++ b/ansible/files/airflow/airflow.cfg
@@ -30,16 +30,16 @@ sql_alchemy_pool_recycle = 3600
 # The amount of parallelism as a setting to the executor. This defines
 # the max number of task instances that should run simultaneously
 # on this airflow installation
-parallelism = 8
+parallelism = 16
 
 # The number of task instances allowed to run concurrently by the scheduler
-dag_concurrency = 8
+dag_concurrency = 16
 
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = False
 
 # The maximum number of active DAG runs per DAG
-max_active_runs_per_dag = 5
+max_active_runs_per_dag = 10
 
 # Whether to load the examples that ship with Airflow. It's good to
 # get started, but you probably want to set this to False in a production

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -6,7 +6,7 @@ from airflow.operators import BashOperator
 default_args = {
     'owner': 'mreid@mozilla.com',
     'depends_on_past': False,
-    'start_date': datetime(2016, 6, 27),
+    'start_date': datetime(2016, 6, 25),
     'email': ['telemetry-alerts@mozilla.com', 'mreid@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
@@ -14,7 +14,7 @@ default_args = {
     'retry_delay': timedelta(minutes=30),
 }
 
-dag = DAG('main_summary', default_args=default_args, schedule_interval='@daily')
+dag = DAG('main_summary', default_args=default_args, schedule_interval='@daily', max_active_runs=10)
 
 # Make sure all the data for the given day has arrived before running.
 t0 = BashOperator(task_id="delayed_start",
@@ -25,7 +25,7 @@ t1 = EMRSparkOperator(task_id="main_summary",
                       job_name="Main Summary View",
                       execution_timeout=timedelta(hours=10),
                       instance_count=10,
-                      env = {"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/main_summary_view.sh",
                       dag=dag)
 


### PR DESCRIPTION
Set the max number of active runs so we don't overwhelm the system,
and rewind the start date by a couple of days to test that the
scheduler does the right thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/30)
<!-- Reviewable:end -->
