### PR TITLE
Replace hyphens w/ underscores in mozetl env vars

### DIFF
--- a/dags/utils/mozetl.py
+++ b/dags/utils/mozetl.py
@@ -16,7 +16,7 @@ def mozetl_envvar(command, options, other={}):
     :returns: a dictionary that contains properly prefixed command and options
     """
     prefixed_options = {
-        "MOZETL_{}_{}".format(command.upper(), key.upper()): value
+        "MOZETL_{}_{}".format(command.upper(), key.upper().replace("-", "_")): value
         for key, value in options.iteritems()
     }
     prefixed_options["MOZETL_COMMAND"] = command


### PR DESCRIPTION
Hyphens are not allowed in environment variable names, so this
prevents names with hyphens being properly passed through to
mozetl tasks.