### PR TITLE
Bug 1345217 - Add churn_to_csv downstream from churn

### DIFF
--- a/dags/churn.py
+++ b/dags/churn.py
@@ -24,3 +24,13 @@ t0 = EMRSparkOperator(task_id="churn",
                       uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn.kp/orig_src/Churn.ipynb",
                       output_visibility="public",
                       dag=dag)
+
+t1 = EMRSparkOperator(task_id="churn_to_csv",
+                      job_name="Generate Churn CSV files",
+                      execution_timeout=timedelta(hours=4),
+                      instance_count=1,
+                      env={"date": DS_WEEKLY},
+                      uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn_to_csv.kp/orig_src/churn_to_csv.ipynb",
+                      dag=dag)
+
+t1.set_upstream(t0)


### PR DESCRIPTION
[Bug 1345217 - [Churn] Separate csv uploads to s3 from churn job](https://bugzilla.mozilla.org/show_bug.cgi?id=1345217)

This job runs downstream of churn, generating csv files from the churn parquet data. The source notebook was added to [mozilla-reports](https://github.com/mozilla/mozilla-reports/pull/36) this week. 