### PR TITLE
Added more workers and extended runtime for taar_lite job

### DIFF
--- a/dags/taar_amodump.py
+++ b/dags/taar_amodump.py
@@ -51,8 +51,8 @@ amowhitelist = EMRSparkOperator(
 taar_lite = EMRSparkOperator(
     task_id="taar_lite",
     job_name="Generate GUID coinstallation JSON for TAAR",
-    execution_timeout=timedelta(hours=1),
-    instance_count=1,
+    execution_timeout=timedelta(hours=2),
+    instance_count=5,
     owner="mlopatka@mozilla.com",
     email=["mlopatka@mozilla.com", "vng@mozilla.com"],
     env=mozetl_envvar("taar_lite",


### PR DESCRIPTION
The taar_lite job is currently timing out in airflow as we do not have enough workers or time to complete the job.  This just bumps the instance count to 5 and extends the runtime to 2 hours which should be more than sufficient to execute the job.