### PR TITLE
Revert "Remove public-read object ACL since this is set on the bucket"

### DIFF
--- a/jobs/probe_scraper.sh
+++ b/jobs/probe_scraper.sh
@@ -24,4 +24,5 @@ python probe_scraper/runner.py --outdir $OUTPUT_DIR --tempdir $CACHE_DIR
 aws s3 sync $OUTPUT_DIR/ s3://$BUCKET/ \
        --delete \
        --content-type 'application/json' \
-       --cache-control 'max-age=28800'
+       --cache-control 'max-age=28800' \
+       --acl public-read


### PR DESCRIPTION
This reverts commit d7c8526571c1e625c507cef4cc68bf34a57f4458.

public-read is set on the bucket but this only allows List permissions. We need the public-read at the object level.