### PR TITLE
Bug 1310715 - Weekly date param should add 6 days to execution date

### DIFF
--- a/dags/utils/constants.py
+++ b/dags/utils/constants.py
@@ -2,6 +2,6 @@ DS_WEEKLY = (
     '{% if dag_run.external_trigger %}'
         '{{ ds_nodash }}'
     '{% else %}'
-        '{{ macros.ds_format(macros.ds_add(ds, 7), "%Y-%m-%d", "%Y%m%d") }}'
+        '{{ macros.ds_format(macros.ds_add(ds, 6), "%Y-%m-%d", "%Y%m%d") }}'
     '{% endif %}'
 )


### PR DESCRIPTION
The weekly date fix from last week should have added 6 days, not 7. Tested and working on dev.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/58)
<!-- Reviewable:end -->
