### PR TITLE
Bug 1358661 - Add tab spinner severity job

### DIFF
--- a/dags/spinner_severity_generator.py
+++ b/dags/spinner_severity_generator.py
@@ -1,0 +1,26 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from operators.emr_spark_operator import EMRSparkOperator
+
+default_args = {
+    'owner': 'frank@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2017, 4, 25),
+    'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 3,
+    'retry_delay': timedelta(minutes=30),
+}
+
+dag = DAG('tab_spinner_severity', default_args=default_args, schedule_interval='@daily')
+
+t0 = EMRSparkOperator(
+    task_id="update_tab_spinner_severity",
+    job_name="Tab Spinner Severity Job",
+    execution_timeout=timedelta(hours=12),
+    instance_count=12,
+    uri="s3://telemetry-analysis-code-2/jobs/spinner-severity-generator/Spinner-Severity-GraphData-Generator.ipynb",
+    dag=dag
+)
+


### PR DESCRIPTION
This job seems like a candidate for some optimization. It's running analysis every day on all pings from 20160908 onward - >6 hours on its last successful run, so >2500 machine-hours a month. Wouldn't be easy though, it's grouping by build-id and client-id.