### PR TITLE
Install mozetl before running hardware report

### DIFF
--- a/jobs/hardware_report.sh
+++ b/jobs/hardware_report.sh
@@ -8,6 +8,7 @@ fi
 # Create the package for distribution across the cluster
 git clone https://github.com/mozilla/python_mozetl.git
 cd python_mozetl
+pip install .
 python setup.py bdist_egg
 
 # Generate the driver script


### PR DESCRIPTION
This ensures the dependencies are also installed.

I'll be able to test this once https://github.com/mozilla/python_mozetl/pull/85 is submitted.