### PR TITLE
Bug 1321424 - Raise memory limits

### DIFF
--- a/ansible/files/docker-compose.yml
+++ b/ansible/files/docker-compose.yml
@@ -72,7 +72,7 @@ flower:
 scheduler:
     image: mozdata/telemetry-airflow
     restart: always
-    mem_limit: 2147483648
+    mem_limit: 4294967296
     environment:
         - AIRFLOW_HOME=/usr/local/airflow
         - AIRFLOW_ENABLE_AUTH
@@ -100,7 +100,7 @@ scheduler:
 worker:
     image: mozdata/telemetry-airflow
     restart: always
-    mem_limit: 2147483648
+    mem_limit: 4294967296
     environment:
         - AIRFLOW_HOME=/usr/local/airflow
     ports:

--- a/dags/debug.py
+++ b/dags/debug.py
@@ -1,0 +1,19 @@
+from airflow import DAG
+from operators.sleep_operator import SleepOperator
+from datetime import datetime, timedelta
+
+default_args = {
+    'owner': 'nobody@example.com',
+    'depends_on_past': False,
+    'start_date': datetime(2099, 5, 31),
+    'email': [],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 3,
+    'retry_delay': timedelta(minutes=10),
+}
+
+dag = DAG('debug', default_args=default_args, schedule_interval='@daily')
+
+for x in range(12):
+    SleepOperator(task_id='sleep{}'.format(x), sleep_time=300, dag=dag)

--- a/dags/operators/sleep_operator.py
+++ b/dags/operators/sleep_operator.py
@@ -1,0 +1,15 @@
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+import logging
+import time
+
+class SleepOperator(BaseOperator):
+    @apply_defaults
+    def __init__(self, sleep_time=30, *args, **kwargs):
+        super(SleepOperator, self).__init__(*args, **kwargs)
+        self.sleep_time=sleep_time
+
+    def execute(self, context):
+        logging.info("Sleeping for {} seconds".format(self.sleep_time))
+        time.sleep(self.sleep_time)
+        logging.info("Done sleeping for {} seconds".format(self.sleep_time))


### PR DESCRIPTION
- Adds a few debugging dags and an operator that I found useful while working on this issue
- Raises memory limits to 4 GB on the worker and the scheduler

I wasn't actually able to reproduce the error locally (just a bunch of the Broken Pipe errors that we apparently get all the time, not just when we get zombie tasks). Nonetheless, it's clear we're running up against the memory limits on these machines when we're running at max concurrency and this is a quick and easy change -- the ECS machine has 30GB of memory so we're far from hitting actual resource limits. I just checked and the scheduler container is at just over 1 GB of memory with 3 concurrent tasks, and I was able to max out 2GB on the worker locally so I think it makes sense to raise the limit for both the worker and scheduler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/79)
<!-- Reviewable:end -->
