### PR TITLE
Reduce the number of instances for Addons

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -42,7 +42,7 @@ t3 = EMRSparkOperator(task_id="addons",
                       job_name="Addons View",
                       execution_timeout=timedelta(hours=4),
                       release_label="emr-5.0.0",
-                      instance_count=10,
+                      instance_count=3,
                       env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addons_view.sh",
                       dag=dag)


### PR DESCRIPTION
Reading from main_summary is a lot more efficient than reading the
raw data. 3 instances should be plenty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/68)
<!-- Reviewable:end -->
