### PR TITLE
Bug 1445646: Fix Sensor Timeouts in Main Summary Backfill

### DIFF
--- a/plugins/celery_visibility_timeout_fix.py
+++ b/plugins/celery_visibility_timeout_fix.py
@@ -1,0 +1,5 @@
+from airflow.executors.celery_executor import app
+
+# We need to override visibility_timeout in a redis-backed celery queue since the default
+# is one hour, meaning sensors are marked as failed after one hour
+app.conf.BROKER_TRANSPORT_OPTIONS = {'visibility_timeout': 10 * 60 * 60}


### PR DESCRIPTION
This PR does two things:
- Set the celery visiblity_timeout to 6 hours, up from the default 1 hour which was causing our step sensors to fail (https://stackoverflow.com/questions/44274381/airflow-long-running-task-in-subdag-marked-as-failed-after-an-hour)
- Serialize each day's step in airflow to run one after the other, in which case sensors should not run past the new 6 hour limit

Setting the visibility_timeout to a higher limit has the downside of slower reaction times when a worker has failed and a task should be requeued. This isn't a very common event, and setting it to 6 hours (vs 1 day, which apparently some people do to work around this airflow issue) seems like a good compromise.