### PR TITLE
Fix ClientCountView crash triggered by Spark 2.0.2

### DIFF
--- a/jobs/client_count_view.sh
+++ b/jobs/client_count_view.sh
@@ -8,9 +8,7 @@ fi
 git clone https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
-spark-submit --conf spark.memory.useLegacyMode=true \
-             --conf spark.storage.memoryFraction=0 \
-             --master yarn \
+spark-submit --master yarn \
              --deploy-mode client \
              --class com.mozilla.telemetry.views.ClientCountView \
              target/scala-2.11/telemetry-batch-view-1.1.jar \


### PR DESCRIPTION
The legacy memory management mode doesn't work properly in Spark 2.0.2
and causes ClientCountView to crash when creating a DataFrame of the
main_summary table.