### PR TITLE
Bug 1456549 - Fix search rollup timeout and increase instance count

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -287,7 +287,7 @@ search_clients_daily.set_upstream(main_summary)
 
 taar_dynamo.set_upstream(main_summary)
 
-add_search_rollup(dag, "daily", 1, upstream=main_summary)
+add_search_rollup(dag, "daily", 3, upstream=main_summary)
 
 clients_daily.set_upstream(main_summary)
 

--- a/dags/search_rollup.py
+++ b/dags/search_rollup.py
@@ -6,32 +6,10 @@ from operators.emr_spark_operator import EMRSparkOperator
 from utils.mozetl import mozetl_envvar
 
 
-# These settings only apply to the monthly DAG
-default_args = {
-    'owner': 'amiyaguchi@mozilla.com',
-    'depends_on_past': False,
-    'start_date': datetime(2017, 8, 20),
-    'email': [
-        'telemetry-alerts@mozilla.com',
-        'amiyaguchi@mozilla.com',
-        'harterrt@mozilla.com',
-    ],
-    'email_on_failure': True,
-    'email_on_retry': True,
-    'retries': 2,
-    'retry_delay': timedelta(hours=2),
-}
-
-
-dag_monthly = DAG('search_rollup_monthly',
-                  default_args=default_args,
-                  schedule_interval='0 0 2 * *')
-
-
 def add_search_rollup(dag, mode, instance_count, upstream=None):
     """Create a search rollup for a particular date date
 
-    This can be called with an optional DAG passed into `upstream`. The rollup
+    This can be called with an optional task passed into `upstream`. The rollup
     job will inherit the default values of the referenced DAG.
     """
 
@@ -39,7 +17,11 @@ def add_search_rollup(dag, mode, instance_count, upstream=None):
         task_id="search_rollup_{}".format(mode),
         job_name="{} search rollup".format(mode).title(),
         owner="amiyaguchi@mozilla.com",
-        email=default_args["email"],
+        email=[
+            'telemetry-alerts@mozilla.com',
+            'amiyaguchi@mozilla.com',
+            'harterrt@mozilla.com',
+        ],
         execution_timeout=timedelta(hours=4),
         instance_count=instance_count,
         env=mozetl_envvar("search_rollup", {
@@ -55,5 +37,20 @@ def add_search_rollup(dag, mode, instance_count, upstream=None):
     if upstream:
         search_rollup.set_upstream(upstream)
 
+
+# These settings only apply to the monthly DAG
+default_args = {
+    'depends_on_past': False,
+    'start_date': datetime(2017, 8, 20),
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+
+dag_monthly = DAG('search_rollup_monthly',
+                  default_args=default_args,
+                  schedule_interval='0 0 2 * *')
 
 add_search_rollup(dag_monthly, "monthly", instance_count=10)


### PR DESCRIPTION
[Bug Link](https://bugzilla.mozilla.org/show_bug.cgi?id=1456549)

The search rollup job has been failing intermittently over the last few weeks. I left out some key arguments in the DAG definition that prevented the intended email recipients from getting the retry alerts. I've also bumped up the instance count and timeout value. 