### PR TITLE
Added TAAR ensemble to the airflow DAG.

### DIFF
--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -40,6 +40,17 @@ addon_recommender = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addon_recommender.sh",
     dag=dag)
 
+ensemble_recommender = EMRSparkOperator(
+    task_id="ensemble_recommender",
+    job_name="Extract the addon data for each Telemetry user to DynamoDB",
+    execution_timeout=timedelta(hours=10),
+    instance_count=20,
+    owner="vng@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "vng@mozilla.com"],
+    env={},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/ensemble_taar.sh",
+    dag=dag)
+
 game_hw_survey = EMRSparkOperator(
     task_id="game_hw_survey",
     job_name="Firefox Hardware Report",
@@ -114,3 +125,4 @@ cross_sectional.set_upstream(longitudinal)
 distribution_viewer.set_upstream(cross_sectional)
 taar_locale_job.set_upstream(longitudinal)
 taar_legacy_job.set_upstream(longitudinal)
+ensemble_recommender.set_upstream(longitudinal)

--- a/jobs/ensemble_taar.sh
+++ b/jobs/ensemble_taar.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [[ -z "$date" ]]; then
+   echo "Missing arguments!" 1>&2
+   exit 1
+fi
+
+# Setup a temp directory to work in 
+mkdir tmp_ensemble
+cd tmp_ensemble
+
+# Fetch the airflow job script
+wget https://raw.githubusercontent.com/crankycoder/taar_loader/releases/1.0/scripts/airflow_job.py
+
+# Fetch the python egg
+wget https://github.com/crankycoder/taar_loader/releases/download/releases%2F1.0/taar_loader-1.0-py3.5.egg
+
+spark-submit --master=yarn \
+             --py-files=taar_loader-1.0-py3.5.egg airflow_job.py --date=$date


### PR DESCRIPTION
WIP: do not merge

@Dexterp37 Can you take a quick look at this to see if I'm setting this up correctly?  

I've got all my code for the taar dynamodb loader in a standalone egg file.

The entry point to run the data load is over here: https://github.com/crankycoder/taar_loader/blob/master/scripts/airflow_job.py 

And the bulk of the code is a straight port of the Scala code from https://github.com/mozilla/telemetry-batch-view/blob/master/src/main/scala/com/mozilla/telemetry/views/HBaseAddonRecommenderView.scala

The new python code currently lives in my repo over at: https://github.com/crankycoder/taar_loader/blob/master/taar_loader/