### PR TITLE
Schedule `python_mozetl/topline/topline_summary`

### DIFF
--- a/jobs/topline_summary_view.sh
+++ b/jobs/topline_summary_view.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
 
-if [[ -z "$bucket" || -z "$date" || -z "$mode" ]]; then
+if [[ -z "$date" || -z "$mode" || -z "$bucket" ]]; then
    echo "Missing arguments!" 1>&2
    exit 1
 fi
 
-git clone https://github.com/mozilla/telemetry-batch-view.git
-cd telemetry-batch-view
-sbt assembly
+# Create the package for distribution across the cluster
+git clone https://github.com/mozilla/python_mozetl.git
+cd python_mozetl
+python setup.py bdist_egg
+
+pip install -e .
+
+# Generate the driver script
+echo 'from mozetl.topline import topline_summary as ts; ts.main()' > run.py
+
+# Avoid errors caused by jupyter
+unset PYSPARK_DRIVER_PYTHON
+
 spark-submit --master yarn \
              --deploy-mode client \
-             --class com.mozilla.telemetry.views.ToplineSummaryView \
-             target/scala-2.11/telemetry-batch-view-1.1.jar \
-             --bucket $bucket \
-             --report_start $date \
-             --mode $mode
+             --py-files dist/*.egg \
+             run.py $date $mode $bucket topline_summary/v1


### PR DESCRIPTION
This schedules the `mozetl` version of `topline_summary`, which is significantly improved from the old version.