### PR TITLE
Install dependencies for mozetl

### DIFF
--- a/jobs/search_rollups.sh
+++ b/jobs/search_rollups.sh
@@ -10,6 +10,8 @@ git clone https://github.com/mozilla/python_mozetl.git
 cd python_mozetl
 python setup.py bdist_egg
 
+pip install -e .
+
 bucket="net-mozaws-prod-us-west-2-pipeline-analysis"
 prefix="spenrose/search/to_vertica"
 


### PR DESCRIPTION
This fixes launch errors from things like arrow in search_rollups

```
Traceback (most recent call last):
  File "/mnt/analyses/python_mozetl/run.py", line 1, in <module>
    from mozetl.search import search_rollups as sr; sr.main()
  File "/mnt/analyses/python_mozetl/mozetl/search/search_rollups.py", line 13, in <module>
    import arrow
ImportError: No module named arrow
```