### PR TITLE
Make the HBase Addon Recommender job use EMR 5.8.0

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -139,6 +139,7 @@ t12 = EMRSparkOperator(task_id="hbase_addon_recommender",
                        execution_timeout=timedelta(hours=10),
                        instance_count=5,
                        env={"date": "{{ ds_nodash }}"},
+                       release_label="emr-5.8.0",
                        uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/hbase_addon_recommender_view.sh",
                        dag=dag)
 


### PR DESCRIPTION
This is needed otherwise, due to bug [SPARK-12837] in Spark < 2.2.0,
broadcasting during a join will result with an OOM error like: "Total
size of serialized results of XXX is bigger than
spark.driver.maxResultSize (YYY GB)"