### PR TITLE
Bug 1381840 - Schedule 1-Day Firefox Retention

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -184,7 +184,8 @@ experiments_daily = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     dag=dag)
 
-heavy_users = EMRSparkOperator(task_id="heavy_users_view",
+heavy_users = EMRSparkOperator(
+    task_id="heavy_users_view",
     job_name="Heavy Users View",
     owner="frank@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com"],
@@ -194,7 +195,8 @@ heavy_users = EMRSparkOperator(task_id="heavy_users_view",
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/heavy_users_view.sh",
     dag=dag)
 
-retention = EMRSparkOperator(task_id="retention",
+retention = EMRSparkOperator(
+    task_id="retention",
     job_name="1-Day Firefox Retention",
     owner="amiyaguchi@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com"],

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -194,6 +194,18 @@ heavy_users = EMRSparkOperator(task_id="heavy_users_view",
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/heavy_users_view.sh",
     dag=dag)
 
+retention = EMRSparkOperator(task_id="retention",
+    job_name="1-Day Firefox Retention",
+    owner="amiyaguchi@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com"],
+    execution_timeout=timedelta(hours=4),
+    instance_count=6,
+    env=mozetl_envvar("retention", {
+        "start_date": "{{ ds_nodash }}",
+        "bucket": "{{ task.__class__.private_output_bucket }}",
+    }),
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/retention.sh",
+    dag=dag)
 
 engagement_ratio.set_upstream(main_summary)
 
@@ -217,3 +229,5 @@ add_search_rollup(dag, "daily", 1, upstream=main_summary)
 clients_daily.set_upstream(main_summary)
 
 heavy_users.set_upstream(main_summary)
+
+retention.set_upstream(main_summary)

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -203,6 +203,7 @@ retention = EMRSparkOperator(task_id="retention",
     env=mozetl_envvar("retention", {
         "start_date": "{{ ds_nodash }}",
         "bucket": "{{ task.__class__.private_output_bucket }}",
+        "slack": 4
     }),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/retention.sh",
     dag=dag)

--- a/jobs/retention.sh
+++ b/jobs/retention.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Bug 1381840 - 1-Day Firefox Retention runner
+# 
+# This script runs the corresponding mozetl and telemetry-batch-view jobs.
+# These two jobs could be individual nodes in the airflow DAG, however the jobs
+# uses local cluster memory to pass intermediate data to each other. All dag
+# nodes (as of this revision) run on independent machines. 
+
+
+set -eou pipefail
+set -x
+
+MOZETL_COMMAND=${MOZETL_COMMAND:-retention}
+
+# The environment variables are passed into this script according to the Click
+# `auto_envvar_prefix` convention.
+export MOZETL_RETENTION_START_DATE=${MOZETL_RETENTION_START_DATE?"start_date must be set"}
+export MOZETL_RETENTION_BUCKET=${MOZETL_RETENTION_BUCKET?"output bucket must be set"}
+export MOZETL_RETENTION_PATH="intermediate_path"
+
+# NOTE: the development branch is under acmiyaguchi/<repo>:bug-1381840-retention
+MOZETL_GIT_BRANCH=master
+MOZETL_GIT_PATH=https://github.com/mozilla/python_mozetl.git
+TBV_GIT_PATH=https://github.com/mozilla/telemetry-batch-view.git 
+
+# Variables that are set in the prepare methods
+MOZETL_RUNNER_PATH=
+MOZETL_EGG_PATH=
+TBV_JAR_PATH=
+
+
+prepare_mozetl () {
+    # fetch and build mozetl by generating the egg
+    git clone ${MOZETL_GIT_PATH} --branch ${MOZETL_GIT_BRANCH}
+    cd python_mozetl
+    pip install .
+    python setup.py bdist_egg
+    local rel_egg_path=`ls dist/*.egg`
+    MOZETL_EGG_PATH=`realpath ${rel_egg_path}`
+}
+
+prepare_tbv () {
+    # fetch and build tbv
+    git clone ${TBV_GIT_PATH} --branch ${MOZETL_GIT_BRANCH}
+    cd telemetry-batch-view
+    sbt assembly
+    local rel_jar_path=`ls target/scala-*/telemetry-batch-view-*.jar`
+    TBV_JAR_PATH=`realpath ${rel_jar_path}`
+}
+
+run_mozetl () {
+    unset PYSPARK_DRIVER_PYTHON
+    spark-submit \
+        --master yarn \
+        --deploy-mode client \
+        --py-files ${MOZETL_EGG_PATH} \
+        ${MOZETL_RUNNER_PATH} ${MOZETL_COMMAND}
+}
+
+run_tbv () {
+    spark-submit \
+        --master yarn \
+        --deploy-mode client \
+        --class com.mozilla.telemetry.views.RetentionView \
+        ${TBV_JAR_PATH}  \
+        --date ${MOZETL_RETENTION_START_DATE} \
+        --input ${MOZETL_RETENTION_PATH} \
+        --bucket ${MOZETL_RETENTION_BUCKET}
+}
+
+main () {
+    # create a temporary directory for work
+    workdir=$(mktemp -d -t tmp.XXXXXXXXXX)
+    cleanup () { rm -rf "$workdir" ; }
+    trap cleanup EXIT
+
+    MOZETL_RUNNER_PATH=${workdir}/runner.py
+    cat <<EOT >> $MOZETL_RUNNER_PATH
+from mozetl import cli
+cli.entry_point(auto_envvar_prefix="MOZETL")
+EOT
+
+    # reset directory after each setup call 
+    cd ${workdir} && prepare_mozetl
+    cd ${workdir} && prepare_tbv
+    cd ${workdir}
+
+    local start_date=${1:-${MOZETL_RETENTION_START_DATE}}
+    local end_date=${2:-${start_date}}
+    end_date=`date -d "$end_date + 1 day" +%Y%m%d`
+
+    local current_date=${start_date}
+    while [ "$current_date" != "$end_date" ]; do
+        echo Running job for $current_date
+        export MOZETL_RETENTION_START_DATE=$current_date
+        run_mozetl
+        run_tbv
+        current_date=`date -d "$current_date + 1 day" +%Y%m%d`
+    done
+}
+
+main "$@"


### PR DESCRIPTION
This schedules the job using a slack of 4 days and 13 bits for the HLL
object. This corresponds to the observation of 99% of client activity
with roughly a 1% standard error introduced HLL.

This job shares components in mozetl and in telemetry-batch-view, so
there is a custom job script to launch. This script also accepts
arguments from the command-line can be useful for backfill.