### PR TITLE
Bug 1364530 - Use search rollup from mozetl instead of gist

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -53,10 +53,10 @@ t4 = EMRSparkOperator(task_id="hbase_main_summary",
 
 t5 = EMRSparkOperator(task_id="daily_search_rollup",
                       job_name="Daily Search Rollup",
-                      email=["telemetry-alerts@mozilla.com", "spenrose@mozilla.com", "amiyaguchi@mozilla.com"],
+                      email=["telemetry-alerts@mozilla.com", "spenrose@mozilla.com", "amiyaguchi@mozilla.com", "harterrt@mozilla.com"],
                       execution_timeout=timedelta(hours=6),
                       instance_count=30,
-                      uri="https://gist.githubusercontent.com/SamPenrose/856aa21191ef9f0de18c94220cd311a8/raw/afaafc7e5903afb4dde047b43d8e5b2dc2bf6968/daily-main_summary-to-vertica-search-rollups.ipynb",
+                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/search_rollups.sh",
                       output_visibility="private",
                       dag=dag)
 

--- a/jobs/search_rollups.sh
+++ b/jobs/search_rollups.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Create the package for distribution across the cluster
+git clone https://github.com/mozilla/python_mozetl.git
+cd python_mozetl
+python setup.py bdist_egg
+
+# Generate the driver script
+echo 'from mozetl.search import daily_search_rollups as dsr; dsr.main()' > run.py
+
+# Avoid errors caused by jupyter
+unset PYSPARK_DRIVER_PYTHON
+
+spark-submit --master yarn \
+             --deploy-mode client \
+             --py-files dist/*.egg \
+             run.py


### PR DESCRIPTION
[Bug 1364530 - Migrate Search ETL job to python_mozetl](https://bugzilla.mozilla.org/show_bug.cgi?id=1364530)

This schedules the search ETL from mozetl instead of the gist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/telemetry-airflow/117)
<!-- Reviewable:end -->
