### PR TITLE
Increase mobile_clients execution timeout

### DIFF
--- a/dags/mobile_clients.py
+++ b/dags/mobile_clients.py
@@ -17,7 +17,7 @@ dag = DAG('mobile_clients', default_args=default_args, schedule_interval='@daily
 
 t0 = EMRSparkOperator(task_id="mobile_clients",
                       job_name="Update mobile clients",
-                      execution_timeout=timedelta(hours=2),
+                      execution_timeout=timedelta(hours=4),
                       instance_count=5,
                       owner="mdoglio@mozilla.com",
                       email=["telemetry-alerts@mozilla.com", "mdoglio@mozilla.com"],


### PR DESCRIPTION
The mobile_clients task is timing out after 2h, let's try to increase it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/33)
<!-- Reviewable:end -->
