### PR TITLE
Remove extraneous version number from topline prefix

### DIFF
--- a/jobs/topline_summary_view.sh
+++ b/jobs/topline_summary_view.sh
@@ -21,4 +21,4 @@ unset PYSPARK_DRIVER_PYTHON
 spark-submit --master yarn \
              --deploy-mode client \
              --py-files dist/*.egg \
-             run.py $date $mode $bucket topline_summary/v1
+             run.py $date $mode $bucket topline_summary


### PR DESCRIPTION
The version number is [appended to the prefix in the topline_summary job](https://github.com/mozilla/python_mozetl/blob/master/mozetl/topline/topline_summary.py#L252), so this should be removed to be in the correct location.

