### PR TITLE
Use default EMR release for telemetry_aggregates

### DIFF
--- a/dags/telemetry_aggregates.py
+++ b/dags/telemetry_aggregates.py
@@ -18,7 +18,6 @@ dag = DAG('telemetry_aggregates', default_args=default_args, schedule_interval='
 t0 = EMRSparkOperator(task_id = "telemetry_aggregate_view",
                       job_name = "Telemetry Aggregate View",
                       instance_count = 10,
-                      release_label="emr-4.5.0",
                       execution_timeout=timedelta(hours=12),
                       env = {"date": "{{ ds_nodash }}"},
                       uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_aggregator.py",

--- a/dags/telemetry_aggregates_fennec_backfill.py
+++ b/dags/telemetry_aggregates_fennec_backfill.py
@@ -18,7 +18,6 @@ dag = DAG('telemetry_aggregates_fennec_backfill', default_args=default_args, sch
 t0 = EMRSparkOperator(task_id = "telemetry_aggregate_fennec_backfill",
                       job_name = "Telemetry Aggregate Fennec Backfill",
                       instance_count = 7,
-                      release_label="emr-4.5.0",
                       execution_timeout=timedelta(hours=5),
                       env = {"date": "{{ ds_nodash }}"},
                       uri = "https://raw.githubusercontent.com/fbertsch/python_mozaggregator/fennec_backfill/telemetry_aggregator.py",


### PR DESCRIPTION
Note: this PR depends on #90 & mozilla/python_mozaggregator#42.

https://bugzilla.mozilla.org/show_bug.cgi?id=1344020.