### PR TITLE
Bug 1286249: Add timeouts to jobs without them

### DIFF
--- a/dags/bugzilla_dataset.py
+++ b/dags/bugzilla_dataset.py
@@ -29,6 +29,7 @@ env = {
 t0 = EMRSparkOperator(
     task_id="update_bugs",
     job_name="Bugzilla Dataset Update",
+    execution_timeout=timedelta(hours=5),
     instance_count=1,
     env=env,
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/bugzilla_dataset.sh",

--- a/dags/crash_aggregates.py
+++ b/dags/crash_aggregates.py
@@ -19,6 +19,7 @@ t0 = EMRSparkOperator(task_id = "crash_aggregate_view",
                       job_name = "Crash Aggregate View",
                       release_label="emr-5.0.0",
                       instance_count = 9,
+                      execution_timeout=timedelta(hours=4),
                       env = {"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/crash_aggregate_view.sh",
                       dag = dag)

--- a/dags/crash_aggregates_backfill.py
+++ b/dags/crash_aggregates_backfill.py
@@ -19,6 +19,7 @@ t0 = EMRSparkOperator(task_id = "crash_aggregates_view_backfill",
                       job_name = "Crash Aggregates View Backfill",
                       release_label="emr-5.0.0",
                       instance_count = 20,
+                      execution_timeout=timedelta(hours=4),
                       env = {"date": "{{ ds_nodash }}", "bucket": "telemetry-test-bucket"},
                       uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/crash_aggregate_view.sh",
                       dag = dag)

--- a/dags/example.py
+++ b/dags/example.py
@@ -19,6 +19,7 @@ dag = DAG('example', default_args=default_args, schedule_interval='@daily')
 t0 = EMRSparkOperator(task_id = "spark",
                       job_name = "Spark Example Job",
                       instance_count = 1,
+                      execution_timeout=timedelta(hours=4),
                       env = {"date": "{{ ds_nodash }}"},
                       uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/examples/spark/example_date.ipynb",
                       dag = dag)
@@ -26,6 +27,7 @@ t0 = EMRSparkOperator(task_id = "spark",
 t1 = EMRSparkOperator(task_id = "bash",
                       job_name = "Bash Example Job",
                       instance_count = 1,
+                      execution_timeout=timedelta(hours=4),
                       env = {"date": "{{ ds_nodash }}"},
                       uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/examples/spark/example_date.sh",
                       dag = dag)

--- a/dags/telemetry_aggregates.py
+++ b/dags/telemetry_aggregates.py
@@ -18,6 +18,7 @@ dag = DAG('telemetry_aggregates', default_args=default_args, schedule_interval='
 t0 = EMRSparkOperator(task_id = "telemetry_aggregate_view",
                       job_name = "Telemetry Aggregate View",
                       instance_count = 6,
+                      execution_timeout=timedelta(hours=10),
                       env = {"date": "{{ ds_nodash }}"},
                       uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_aggregator.py",
                       dag = dag)


### PR DESCRIPTION
Not sure how I should be testing these, but the dags are kicking off fine locally so it looks like the timeouts are being parsed correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/55)
<!-- Reviewable:end -->
