### PR TITLE
Bump default emr release to 5.9.0

### DIFF
--- a/dags/operators/emr_spark_operator.py
+++ b/dags/operators/emr_spark_operator.py
@@ -62,7 +62,7 @@ class EMRSparkOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self, job_name, owner, uri, instance_count,
-                 release_label='emr-5.2.1', output_visibility='private',
+                 release_label='emr-5.9.0', output_visibility='private',
                  env=None, arguments='', *args, **kwargs):
         super(EMRSparkOperator, self).__init__(*args, **kwargs)
         self.job_name = job_name


### PR DESCRIPTION
Bumps the default EMR version to 5.9.0, which I believe has been the default version on ATMO for a while. EMR greater than 5.8.0 contains the application history log for free. 

Here's a cluster run: [link](https://us-west-2.console.aws.amazon.com/elasticmapreduce/home?region=us-west-2#cluster-details:j-2050NFW5OFQD9)