### PR TITLE
Bug 1404502 - Pin churn_v2 to `python_mozetl/churn-v2` branch

### DIFF
--- a/dags/churn.py
+++ b/dags/churn.py
@@ -16,24 +16,26 @@ default_args = {
 
 dag = DAG('churn', default_args=default_args, schedule_interval='0 0 * * 3')
 
-t0 = EMRSparkOperator(task_id="churn",
-                      job_name="Generate weekly desktop retention dataset",
-                      execution_timeout=timedelta(hours=4),
-                      instance_count=5,
-                      env=mozetl_envvar("churn", {
-                          "start_date": "{{ ds_nodash }}",
-                          "bucket": "{{ task.__class__.private_output_bucket }}"
-                      }),
-                      uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
-                      output_visibility="public",
-                      dag=dag)
+churn = EMRSparkOperator(
+    task_id="churn",
+    job_name="Generate weekly desktop retention dataset",
+    execution_timeout=timedelta(hours=4),
+    instance_count=5,
+    env=mozetl_envvar("churn", {
+        "start_date": "{{ ds_nodash }}",
+        "bucket": "{{ task.__class__.private_output_bucket }}"
+    }),
+    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
+    output_visibility="public",
+    dag=dag)
 
-t1 = EMRSparkOperator(task_id="churn_to_csv",
-                      job_name="Generate Churn CSV files",
-                      execution_timeout=timedelta(hours=4),
-                      instance_count=1,
-                      env={"date": "{{ ds_nodash }}"},
-                      uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn_to_csv.kp/orig_src/churn_to_csv.ipynb",
-                      dag=dag)
+churn_to_csv = EMRSparkOperator(
+    task_id="churn_to_csv",
+    job_name="Generate Churn CSV files",
+    execution_timeout=timedelta(hours=4),
+    instance_count=1,
+    env={"date": "{{ ds_nodash }}"},
+    uri="https://raw.githubusercontent.com/mozilla/mozilla-reports/master/etl/churn_to_csv.kp/orig_src/churn_to_csv.ipynb",
+    dag=dag)
 
-t1.set_upstream(t0)
+churn_to_csv.set_upstream(churn)

--- a/dags/churn.py
+++ b/dags/churn.py
@@ -24,6 +24,8 @@ churn = EMRSparkOperator(
     env=mozetl_envvar("churn", {
         "start_date": "{{ ds_nodash }}",
         "bucket": "{{ task.__class__.private_output_bucket }}"
+    }, {
+        "MOZETL_GIT_BRANCH": "churn-v2"
     }),
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     output_visibility="public",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1404502)

`churn_v3` adds `new_profile_ping_parquet` as a source for first session clients. I'd like to schedule `churn_v2` in parallel to compare the differences. This uses the `MOZETL_GIT_BRANCH` variable to pass the branch of the pinned v2 code.

Below is an excerpt from [`make run COMMAND="test churn churn 20170910"` logs](https://us-west-2.console.aws.amazon.com/elasticmapreduce/home?region=us-west-2#cluster-details:j-16U3037M03L2B)
```
+ MOZETL_ARGS=churn
+ MOZETL_GIT_PATH=https://github.com/mozilla/python_mozetl.git
+ MOZETL_GIT_BRANCH=churn-v2
+ MOZETL_SPARK_MASTER=yarn
+ unset PYSPARK_DRIVER_PYTHON
++ mktemp -d -t tmp.XXXXXXXXXX
+ workdir=/tmp/tmp.IONh4V2GiY
```



