### PR TITLE
Bug 1434991 - Add total_uri_count_threshold to client_count_daily

### DIFF
--- a/jobs/client_count_daily_view.sh
+++ b/jobs/client_count_daily_view.sh
@@ -18,14 +18,18 @@ base+="e10s_enabled,"
 base+="os"
 
 select+="devtools_toolbox_opened_count > 0 as devtools_toolbox_opened,"
-select+="case when distribution_id in ('canonical', 'MozillaOnline', 'yandex') "
-select+="then distribution_id else null end as top_distribution_id,"
+select+="case when distribution_id in ('canonical', 'MozillaOnline', 'yandex')"
+select+=" then distribution_id else null end as top_distribution_id,"
 select+="normalized_os_version as os_version,"
+select+="bucketed(scalar_parent_browser_engagement_total_uri_count,"
+select+=" array(int('0'), int('5'), int('20'), int('50'), int('100'), int('250')))"
+select+=" as total_uri_count_threshold,"
 select+=$base
 
 group+="devtools_toolbox_opened,"
 group+="top_distribution_id,"
 group+="os_version,"
+group+="total_uri_count_threshold,"
 group+=$base
 
 spark-submit --master yarn \


### PR DESCRIPTION
Tested this for `submission_date=20180211` and ran DatasetComparator with all columns except hll and bucketed_uri_count to get:

```
=======================================================================================
BEGINNING JOB dataset_comparator FOR 20180211
Wrong number of rows. Expected 830493. Got 2055911
Wrong number of null values in 'devtools_toolbox_opened'. Expected 740186. Got 1888523
Wrong number of null values in 'top_distribution_id'. Expected 651182. Got 1644546
FAILURE ON JOB dataset_comparator FOR 20180211
=======================================================================================
```

Indicating the same set of distinct value combinations for pre-existing non-hll columns, and a ~2.5 times increase in number of rows due to the new column. increase in number of nulls for calculated columns also increased by ~2.5 times