### PR TITLE
Bug 1309881: Use fewer nodes to run sync_view job

### DIFF
--- a/dags/sync_view.py
+++ b/dags/sync_view.py
@@ -18,7 +18,7 @@ dag = DAG('sync_view', default_args=default_args, schedule_interval='@daily')
 t0 = EMRSparkOperator(task_id="sync_view",
                       job_name="Sync Pings View",
                       execution_timeout=timedelta(hours=10),
-                      instance_count=10,
+                      instance_count=5,
                       env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/sync_view.sh",
                       dag=dag)


### PR DESCRIPTION
Cut the number of nodes in the cluster from ten to five.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/113)
<!-- Reviewable:end -->
