### PR TITLE
Add events job to main_summary dag

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -62,7 +62,19 @@ t5 = EMRSparkOperator(task_id="daily_search_rollup",
                       output_visibility="private",
                       dag=dag)
 
+t6 = EMRSparkOperator(task_id="main_events",
+                      job_name="Main Events View",
+                      execution_timeout=timedelta(hours=4),
+                      release_label="emr-5.2.1",
+                      owner="ssuh@mozilla.com",
+                      email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
+                      instance_count=1,
+                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/main_events_view.sh",
+                      dag=dag)
+
 t2.set_upstream(t1)
 t3.set_upstream(t1)
 t4.set_upstream(t1)
 t5.set_upstream(t1)
+t6.set_upstream(t1)

--- a/jobs/main_events_view.sh
+++ b/jobs/main_events_view.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ -z "$bucket" || -z "$date" ]]; then
+   echo "Missing arguments!" 1>&2
+   exit 1
+fi
+
+git clone https://github.com/mozilla/telemetry-batch-view.git
+cd telemetry-batch-view
+sbt assembly
+spark-submit --master yarn \
+             --deploy-mode client \
+             --class com.mozilla.telemetry.views.MainEventsView \
+             target/scala-2.11/telemetry-batch-view-1.1.jar \
+             --bucket $bucket \
+             --from $date \
+             --to $date


### PR DESCRIPTION
Landed this job last week in telemetry-batch-view and am now getting around to adding it to the daily main_summary dag (I'll run the backfill by hand through whenever this lands)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/87)
<!-- Reviewable:end -->
