### PR TITLE
EMR release version should be configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.retry
+*undo-tree~
+*.un~
 venv

--- a/ansible/deploy_aws.yml
+++ b/ansible/deploy_aws.yml
@@ -51,7 +51,6 @@
       environment:
         AWS_REGION: "{{ region }}"
         EMR_KEY_NAME: "{{ emr_key_name }}"
-        EMR_RELEASE_LABEL: "{{ emr_release_label }}"
         EMR_FLOW_ROLE: "{{ emr_flow_role }}"
         EMR_SERVICE_ROLE: "{{ emr_service_role }}"
         EMR_INSTANCE_TYPE: "{{ emr_instance_type }}"

--- a/ansible/deploy_local.yml
+++ b/ansible/deploy_local.yml
@@ -15,7 +15,6 @@
       environment:
         AWS_REGION: "{{ region }}"
         EMR_KEY_NAME: "{{ emr_key_name }}"
-        EMR_RELEASE_LABEL: "{{ emr_release_label }}"
         EMR_FLOW_ROLE: "{{ emr_flow_role }}"
         EMR_SERVICE_ROLE: "{{ emr_service_role }}"
         EMR_INSTANCE_TYPE: "{{ emr_instance_type }}"

--- a/ansible/envs/dev.yml
+++ b/ansible/envs/dev.yml
@@ -5,7 +5,6 @@ public_output_bucket: telemetry-test-bucket
 private_output_bucket: telemetry-test-bucket
 
 emr_key_name: mozilla_vitillo
-emr_release_label: emr-4.5.0
 emr_flow_role: telemetry-spark-cloudformation-TelemetrySparkInstanceProfile-1SATUBVEXG7E3
 emr_service_role: EMR_DefaultRole
 emr_instance_type: c3.4xlarge

--- a/ansible/envs/stage.yml
+++ b/ansible/envs/stage.yml
@@ -5,7 +5,6 @@ public_output_bucket: telemetry-public-analysis-2
 private_output_bucket: telemetry-parquet
 
 emr_key_name: mozilla_vitillo
-emr_release_label: emr-4.5.0
 emr_flow_role: telemetry-spark-cloudformation-TelemetrySparkInstanceProfile-1SATUBVEXG7E3
 emr_service_role: EMR_DefaultRole
 emr_instance_type: c3.4xlarge

--- a/ansible/files/docker-compose.yml
+++ b/ansible/files/docker-compose.yml
@@ -17,7 +17,6 @@ webserver:
         - AIRFLOW_ENABLE_AUTH
         - AWS_REGION
         - EMR_KEY_NAME
-        - EMR_RELEASE_LABEL
         - EMR_FLOW_ROLE
         - EMR_SERVICE_ROLE
         - EMR_INSTANCE_TYPE
@@ -49,7 +48,6 @@ flower:
         - AIRFLOW_ENABLE_AUTH
         - AWS_REGION
         - EMR_KEY_NAME
-        - EMR_RELEASE_LABEL
         - EMR_FLOW_ROLE
         - EMR_SERVICE_ROLE
         - EMR_INSTANCE_TYPE
@@ -80,7 +78,6 @@ scheduler:
         - AIRFLOW_ENABLE_AUTH
         - AWS_REGION
         - EMR_KEY_NAME
-        - EMR_RELEASE_LABEL
         - EMR_FLOW_ROLE
         - EMR_SERVICE_ROLE
         - EMR_INSTANCE_TYPE
@@ -113,7 +110,6 @@ worker:
         - AIRFLOW_ENABLE_AUTH
         - AWS_REGION
         - EMR_KEY_NAME
-        - EMR_RELEASE_LABEL
         - EMR_FLOW_ROLE
         - EMR_SERVICE_ROLE
         - EMR_INSTANCE_TYPE

--- a/dags/operators/emr_spark_operator.py
+++ b/dags/operators/emr_spark_operator.py
@@ -33,7 +33,6 @@ class EMRSparkOperator(BaseOperator):
 
     region = environ["AWS_REGION"]
     key_name = environ["EMR_KEY_NAME"]
-    release_label = environ["EMR_RELEASE_LABEL"]
     flow_role = environ["EMR_FLOW_ROLE"]
     service_role = environ["EMR_SERVICE_ROLE"]
     instance_type = environ["EMR_INSTANCE_TYPE"]
@@ -65,11 +64,12 @@ class EMRSparkOperator(BaseOperator):
 
 
     @apply_defaults
-    def __init__(self, job_name, owner, uri, instance_count, output_visibility="private", env={}, arguments="", *args, **kwargs):
+    def __init__(self, job_name, owner, uri, instance_count, release_label="emr-4.5.0", output_visibility="private", env={}, arguments="", *args, **kwargs):
         super(EMRSparkOperator, self).__init__(*args, **kwargs)
         self.job_name = job_name
         self.owner = owner
         self.uri = uri
+        self.release_label = release_label
         self.arguments = arguments
         self.environment = " ".join(["{}={}".format(k, v) for k, v in env.iteritems()])
         self.job_flow_id = None
@@ -104,7 +104,7 @@ class EMRSparkOperator(BaseOperator):
         client = boto3.client('emr', region_name=EMRSparkOperator.region)
         response = client.run_job_flow(
             Name = self.job_name,
-            ReleaseLabel = EMRSparkOperator.release_label,
+            ReleaseLabel = self.release_label,
             JobFlowRole = EMRSparkOperator.flow_role,
             ServiceRole = EMRSparkOperator.service_role,
             Applications = [{'Name': 'Spark'}, {'Name': 'Hive'}],


### PR DESCRIPTION
As we want to support multiple versions of Spark we have to allow users
to configure the EMR release they want their tasks to run in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/41)
<!-- Reviewable:end -->
