### PR TITLE
Bug 1304503 - Port the churn report job to Airflow

### DIFF
--- a/dags/churn.py
+++ b/dags/churn.py
@@ -1,0 +1,27 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from operators.emr_spark_operator import EMRSparkOperator
+from utils.constants import DS_WEEKLY
+
+default_args = {
+    'owner': 'amiyaguchi@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2016, 12, 23),
+    'email': ['telemetry-alerts@mozilla.com', 'amiyaguchi@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+dag = DAG('churn', default_args=default_args, schedule_interval='@weekly')
+
+t0 = EMRSparkOperator(task_id="churn",
+                      job_name="Generate weekly desktop retention dataset",
+                      execution_timeout=timedelta(hours=4),
+                      release_label="emr-5.0.0",
+                      instance_count=5,
+                      env={"date": DS_WEEKLY},
+                      uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn.kp/orig_src/Churn.ipynb",
+                      output_visibility="public",
+                      dag=dag)


### PR DESCRIPTION
This schedules the weekly job for generating the desktop churn/retention dataset.

This has been tested with the following command:
`> ansible-playbook ansible/deploy_local.yml -e '@ansible/envs/dev.yml' -e "command='test churn churn 20161221'"`

r? @Dexterp37

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/77)
<!-- Reviewable:end -->
