### PR TITLE
Reduce parquet file size for client_count

### DIFF
--- a/jobs/client_count_view.sh
+++ b/jobs/client_count_view.sh
@@ -40,4 +40,5 @@ spark-submit --master yarn \
              --select "$select" \
              --grouping-columns "$group" \
              --where "client_id IS NOT NULL" \
-             --output "$bucket/client_count"
+             --output "$bucket/client_count" \
+             --num-parquet-files 250


### PR DESCRIPTION
We're averaging around 70GB per run these days, so increase from
the default of 32 partitions to 250 to bring file size back into
the "sweet spot" of 200-300MB.