### PR TITLE
Remove errant character in txp_pulse

### DIFF
--- a/dags/txp_pulse.py
+++ b/dags/txp_pulse.py
@@ -18,7 +18,7 @@ dag = DAG('txp_pulse', default_args=default_args, schedule_interval='@daily')
 t0 = EMRSparkOperator(task_id="txp_pulse",
                       job_name="Pulse Testpilot Experiment ETL",
                       execution_timeout=timedelta(hours=2),
-r                     instance_count=5,
+                      instance_count=5,
                       env={},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/txp_pulse.sh",
                       dag=dag)


### PR DESCRIPTION
Looks like I added an errant 'r' when appending to my previous commit. Did a local deploy offline to make sure there weren't any other silly errors.