### PR TITLE
Bug 1449249 - Increase number of longitudinal machines to 40

### DIFF
--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -22,7 +22,7 @@ longitudinal = EMRSparkOperator(
     task_id="longitudinal",
     job_name="Longitudinal View",
     execution_timeout=timedelta(hours=12),
-    instance_count=30,
+    instance_count=40,
     release_label="emr-5.11.0",
     env={"date": DS_WEEKLY, "bucket": "{{ task.__class__.private_output_bucket }}"},
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/longitudinal_view.sh",


### PR DESCRIPTION
Let's just hope we don't keep this around much longer...

Note this already ran on 40 machines successfully, and the data already exists for 20180324.