### PR TITLE
Increase nodes for monthly ToplineSummary to 20

### DIFF
--- a/dags/topline.py
+++ b/dags/topline.py
@@ -37,4 +37,4 @@ dag_monthly = DAG('topline_monthly',
                   schedule_interval='@monthly')
 
 topline_dag(dag_weekly, "weekly", instance_count=5)
-topline_dag(dag_monthly, "monthly", instance_count=10)
+topline_dag(dag_monthly, "monthly", instance_count=20)


### PR DESCRIPTION
This increases the number of nodes for monthly topline summary to 20 nodes, which is 4x the capacity of the weekly job. This job would fail before, but now takes 1.75 hours to complete (j-3OTVLPM4P9DH6 is the cluster used for testing).

