### PR TITLE
Change ipython location for telemetry aggregator

### DIFF
--- a/jobs/telemetry_aggregator.py
+++ b/jobs/telemetry_aggregator.py
@@ -1,4 +1,4 @@
-#!/home/hadoop/anaconda2/bin/ipython
+#!/mnt/anaconda2/bin/ipython
 
 import logging
 from os import environ


### PR DESCRIPTION
The changes to telemetry.sh moves anaconda from /home/hadoop to /mnt.

Tested this and it works. @vitillo r?