### PR TITLE
Use submission_date_s3 col for client_count

### DIFF
--- a/jobs/client_count_view.sh
+++ b/jobs/client_count_view.sh
@@ -36,7 +36,6 @@ spark-submit --master yarn \
              target/scala-2.11/telemetry-batch-view-1.1.jar \
              --to $date \
              --files "s3://telemetry-parquet/main_summary/v4/" \
-             --submission-date-col "submission_date" \
              --count-column "client_id" \
              --select "$select" \
              --grouping-columns "$group" \


### PR DESCRIPTION
Noticed this as I was investigating the failures.

Used submission_date previously, which is not a partitioned col.
This should speed up the job a bit. Note that GenericCountView
uses submission_date_s3 as the default, so we can just remove
the argument altogether.