### PR TITLE
Bug 1415602 - Make date sanitation correct for future year boundaries

### DIFF
--- a/jobs/core_client_count_view.sh
+++ b/jobs/core_client_count_view.sh
@@ -18,7 +18,11 @@ base+="osversion,"
 base+="distribution_id," # 31 values
 base+="arch" # 5 values
 
-select="regexp_extract(created, '(201[67]-[0-9]{2}-[0-9]{2})', 1) as created_date,"
+year=$(date +"%Y")
+prev_year=$(($year - 1))
+next_year=$(($year + 1))
+
+select="regexp_extract(created, '(($prev_year|$year|$next_year)-[0-9]{2}-[0-9]{2})', 1) as created_date,"
 select+="metadata.geo_country as geo_country," # 247 values
 select+=$base
 


### PR DESCRIPTION
This moves from a static year sanitation to a programmatically
determined one from the current year, allowing for edge
boundaries of Dec 31 and Jan 1 (where the year can be the
previous or the next).

Tested on Presto.