### PR TITLE
Add core client count job

### DIFF
--- a/dags/core_client_count.py
+++ b/dags/core_client_count.py
@@ -1,0 +1,24 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from operators.emr_spark_operator import EMRSparkOperator
+
+default_args = {
+    'owner': 'frank@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2017, 5, 26),
+    'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+dag = DAG('core_client_count', default_args=default_args, schedule_interval='@weekly')
+
+t0 = EMRSparkOperator(task_id="core_client_count_view",
+                      job_name="Core Client Count View",
+                      execution_timeout=timedelta(hours=4),
+                      instance_count=20,
+                      env = {"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/core_client_count_view.sh",
+                      dag=dag)

--- a/jobs/core_client_count_view.sh
+++ b/jobs/core_client_count_view.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [[ -z "$bucket" || -z "$date" ]]; then
+    echo "Missing arguments!" 1>&2
+    exit 1
+fi
+
+git clone https://github.com/mozilla/telemetry-batch-view.git
+cd telemetry-batch-view
+sbt assembly
+
+base="channel,"
+base+="default_search," # 143 values
+base+="locale,"
+base+="app_name,"
+base+="os,"
+base+="osversion,"
+base+="distribution_id," # 31 values
+base+="arch" # 5 values
+
+select="regexp_extract(created, '(201[67]-[0-9]{2}-[0-9]{2})', 1) as created_date,"
+select+="metadata.geo_country as geo_country," # 247 values
+select+=$base
+
+group="created_date,"
+group+="geo_country,"
+group+=$base
+
+spark-submit --master yarn \
+             --deploy-mode client \
+             --class com.mozilla.telemetry.views.GenericCountView \
+             target/scala-2.11/telemetry-batch-view-1.1.jar \
+             --to $date \
+             --files "s3://net-mozaws-prod-us-west-2-pipeline-data/telemetry-core-parquet/v2" \
+             --count-column "client_id" \
+             --select "$select" \
+             --grouping-columns "$group" \
+             --where "client_id IS NOT NULL" \
+             --output "$bucket/core_client_count"


### PR DESCRIPTION
Tested this in `telemetry-test-bucket`. Test table is in STMO already (`core_client_count` table).