### PR TITLE
Bug 1422876 - Bump workers for monthly search rollup

### DIFF
--- a/dags/search_rollup.py
+++ b/dags/search_rollup.py
@@ -51,4 +51,4 @@ def add_search_rollup(dag, mode, instance_count, upstream=None):
         search_rollup.set_upstream(upstream)
 
 
-add_search_rollup(dag_monthly, "monthly", instance_count=3)
+add_search_rollup(dag_monthly, "monthly", instance_count=10)


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1422876)

The airflow job for monthly search rollups times out at 4 hours. This bumps the number of nodes from 3 to 10. 