### PR TITLE
Bug 1357877 - [part 1] Add ToplineSummaryView

### DIFF
--- a/dags/topline.py
+++ b/dags/topline.py
@@ -1,0 +1,40 @@
+from airflow import DAG
+from datetime import timedelta, datetime
+from operators.emr_spark_operator import EMRSparkOperator
+
+default_args = {
+    'owner': 'amiyaguchi@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2017, 3, 26),
+    'email': ['telemetry-alerts@mozilla.com', 'amiyaguchi@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+
+def topline_dag(dag, mode, instance_count):
+    t0 = EMRSparkOperator(
+        task_id="topline_summary",
+        job_name="Topline Summary View",
+        execution_timeout=timedelta(hours=8),
+        instance_count=instance_count,
+        env={
+            "date": "{{ ds_nodash }}",
+            "bucket": "{{ task.__class__.private_output_bucket }}",
+            "mode": mode
+        },
+        uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/topline_summary_view.sh",
+        dag=dag)
+
+
+dag_weekly = DAG('topline_weekly',
+                 default_args=default_args,
+                 schedule_interval='@weekly')
+dag_monthly = DAG('topline_monthly',
+                  default_args=default_args,
+                  schedule_interval='@monthly')
+
+topline_dag(dag_weekly, "weekly", instance_count=5)
+topline_dag(dag_monthly, "monthly", instance_count=10)

--- a/jobs/topline_summary_view.sh
+++ b/jobs/topline_summary_view.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ -z "$bucket" || -z "$date" || -z "$mode" ]]; then
+   echo "Missing arguments!" 1>&2
+   exit 1
+fi
+
+git clone https://github.com/mozilla/telemetry-batch-view.git
+cd telemetry-batch-view
+sbt assembly
+spark-submit --master yarn \
+             --deploy-mode client \
+             --class com.mozilla.telemetry.views.ToplineSummaryView \
+             target/scala-2.11/telemetry-batch-view-1.1.jar \
+             --bucket $bucket \
+             --report_start $date \
+             --mode $mode


### PR DESCRIPTION
This commit adds monthly and weekly topline summary generation to airflow. The current reporting uses periods compatible with airflow's `@weekly`and `@monthly` shortcuts.