### PR TITLE
Bug 1310486 - Default dags_are_paused_at_creation to True in airflow config

### DIFF
--- a/ansible/files/airflow/airflow.cfg
+++ b/ansible/files/airflow/airflow.cfg
@@ -36,7 +36,7 @@ parallelism = 16
 dag_concurrency = 16
 
 # Are DAGs paused by default at creation
-dags_are_paused_at_creation = False
+dags_are_paused_at_creation = True
 
 # The maximum number of active DAG runs per DAG
 max_active_runs_per_dag = 5


### PR DESCRIPTION
This fixes the issue of dev deployments accidentally launching clusters for elapsed jobs -- all new DAGs will now start off by default and must be explicitly turned on when ready.

![screen shot 2016-10-17 at 5 17 31 pm](https://cloud.githubusercontent.com/assets/953153/19457813/bdaea71e-948d-11e6-8b23-6cfc66f03c52.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/57)
<!-- Reviewable:end -->
