### PR TITLE
Bug 1350380 - Use ds_nodash instead of DS_WEEKLY for churn

### DIFF
--- a/dags/churn.py
+++ b/dags/churn.py
@@ -20,7 +20,7 @@ t0 = EMRSparkOperator(task_id="churn",
                       job_name="Generate weekly desktop retention dataset",
                       execution_timeout=timedelta(hours=4),
                       instance_count=5,
-                      env={"date": DS_WEEKLY},
+                      env={"date": "{{ ds_nodash }}"},
                       uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn.kp/orig_src/Churn.ipynb",
                       output_visibility="public",
                       dag=dag)
@@ -29,7 +29,7 @@ t1 = EMRSparkOperator(task_id="churn_to_csv",
                       job_name="Generate Churn CSV files",
                       execution_timeout=timedelta(hours=4),
                       instance_count=1,
-                      env={"date": DS_WEEKLY},
+                      env={"date": "{{ ds_nodash }}"},
                       uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn_to_csv.kp/orig_src/churn_to_csv.ipynb",
                       dag=dag)
 

--- a/dags/churn.py
+++ b/dags/churn.py
@@ -14,7 +14,7 @@ default_args = {
     'retry_delay': timedelta(minutes=30),
 }
 
-dag = DAG('churn', default_args=default_args, schedule_interval='@weekly')
+dag = DAG('churn', default_args=default_args, schedule_interval='0 0 * * 3')
 
 t0 = EMRSparkOperator(task_id="churn",
                       job_name="Generate weekly desktop retention dataset",


### PR DESCRIPTION
This uses `ds_nodash` to set the execution date to the date that the job is scheduled on. 

