### PR TITLE
Adding status badge for circleci build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCi](https://circleci.com/gh/mozilla/telemetry-airflow.svg?style=shield&circle-token=62f4c1be98e5c9f36bd667edb7545fa736eed3ae)](https://circleci.com/gh/mozilla/telemetry-airflow)
+
 # Telemetry-Airflow
 Airflow is a platform to programmatically author, schedule and monitor workflows.
 


### PR DESCRIPTION
Adding status badge for circleci build.  This should be an indicator that the dags/*.py files are compiling successfully in master.  

This becomes important because we will soon have airflow sync the dags folder from master every 10 minutes, rather than having to redeploy wtmo every time we want a change to dags.