### PR TITLE
Fix argument order for search rollup

### DIFF
--- a/jobs/search_rollups.sh
+++ b/jobs/search_rollups.sh
@@ -24,4 +24,4 @@ unset PYSPARK_DRIVER_PYTHON
 spark-submit --master yarn \
              --deploy-mode client \
              --py-files dist/*.egg \
-             run.py $mode $date $bucket $prefix
+             run.py $date $mode $bucket $prefix


### PR DESCRIPTION
The order of arguments into the search rollup is wrong.

```
Successfully installed arrow-0.10.0 mozetl
Usage: run.py [OPTIONS] START_DATE MODE BUCKET PREFIX

Error: Invalid value for "mode": invalid choice: 20170628. (choose from daily, monthly)
```