### PR TITLE
Fix syntax error in main_summary dag

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -30,7 +30,7 @@ t2 = EMRSparkOperator(task_id="engagement_ratio",
                       email=["telemetry-alerts@mozilla.com", "spenrose@mozilla.com"],
                       execution_timeout=timedelta(hours=6),
                       instance_count=10,
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/engagement_ratio.sh"
+                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/engagement_ratio.sh",
                       output_visibility="public",
                       dag=dag)
 


### PR DESCRIPTION
``` Broken DAG: [/app/dags/main_summary.py] invalid syntax (main_summary.py, line 34) ``` showed up on the stage instance.