### PR TITLE
Bug 1361113 - Use churn from mozetl instead of mozilla-reports

### DIFF
--- a/dags/churn.py
+++ b/dags/churn.py
@@ -20,8 +20,8 @@ t0 = EMRSparkOperator(task_id="churn",
                       job_name="Generate weekly desktop retention dataset",
                       execution_timeout=timedelta(hours=4),
                       instance_count=5,
-                      env={"date": "{{ ds_nodash }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn.kp/orig_src/Churn.ipynb",
+                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/churn.sh",
                       output_visibility="public",
                       dag=dag)
 

--- a/jobs/churn.sh
+++ b/jobs/churn.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [[ -z "$bucket" || -z "$date" ]]; then
+   echo "Missing arguments!" 1>&2
+   exit 1
+fi
+
+# Create the package for distribution across the cluster
+git clone https://github.com/mozilla/python_mozetl.git
+cd python_mozetl
+python setup.py bdist_egg
+
+# Generate the driver script
+echo 'from mozetl.churn import churn; churn.main()' > run.py
+
+# Avoid errors caused by jupyter
+unset PYSPARK_DRIVER_PYTHON
+
+spark-submit --master yarn \
+             --deploy-mode client \
+             --py-files dist/*.egg \
+             run.py $date $bucket


### PR DESCRIPTION
This schedules churn from mozetl instead of mozilla-reports. See [cluster details of the test run](https://us-west-2.console.aws.amazon.com/elasticmapreduce/home?region=us-west-2#cluster-details:j-1IY45MWS4RJS5) for reference. The test job is still running as of this comment. 