### PR TITLE
Temporarily disable scalar bootstrapping in experiment aggregates view

### DIFF
--- a/jobs/experiment_aggregates_view.sh
+++ b/jobs/experiment_aggregates_view.sh
@@ -14,4 +14,5 @@ spark-submit --master yarn \
              target/scala-2.11/telemetry-batch-view-1.1.jar \
              --input "s3://$bucket/experiments/v1" \
              --output "s3://$bucket/experiments_aggregates/v1" \
-             --date $date
+             --date $date \
+             --nobootstrapScalars


### PR DESCRIPTION
I'm working on profiling the job a bit to see where it'd be best to apply effort but for now we should make sure there's up-to-date data in the viewer