### PR TITLE
Force Scala jobs to use Spark 1.6

### DIFF
--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -18,9 +18,10 @@ dag = DAG('longitudinal', default_args=default_args, schedule_interval='@weekly'
 t0 = EMRSparkOperator(task_id="longitudinal",
                       job_name="Longitudinal View",
                       execution_timeout=timedelta(hours=10),
+                      release_label="emr-5.0.0",
                       instance_count=30,
                       env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/longitudinal_view.sh",
+                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/spark2/jobs/longitudinal_view.sh",
                       dag=dag)
 
 t1 = EMRSparkOperator(task_id="update_orphaning",

--- a/jobs/addon_recommender.sh
+++ b/jobs/addon_recommender.sh
@@ -5,7 +5,7 @@ if [[ -z "$privateBucket" || -z "$publicBucket" || -z "$date" ]]; then
     exit 1
 fi
 
-git clone https://github.com/mozilla/telemetry-batch-view.git
+git clone -b spark1.6 https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
 mkdir ml_output

--- a/jobs/client_count_view.sh
+++ b/jobs/client_count_view.sh
@@ -5,7 +5,7 @@ if [[ -z "$bucket" || -z "$date" ]]; then
     exit 1
 fi
 
-git clone https://github.com/mozilla/telemetry-batch-view.git
+git clone -b spark1.6 https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
 spark-submit --conf spark.memory.useLegacyMode=true \

--- a/jobs/crash_aggregate_view.sh
+++ b/jobs/crash_aggregate_view.sh
@@ -5,7 +5,7 @@ if [[ -z "$bucket" || -z "$date" ]]; then
    exit 1
 fi
 
-git clone https://github.com/mozilla/telemetry-batch-view.git
+git clone -b spark1.6 https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
 spark-submit --master yarn-client --class com.mozilla.telemetry.views.CrashAggregateView target/scala-2.10/telemetry-batch-view-1.1.jar --bucket $bucket --from $date --to $date

--- a/jobs/longitudinal_view.sh
+++ b/jobs/longitudinal_view.sh
@@ -5,7 +5,7 @@ if [[ -z "$bucket" || -z "$date" ]]; then
     exit 1
 fi
 
-git clone https://github.com/mozilla/telemetry-batch-view.git
+git clone -b spark1.6 https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
 spark-submit --executor-cores 8 \

--- a/jobs/longitudinal_view.sh
+++ b/jobs/longitudinal_view.sh
@@ -5,14 +5,15 @@ if [[ -z "$bucket" || -z "$date" ]]; then
     exit 1
 fi
 
-git clone -b spark1.6 https://github.com/mozilla/telemetry-batch-view.git
+git clone -b spark2 https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
 spark-submit --executor-cores 8 \
              --conf spark.memory.useLegacyMode=true \
              --conf spark.storage.memoryFraction=0 \
-             --master yarn-client \
+             --master yarn \
+             --deploy-mode client \
              --class com.mozilla.telemetry.views.LongitudinalView \
-             target/scala-2.10/telemetry-batch-view-1.1.jar \
+             target/scala-2.11/telemetry-batch-view-1.1.jar \
              --to $date \
              --bucket $bucket

--- a/jobs/main_summary_view.sh
+++ b/jobs/main_summary_view.sh
@@ -5,7 +5,7 @@ if [[ -z "$bucket" || -z "$date" ]]; then
    exit 1
 fi
 
-git clone https://github.com/mozilla/telemetry-batch-view.git
+git clone -b spark1.6 https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
 spark-submit --master yarn-client \


### PR DESCRIPTION
This patch will ensure that Scala jobs use the latest available
version of telemetry-batch-view written for Spark 1.6. This is needed as
the master branch of telemetry-batch-view is going to be based on Spark 2.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/42)
<!-- Reviewable:end -->
