### PR TITLE
Bug 1291340 - Add sync log import DAG

### DIFF
--- a/dags/sync_log.py
+++ b/dags/sync_log.py
@@ -1,0 +1,27 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from operators.emr_spark_operator import EMRSparkOperator
+
+default_args = {
+    'owner': 'mreid@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2017, 1, 1),
+    'email': ['telemetry-alerts@mozilla.com', 'mreid@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+# Make sure all the data for the given day has arrived before running.
+# Running at 1am should suffice.
+dag = DAG('sync_log', default_args=default_args, schedule_interval='0 1 * * *')
+
+t0 = EMRSparkOperator(task_id="sync_log",
+                      job_name="Sync Log Import",
+                      execution_timeout=timedelta(hours=10),
+                      release_label="emr-5.0.0",
+                      instance_count=10,
+                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/sync_log.kp/orig_src/ImportSyncLogs.ipynb",
+                      dag=dag)

--- a/dags/sync_view.py
+++ b/dags/sync_view.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
-from airflow.operators import BashOperator
 
 default_args = {
     'owner': 'markh@mozilla.com',


### PR DESCRIPTION
Schedule the sync_log job to run daily (after a 1-hour timeout to wait for all data to arrive).

I am running a test right now, will update when it completes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/80)
<!-- Reviewable:end -->
