### PR TITLE
Bug 1290146 - Change date param to end of the week in longitudinal tasks

### DIFF
--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -1,7 +1,7 @@
 from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
-from utils.constants import DS_PLUS_7_NO_DASH
+from utils.constants import DS_WEEKLY
 
 default_args = {
     'owner': 'rvitillo@mozilla.com',
@@ -21,7 +21,7 @@ t0 = EMRSparkOperator(task_id="longitudinal",
                       execution_timeout=timedelta(hours=10),
                       release_label="emr-5.0.0",
                       instance_count=30,
-                      env={"date": DS_PLUS_7_NO_DASH, "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      env={"date": DS_WEEKLY, "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/longitudinal_view.sh",
                       dag=dag)
 
@@ -32,7 +32,7 @@ t1 = EMRSparkOperator(task_id="update_orphaning",
                       owner="spohl@mozilla.com",
                       email=["telemetry-alerts@mozilla.com", "spohl@mozilla.com",
                              "mhowell@mozilla.com"],
-                      env={"date": DS_PLUS_7_NO_DASH},
+                      env={"date": DS_WEEKLY},
                       uri="https://raw.githubusercontent.com/mozilla-services/data-pipeline/master/reports/update-orphaning/Update%20orphaning%20analysis%20using%20longitudinal%20dataset.ipynb",
                       output_visibility="public",
                       dag=dag)
@@ -45,7 +45,7 @@ t2 = EMRSparkOperator(task_id="addon_recommender",
                       owner="aplacitelli@mozilla.com",
                       email=["telemetry-alerts@mozilla.com", "rvitillo@mozilla.com",
                              "aplacitelli@mozilla.com"],
-                      env={"date": DS_PLUS_7_NO_DASH,
+                      env={"date": DS_WEEKLY,
                            "privateBucket": "{{ task.__class__.private_output_bucket }}",
                            "publicBucket": "{{ task.__class__.public_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addon_recommender.sh",
@@ -67,7 +67,7 @@ t4 = EMRSparkOperator(task_id="cross_sectional",
                       execution_timeout=timedelta(hours=10),
                       release_label="emr-5.0.0",
                       instance_count=30,
-                      env={"date": DS_PLUS_7_NO_DASH, "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      env={"date": DS_WEEKLY, "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/cross_sectional_view.sh",
                       dag=dag)
 

--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -1,6 +1,7 @@
 from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
+from utils.constants import DS_PLUS_7_NO_DASH
 
 default_args = {
     'owner': 'rvitillo@mozilla.com',
@@ -20,7 +21,7 @@ t0 = EMRSparkOperator(task_id="longitudinal",
                       execution_timeout=timedelta(hours=10),
                       release_label="emr-5.0.0",
                       instance_count=30,
-                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      env={"date": DS_PLUS_7_NO_DASH, "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/longitudinal_view.sh",
                       dag=dag)
 
@@ -31,7 +32,7 @@ t1 = EMRSparkOperator(task_id="update_orphaning",
                       owner="spohl@mozilla.com",
                       email=["telemetry-alerts@mozilla.com", "spohl@mozilla.com",
                              "mhowell@mozilla.com"],
-                      env={"date": "{{ ds_nodash }}"},
+                      env={"date": DS_PLUS_7_NO_DASH},
                       uri="https://raw.githubusercontent.com/mozilla-services/data-pipeline/master/reports/update-orphaning/Update%20orphaning%20analysis%20using%20longitudinal%20dataset.ipynb",
                       output_visibility="public",
                       dag=dag)
@@ -44,7 +45,7 @@ t2 = EMRSparkOperator(task_id="addon_recommender",
                       owner="aplacitelli@mozilla.com",
                       email=["telemetry-alerts@mozilla.com", "rvitillo@mozilla.com",
                              "aplacitelli@mozilla.com"],
-                      env={"date": "{{ ds_nodash }}",
+                      env={"date": DS_PLUS_7_NO_DASH,
                            "privateBucket": "{{ task.__class__.private_output_bucket }}",
                            "publicBucket": "{{ task.__class__.public_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addon_recommender.sh",
@@ -66,7 +67,7 @@ t4 = EMRSparkOperator(task_id="cross_sectional",
                       execution_timeout=timedelta(hours=10),
                       release_label="emr-5.0.0",
                       instance_count=30,
-                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      env={"date": DS_PLUS_7_NO_DASH, "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/cross_sectional_view.sh",
                       dag=dag)
 

--- a/dags/utils/constants.py
+++ b/dags/utils/constants.py
@@ -1,4 +1,4 @@
-DS_PLUS_7_NO_DASH = (
+DS_WEEKLY = (
     '{% if dag_run.external_trigger %}'
         '{{ ds_nodash }}'
     '{% else %}'

--- a/dags/utils/constants.py
+++ b/dags/utils/constants.py
@@ -1,0 +1,1 @@
+DS_PLUS_7_NO_DASH = '{{ macros.ds_format(macros.ds_add(ds, 7), "%Y-%m-%d", "%Y%m%d") }}'

--- a/dags/utils/constants.py
+++ b/dags/utils/constants.py
@@ -1,1 +1,7 @@
-DS_PLUS_7_NO_DASH = '{{ macros.ds_format(macros.ds_add(ds, 7), "%Y-%m-%d", "%Y%m%d") }}'
+DS_PLUS_7_NO_DASH = (
+    '{% if dag_run.external_trigger %}'
+        '{{ ds_nodash }}'
+    '{% else %}'
+        '{{ macros.ds_format(macros.ds_add(ds, 7), "%Y-%m-%d", "%Y%m%d") }}'
+    '{% endif %}'
+)


### PR DESCRIPTION
This hasn't been tested on an actual run, but the rendered output on each of the tasks looks correct:
<img src="https://cloud.githubusercontent.com/assets/953153/19368618/749d3682-9166-11e6-8c3e-9e4cc374c155.png" />

Note that this means if we trigger a manual run of the DAG, the date passed will be current_date + 7 days since there's no way to override execution date in that command.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/56)
<!-- Reviewable:end -->
