### PR TITLE
Read events_to_amplitude config file from JAR

### DIFF
--- a/dags/events_to_amplitude.py
+++ b/dags/events_to_amplitude.py
@@ -10,6 +10,7 @@ VCPUS_PER_INSTANCE = 16
 
 environment = "{{ task.__class__.deploy_environment }}"
 key_file = "s3://telemetry-airflow/config/amplitude/{}/apiKey".format(environment)
+config_file = "focus_android_events_schemas.json"
 
 bucket = "{{ task.__class__.artifacts_bucket }}"
 mozilla_slug = "{{ test.__class__.mozilla_slug }}"
@@ -31,6 +32,8 @@ default_args = {
 
 dag = DAG('events_to_amplitude', default_args=default_args, schedule_interval='0 1 * * *')
 
+
+
 events_to_amplitude = EMRSparkOperator(
     task_id="focus_android_events_to_amplitude",
     job_name="Focus Android Events to Amplitude",
@@ -41,7 +44,8 @@ events_to_amplitude = EMRSparkOperator(
         "date": "{{ ds_nodash }}",
         "max_requests": FOCUS_ANDROID_INSTANCES * VCPUS_PER_INSTANCE,
         "key_file": key_file,
-        "artifact": url
+        "artifact": url,
+        "config_filename": config_file
     },
-    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/focus_android_events_to_amplitude.sh",
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
     dag=dag)

--- a/jobs/events_to_amplitude.sh
+++ b/jobs/events_to_amplitude.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-if [[ -z "$date" || -z "$max_requests" || -z "$key_file" || -z "$artifact" ]]; then
+if [[ -z "$date" || -z "$max_requests" || -z "$key_file" || -z "$artifact" || -z "$config_filename"]]; then
     echo "Missing arguments!" 1>&2
     exit 1
 fi
 
 artifact_filename="artifact.jar"
 wget "$artifact" -O "$artifact_filename"
+
+unzip -q artifact.jar "$config_filename"
 
 key_filename="amplitude_key_file"
 aws s3 cp "$key_file" "$key_filename"
@@ -15,7 +17,7 @@ export AMPLITUDE_API_KEY=$(cat "$key_filename")
 spark-submit --master yarn \
              --deploy-mode client \
              --class com.mozilla.telemetry.streaming.EventsToAmplitude $artifact_filename \
-             --config-file-path ./configs/focus_android_events_schemas.json \
+             --config-file-path $config_filename \
              --url https://api.amplitude.com/httpapi \
              --from $date \
              --to $date \


### PR DESCRIPTION
This also means the bash script is no longer specific for
focus_android, so that part of the filename has been dropped.

Depends on https://github.com/mozilla/telemetry-streaming/pull/128