### PR TITLE
Fix LongitudinalView crash triggered by Spark 2.0.2

### DIFF
--- a/jobs/longitudinal_view.sh
+++ b/jobs/longitudinal_view.sh
@@ -9,8 +9,6 @@ git clone https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
 spark-submit --executor-cores 8 \
-             --conf spark.memory.useLegacyMode=true \
-             --conf spark.storage.memoryFraction=0 \
              --master yarn \
              --deploy-mode client \
              --class com.mozilla.telemetry.views.LongitudinalView \


### PR DESCRIPTION
The legacy memory management mode doesn't work properly in Spark
2.0.2 and causes LongitudinalView to crash.