### PR TITLE
Bug 1380173 - Reduce daily_search_rollup instance count to 1

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -56,7 +56,7 @@ t5 = EMRSparkOperator(task_id="daily_search_rollup",
                       job_name="Daily Search Rollup",
                       email=["telemetry-alerts@mozilla.com", "spenrose@mozilla.com", "amiyaguchi@mozilla.com", "harterrt@mozilla.com"],
                       execution_timeout=timedelta(hours=6),
-                      instance_count=10,
+                      instance_count=1,
                       env={
                         "date": "{{ ds_nodash }}",
                         "mode": "daily"


### PR DESCRIPTION
[Bug 1380173 - Reduce daily_search_rollup instance count to 1](https://bugzilla.mozilla.org/show_bug.cgi?id=1380173)

This reduces the size of the job from 10 nodes to 1 node. The job takes 51 minutes to run on a single node. 