### PR TITLE
Bug 1329844 - Add topline dashboard generator

### DIFF
--- a/dags/topline.py
+++ b/dags/topline.py
@@ -28,6 +28,17 @@ def topline_dag(dag, mode, instance_count):
         uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/topline_summary_view.sh",
         dag=dag)
 
+    t1 = EMRSparkOperator(
+        task_id="topline_dashboard",
+        job_name="Topline Dashboard",
+        execution_timeout=timedelta(hours=2),
+        instance_count=1,
+        env={"mode": mode},
+        uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/topline_dashboard.sh",
+        dag=dag)
+
+    t1.set_upstream(t0)
+
 
 dag_weekly = DAG('topline_weekly',
                  default_args=default_args,

--- a/jobs/topline_dashboard.sh
+++ b/jobs/topline_dashboard.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -x
+
+if [[ -z "$mode" ]]; then
+   echo "Missing arguments!" 1>&2
+   exit 1
+fi
+
+bucket="net-mozaws-prod-metrics-data"
+prefix="firefox-dashboard"
+
+git clone https://github.com/mozilla/python_mozetl.git
+cd python_mozetl
+python setup.py bdist_egg
+
+# Generate the driver script
+echo "from mozetl.topline import topline_dashboard; topline_dashboard.main()" > run.py
+
+# Avoid errors caused by jupyter
+unset PYSPARK_DRIVER_PYTHON
+
+spark-submit --master yarn \
+             --deploy-mode client \
+             --py-files dist/*.egg \
+             run.py $mode $bucket $prefix


### PR DESCRIPTION
[Bug 1357877 - Add `ToplineSummary` and `topline_dashboard` to Airflow](https://bugzilla.mozilla.org/show_bug.cgi?id=1357877)

This adds the mozetl topline_dashboard script as a dependency of the topline summary. The PR for fixing toLocalIterator issues with timeouts should be addressed before this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/114)
<!-- Reviewable:end -->
