### PR TITLE
Bug 1355153 - Run parquet2hive after longitudinal generation

### DIFF
--- a/jobs/longitudinal_view.sh
+++ b/jobs/longitudinal_view.sh
@@ -5,6 +5,8 @@ if [[ -z "$bucket" || -z "$date" ]]; then
     exit 1
 fi
 
+set -e
+
 git clone https://github.com/mozilla/telemetry-batch-view.git
 cd telemetry-batch-view
 sbt assembly
@@ -15,3 +17,5 @@ spark-submit --executor-cores 8 \
              target/scala-2.11/telemetry-batch-view-1.1.jar \
              --to $date \
              --bucket $bucket
+
+parquet2hive -ulv 1 --sql s3://telemetry-parquet/longitudinal | beeline -u jdbc:hive2://${HIVE_SERVER}:10000


### PR DESCRIPTION
Requires https://github.com/mozilla/emr-bootstrap-spark/pull/79.

I verified that steps run via EMRSparkOperator inherit the environment variables added in the bootstrap script.