### PR TITLE
Fix `make build` on osx

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,7 +38,8 @@ RUN mkdir /app && \
     groupadd --gid 10001 app && \
     useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
 
-RUN apt-get update && \
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
+    apt-get update && \
     apt-get install -y --no-install-recommends \
         apt-transport-https build-essential curl git libpq-dev \
         postgresql-client gettext sqlite3 libffi-dev libsasl2-dev && \


### PR DESCRIPTION
I can't run `make build` on osx for testing dags without this