### PR TITLE
Bug 1397048 - Embed search_rollups directly into dags

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -2,6 +2,7 @@ from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
 from utils.mozetl import mozetl_envvar
+from search_rollup import add_search_rollup
 
 default_args = {
     'owner': 'mreid@mozilla.com',
@@ -158,3 +159,5 @@ t10.set_upstream(t9)
 t11.set_upstream(t10)
 t12.set_upstream(t1)
 t13.set_upstream(t1)
+
+add_search_rollup(dag, "daily", 1, upstream=t1)

--- a/dags/search_rollup.py
+++ b/dags/search_rollup.py
@@ -24,25 +24,13 @@ default_args = {
 }
 
 
-dag_daily = DAG('search_rollup_daily',
-                 default_args=default_args,
-                 schedule_interval='@daily')
-
-
 dag_monthly = DAG('search_rollup_monthly',
                   default_args=default_args,
-                  schedule_interval='@monthly')
+                  schedule_interval='0 0 2 * *')
 
 
-def search_rollup_dag(dag, mode, instance_count):
-    """Create a sensor for main_summary and attach the search rollup."""
-
-    main_summary_sensor = ExternalTaskSensor(
-        task_id="main_summary_sensor",
-        external_dag_id="main_summary",
-        external_task_id="main_summary",
-        dag=dag
-    )
+def add_search_rollup(dag, mode, instance_count, upstream=None):
+    """Create a search rollup for a particular date date"""
 
     search_rollup = EMRSparkOperator(
         task_id="search_rollup_{}".format(mode),
@@ -59,8 +47,8 @@ def search_rollup_dag(dag, mode, instance_count):
         dag=dag
     )
 
-    search_rollup.set_upstream(main_summary_sensor)
+    if upstream:
+        search_rollup.set_upstream(upstream)
 
 
-search_rollup_dag(dag_daily, "daily", instance_count=1)
-search_rollup_dag(dag_monthly, "monthly", instance_count=3)
+add_search_rollup(dag_monthly, "monthly", instance_count=3)


### PR DESCRIPTION
This removes the `ExternalTaskSensor` and makes the `search_rollup` job depend
on concrete instances of a job. The daily job will depend on the
`main_summary` dag, while the monthly job will run on the 2nd of the
month.