### PR TITLE
Use EMR 5.8.0 for experiment aggregates job

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -110,6 +110,7 @@ experiments_aggregates = EMRSparkOperator(
     job_name="Experiments Aggregates View",
     execution_timeout=timedelta(hours=15),
     instance_count=20,
+    release_label="emr-5.8.0",
     owner="ssuh@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
     env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},


### PR DESCRIPTION
The experiment aggregates job timed out at least once over the weekend -- it looks like some of the recent spark improvements included EMR 5.8.0 benefit the experiment aggregates job so I'm opting for this instead of upping the number of machines right now.