### PR TITLE
Incorrect submission type fix for the taar_lite job

### DIFF
--- a/dags/taar_amodump.py
+++ b/dags/taar_amodump.py
@@ -51,13 +51,13 @@ amowhitelist = EMRSparkOperator(
 taar_lite = EMRSparkOperator(
     task_id="taar_lite",
     job_name="Generate GUID coinstallation JSON for TAAR",
-    execution_timeout=timedelta(hours=2),
     instance_count=5,
+    execution_timeout=timedelta(hours=4),
     owner="mlopatka@mozilla.com",
     email=["mlopatka@mozilla.com", "vng@mozilla.com"],
     env=mozetl_envvar("taar_lite",
                       {"date": "{{ ds_nodash }}"},
-                      {'MOZETL_SUBMISSION_METHOD': 'python'}),
+                      {'MOZETL_SUBMISSION_METHOD': 'spark'}),
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     output_visibility="private",
     dag=dag


### PR DESCRIPTION
The submission method should be 'spark' to run the taar_lite job correctly.
I've also bumped up the time out period to 4 hours as we've seen the job run up to 2 hours with a 4 node ATMO cluster.
