### PR TITLE
Bug 1304662 - Increase main_summary delay to 1hr

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -18,7 +18,7 @@ dag = DAG('main_summary', default_args=default_args, schedule_interval='@daily')
 
 # Make sure all the data for the given day has arrived before running.
 t0 = BashOperator(task_id="delayed_start",
-                  bash_command="sleep 1800",
+                  bash_command="sleep 3600",
                   dag=dag)
 
 t1 = EMRSparkOperator(task_id="main_summary",


### PR DESCRIPTION
Handle the increased timeout to flush data to S3, ensuring that all
data is available for the previous day when we process main pings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/52)
<!-- Reviewable:end -->
