### PR TITLE
Bug 1401655 - Run clients_daily and experiments_daily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ redis-cli:
 	docker-compose run redis redis-cli -h redis
 
 run:
-	docker-compose run web airflow $(COMMAND)
+	docker-compose run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID web airflow $(COMMAND)
 
 secret:
 	@docker-compose run web python -c \

--- a/README.md
+++ b/README.md
@@ -25,11 +25,18 @@ An Airflow container can be built with
 make build
 ```
 
+You should then run the database migrations to complete the container initialization with
+
+```bash
+make migrate
+```
+
 ### Testing
 
 A single task, e.g. `spark`, of an Airflow dag, e.g. `example`, can be run with an execution date, e.g. `2016-01-01`, in the `dev` environment with:
 ```bash
-AWS_SECRET_ACCESS_KEY=... AWS_ACCESS_KEY_ID=... \
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_ACCESS_KEY_ID=...
 make run COMMAND="test example spark 20160101"
 ```
 

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -19,145 +19,156 @@ default_args = {
 # Running at 1am should suffice.
 dag = DAG('main_summary', default_args=default_args, schedule_interval='0 1 * * *')
 
-t1 = EMRSparkOperator(task_id="main_summary",
-                      job_name="Main Summary View",
-                      execution_timeout=timedelta(hours=10),
-                      instance_count=25,
-                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/main_summary_view.sh",
-                      dag=dag)
+main_summary = EMRSparkOperator(
+    task_id="main_summary",
+    job_name="Main Summary View",
+    execution_timeout=timedelta(hours=10),
+    instance_count=25,
+    env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/main_summary_view.sh",
+    dag=dag)
 
-t2 = EMRSparkOperator(task_id="engagement_ratio",
-                      job_name="Update Engagement Ratio",
-                      email=["telemetry-alerts@mozilla.com", "spenrose@mozilla.com"],
-                      execution_timeout=timedelta(hours=6),
-                      instance_count=10,
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/engagement_ratio.sh",
-                      output_visibility="public",
-                      dag=dag)
+engagement_ratio = EMRSparkOperator(
+    task_id="engagement_ratio",
+    job_name="Update Engagement Ratio",
+    execution_timeout=timedelta(hours=6),
+    instance_count=10,
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/engagement_ratio.sh",
+    output_visibility="public",
+    dag=dag)
 
-t3 = EMRSparkOperator(task_id="addons",
-                      job_name="Addons View",
-                      execution_timeout=timedelta(hours=4),
-                      instance_count=3,
-                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addons_view.sh",
-                      dag=dag)
+addons = EMRSparkOperator(
+    task_id="addons",
+    job_name="Addons View",
+    execution_timeout=timedelta(hours=4),
+    instance_count=3,
+    env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addons_view.sh",
+    dag=dag)
 
-t4 = EMRSparkOperator(task_id="hbase_main_summary",
-                      job_name="HBase Main Summary View",
-                      owner="jason@mozilla.com",
-                      email=["telemetry-alerts@mozilla.com", "jason@mozilla.com"],
-                      execution_timeout=timedelta(hours=10),
-                      instance_count=5,
-                      env={"date": "{{ ds_nodash }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/hbase_main_summary_view.sh",
-                      dag=dag)
+hbase_main_summary = EMRSparkOperator(
+    task_id="hbase_main_summary",
+    job_name="HBase Main Summary View",
+    owner="jason@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "jason@mozilla.com"],
+    execution_timeout=timedelta(hours=10),
+    instance_count=5,
+    env={"date": "{{ ds_nodash }}"},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/hbase_main_summary_view.sh",
+    dag=dag)
 
-t6 = EMRSparkOperator(task_id="main_events",
-                      job_name="Main Events View",
-                      execution_timeout=timedelta(hours=4),
-                      owner="ssuh@mozilla.com",
-                      email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
-                      instance_count=1,
-                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/main_events_view.sh",
-                      dag=dag)
+main_events = EMRSparkOperator(
+    task_id="main_events",
+    job_name="Main Events View",
+    execution_timeout=timedelta(hours=4),
+    owner="ssuh@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
+    instance_count=1,
+    env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/main_events_view.sh",
+    dag=dag)
 
-t7 = EMRSparkOperator(task_id="addon_aggregates",
-                      job_name="Addon Aggregates View",
-                      execution_timeout=timedelta(hours=4),
-                      owner="bmiroglio@mozilla.com",
-                      email=["telemetry-alerts@mozilla.com", "bmiroglio@mozilla.com"],
-                      instance_count=3,
-                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/addons/okr-daily-script.kp/orig_src/addonOKRDataCollection.ipynb",
-                      dag=dag)
+addon_aggregates = EMRSparkOperator(
+    task_id="addon_aggregates",
+    job_name="Addon Aggregates View",
+    execution_timeout=timedelta(hours=4),
+    owner="bmiroglio@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "bmiroglio@mozilla.com"],
+    instance_count=3,
+    env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/addons/okr-daily-script.kp/orig_src/addonOKRDataCollection.ipynb",
+    dag=dag)
 
-t8 = EMRSparkOperator(task_id="txp_mau_dau",
-                      job_name="Test Pilot MAU DAU",
-                      execution_timeout=timedelta(hours=4),
-                      owner="ssuh@mozilla.com",
-                      email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
-                      instance_count=5,
-                      env={"date": "{{ ds_nodash }}",
-                           "bucket": "{{ task.__class__.private_output_bucket }}",
-                           "prefix": "txp_mau_dau_simple",
-                           "inbucket": "{{ task.__class__.private_output_bucket }}",
-                           "inprefix": "addons/v2"},
-                      uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/mozetl/testpilot/txp_mau_dau.py",
-                      dag=dag)
+txp_mau_dau = EMRSparkOperator(
+    task_id="txp_mau_dau",
+    job_name="Test Pilot MAU DAU",
+    execution_timeout=timedelta(hours=4),
+    owner="ssuh@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
+    instance_count=5,
+    env={"date": "{{ ds_nodash }}",
+         "bucket": "{{ task.__class__.private_output_bucket }}",
+         "prefix": "txp_mau_dau_simple",
+         "inbucket": "{{ task.__class__.private_output_bucket }}",
+         "inprefix": "addons/v2"},
+    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/mozetl/testpilot/txp_mau_dau.py",
+    dag=dag)
 
-t9 = EMRSparkOperator(task_id="main_summary_experiments",
-                      job_name="Experiments Main Summary View",
-                      execution_timeout=timedelta(hours=10),
-                      instance_count=10,
-                      owner="ssuh@mozilla.com",
-                      email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
-                      env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/experiment_main_summary_view.sh",
-                      dag=dag)
+main_summary_experiments = EMRSparkOperator(
+    task_id="main_summary_experiments",
+    job_name="Experiments Main Summary View",
+    execution_timeout=timedelta(hours=10),
+    instance_count=10,
+    owner="ssuh@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
+    env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/experiment_main_summary_view.sh",
+    dag=dag)
 
-t10 = EMRSparkOperator(task_id="experiments_aggregates",
-                       job_name="Experiments Aggregates View",
-                       execution_timeout=timedelta(hours=15),
-                       instance_count=20,
-                       owner="ssuh@mozilla.com",
-                       email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
-                       env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/experiment_aggregates_view.sh",
-                       dag=dag)
+experiments_aggregates = EMRSparkOperator(
+    task_id="experiments_aggregates",
+    job_name="Experiments Aggregates View",
+    execution_timeout=timedelta(hours=15),
+    instance_count=20,
+    owner="ssuh@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
+    env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/experiment_aggregates_view.sh",
+    dag=dag)
 
-t11 = EMRSparkOperator(task_id="experiments_aggregates_import",
-                       job_name="Experiments Aggregates Import",
-                       execution_timeout=timedelta(hours=10),
-                       instance_count=1,
-                       owner="robhudson@mozilla.com",
-                       email=["telemetry-alerts@mozilla.com", "robhudson@mozilla.com"],
-                       env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
-                       uri="https://raw.githubusercontent.com/mozilla/experiments-viewer/master/notebooks/import.py",
-                       dag=dag)
+experiments_aggregates_import = EMRSparkOperator(
+    task_id="experiments_aggregates_import",
+    job_name="Experiments Aggregates Import",
+    execution_timeout=timedelta(hours=10),
+    instance_count=1,
+    owner="robhudson@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "robhudson@mozilla.com"],
+    env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/experiments-viewer/master/notebooks/import.py",
+    dag=dag)
 
-t12 = EMRSparkOperator(task_id="hbase_addon_recommender",
-                       job_name="HBase Addon Recommender View",
-                       owner="aplacitelli@mozilla.com",
-                       email=["telemetry-alerts@mozilla.com", "aplacitelli@mozilla.com"],
-                       execution_timeout=timedelta(hours=10),
-                       instance_count=5,
-                       env={"date": "{{ ds_nodash }}"},
-                       release_label="emr-5.8.0",
-                       uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/hbase_addon_recommender_view.sh",
-                       dag=dag)
+hbase_addon_recommender = EMRSparkOperator(
+    task_id="hbase_addon_recommender",
+    job_name="HBase Addon Recommender View",
+    owner="aplacitelli@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "aplacitelli@mozilla.com"],
+    execution_timeout=timedelta(hours=10),
+    instance_count=5,
+    env={"date": "{{ ds_nodash }}"},
+    release_label="emr-5.8.0",
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/hbase_addon_recommender_view.sh",
+    dag=dag)
 
-t13 = EMRSparkOperator(task_id="search_dashboard",
-                       job_name="Search Dashboard",
-                       execution_timeout=timedelta(hours=3),
-                       instance_count=3,
-                       owner="harterrt@mozilla.com",
-                       email=["telemetry-alerts@mozilla.com", "harterrt@mozilla.com"],
-                       env=mozetl_envvar("search_dashboard", {
-                             "submission_date": "{{ ds_nodash }}",
-                             "bucket": "{{ task.__class__.private_output_bucket }}",
-                             "prefix": "harter/searchdb",
-                             "save_mode": "overwrite"
-                       }),
-                       uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
-                       output_visibility="private",
-                       dag=dag)
+search_dashboard = EMRSparkOperator(
+    task_id="search_dashboard",
+    job_name="Search Dashboard",
+    execution_timeout=timedelta(hours=3),
+    instance_count=3,
+    owner="harterrt@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "harterrt@mozilla.com"],
+    env=mozetl_envvar("search_dashboard", {
+        "submission_date": "{{ ds_nodash }}",
+        "bucket": "{{ task.__class__.private_output_bucket }}",
+        "prefix": "harter/searchdb",
+        "save_mode": "overwrite"
+    }),
+    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
+    output_visibility="private",
+    dag=dag)
 
-t2.set_upstream(t1)
+engagement_ratio.set_upstream(main_summary)
 
-t3.set_upstream(t1)
-t7.set_upstream(t3)
-t8.set_upstream(t3)
+addons.set_upstream(main_summary)
+addon_aggregates.set_upstream(addons)
+txp_mau_dau.set_upstream(addons)
 
-t4.set_upstream(t1)
-t6.set_upstream(t1)
+hbase_main_summary.set_upstream(main_summary)
+main_events.set_upstream(main_summary)
 
-t9.set_upstream(t1)
-t10.set_upstream(t9)
-t11.set_upstream(t10)
-t12.set_upstream(t1)
-t13.set_upstream(t1)
+main_summary_experiments.set_upstream(main_summary)
+experiments_aggregates.set_upstream(main_summary_experiments)
+experiments_aggregates_import.set_upstream(experiments_aggregates)
+hbase_addon_recommender.set_upstream(main_summary)
+search_dashboard.set_upstream(main_summary)
 
-add_search_rollup(dag, "daily", 1, upstream=t1)
+add_search_rollup(dag, "daily", 1, upstream=main_summary)


### PR DESCRIPTION
This also addresses #155, at least for the `main_summary` DAG.

This needs to land after [the associated PR over in python_mozetl](https://github.com/mozilla/python_mozetl/pull/128), and I need to test this first, so please hold off on reviewing.