### PR TITLE
Bug 1309352 - Update all local paths in ansible playbooks for ansible 2.1.2.0

### DIFF
--- a/ansible/deploy_aws.yml
+++ b/ansible/deploy_aws.yml
@@ -9,7 +9,7 @@
       s3: bucket={{airflow_bucket}} region={{region}} mode=create
 
     - name: copy EMR bootstrap script
-      s3: bucket={{airflow_bucket}} region={{region}} object=steps/airflow.sh src=ansible/files/spark/airflow.sh mode=put
+      s3: bucket={{airflow_bucket}} region={{region}} object=steps/airflow.sh src={{ playbook_dir }}/files/spark/airflow.sh mode=put
 
     - name: create load balancer
       ec2_elb_lb:
@@ -47,7 +47,7 @@
       shell: "{{ item }}"
       with_items:
         - ecs-cli configure --cluster {{ ecs_cluster_name }}
-        - ecs-cli compose --project-name telemetry-airflow --file ansible/files/docker-compose.yml create
+        - ecs-cli compose --project-name telemetry-airflow --file {{ playbook_dir }}/files/docker-compose.yml create
       environment:
         AWS_REGION: "{{ region }}"
         EMR_KEY_NAME: "{{ emr_key_name }}"

--- a/ansible/deploy_local.yml
+++ b/ansible/deploy_local.yml
@@ -3,8 +3,8 @@
   vars:
     command: scheduler -n 5 # See bug 1286825
     compose_conf:
-      - ansible/files/docker-compose.yml
-      - ansible/files/docker-compose-local.yml
+      - "{{ playbook_dir }}/files/docker-compose.yml"
+      - "{{ playbook_dir }}/files/docker-compose-local.yml"
 
   tasks:
     - name: launch Airflow containers

--- a/ansible/provision_aws.yml
+++ b/ansible/provision_aws.yml
@@ -16,7 +16,7 @@
         state: "present"
         region: "{{ region }}"
         disable_rollback: true
-        template: "ansible/files/cloudformation.json"
+        template: "{{ playbook_dir }}/files/cloudformation.json"
         tags:
           type: "telemetry"
           application: "ecs"


### PR DESCRIPTION
Local paths in playbooks are now relative to the playbook location, not where the playbook is run from in ansible 2.1.2.0

After we merge these changes, everyone will need to update their ansible versions locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/60)
<!-- Reviewable:end -->
