### PR TITLE
Sync probe-scraper cache before and after running

### DIFF
--- a/jobs/probe_scraper.sh
+++ b/jobs/probe_scraper.sh
@@ -3,9 +3,12 @@
 # Print all the executed commands to the terminal.
 set -x
 
-BUCKET="net-mozaws-prod-us-west-2-data-pitmo"
+OUTPUT_BUCKET="net-mozaws-prod-us-west-2-data-pitmo"
+CACHE_BUCKET="telemetry-private-analysis-2/probe-scraper"
 CACHE_DIR="probe_cache"
 OUTPUT_DIR="probe_data"
+
+aws s3 sync s3://$CACHE_BUCKET/ $CACHE_DIR/ --delete
 
 # Clone and setup the scraper
 git clone https://github.com/mozilla/probe-scraper.git
@@ -26,9 +29,17 @@ then
 else
     # The Cloudfront distribution will automatically gzip objects
     # Upload to S3.
-    aws s3 sync $OUTPUT_DIR/ s3://$BUCKET/ \
+    aws s3 sync $OUTPUT_DIR/ s3://$OUTPUT_BUCKET/ \
            --delete \
            --content-type 'application/json' \
            --cache-control 'max-age=28800' \
            --acl public-read
+fi
+
+if [ -n "$(find $CACHE_DIR -prune -empty 2>/dev/null)" ]
+then
+    echo "$CACHE_DIR is empty"
+    exit 1
+else
+    aws s3 sync $CACHE_DIR/ s3://$CACHE_BUCKET/  --delete
 fi


### PR DESCRIPTION
DO NOT MERGE YET

@jasonthomas, do you have any recommendations for which bucket location we should use to store the probe-scraper cache?

@Dexterp37 also note that with this change we should probably remove the requests cache database object.