### PR TITLE
Bug 1306558 - Don't use jupyter to run .py files

### DIFF
--- a/ansible/files/spark/airflow.sh
+++ b/ansible/files/spark/airflow.sh
@@ -99,7 +99,7 @@ elif [[ $uri == *.ipynb ]]; then
     fi
 elif [[ $uri == *.py ]]; then
     time env $environment \
-    PYSPARK_PYTHON=/home/hadoop/anaconda2/bin/python spark-submit \
+    PYSPARK_DRIVER_PYTHON=/home/hadoop/anaconda2/bin/python PYSPARK_DRIVER_PYTHON_OPTS= spark-submit \
     $runner_args --master yarn-client "./$job" $args
     rc=$?
 else


### PR DESCRIPTION
The PYSPARK_DRIVER_PYTHON inherited by the environment is jupyter by
default, so we need to revert it to plain python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/50)
<!-- Reviewable:end -->
