### PR TITLE
Added taar_lite_guidranking to the longitudinal DAG

### DIFF
--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -60,7 +60,7 @@ cross_sectional = EMRSparkOperator(
     job_name="Cross Sectional View",
     execution_timeout=timedelta(hours=10),
     instance_count=30,
-    env = tbv_envvar("com.mozilla.telemetry.views.CrossSectionalView", {
+    env=tbv_envvar("com.mozilla.telemetry.views.CrossSectionalView", {
         "outName": "v" + DS_WEEKLY,
         "outputBucket": "{{ task.__class__.private_output_bucket }}"}),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
@@ -111,9 +111,25 @@ taar_legacy_job = EMRSparkOperator(
     output_visibility="private",
     dag=dag)
 
+taar_lite_guidranking = EMRSparkOperator(
+    task_id="taar_lite_guidranking",
+    job_name="TAARlite Addon Ranking",
+    owner="mlopatka@mozilla.com",
+    email=["vng@mozilla.com", "mlopatka@mozilla.com"],
+    execution_timeout=timedelta(hours=2),
+    instance_count=4,
+    env=mozetl_envvar("taar_lite_guidranking",
+                      {"date": "{{ ds_nodash }}"},
+                      {'MOZETL_SUBMISSION_METHOD': 'spark'}),
+    release_label="emr-5.8.0",
+    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
+    output_visibility="private",
+    dag=dag)
+
 addon_recommender.set_upstream(longitudinal)
 game_hw_survey.set_upstream(longitudinal)
 cross_sectional.set_upstream(longitudinal)
 distribution_viewer.set_upstream(cross_sectional)
 taar_locale_job.set_upstream(longitudinal)
 taar_legacy_job.set_upstream(longitudinal)
+taar_lite_guidranking.set_upstream(longitudinal)


### PR DESCRIPTION
I can start the guidranking job from my shell using the test command:

```
(py27) victorng@Victors-MacBook-Pro-2  ~/dev/telemetry-airflow   features/taarlite_guidranking_dag ●  make run COMMAND="test longitudinal taar_lite_guidranking 20180505"
docker-compose run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID web airflow test longitudinal taar_lite_guidranking 20180505
Starting telemetry-airflow_db_1    ... done
Starting telemetry-airflow_redis_1 ... done
Starting telemetry-airflow_app_1   ... done
Waiting for db to listen on 5432...
Waiting for redis to listen on 6379...
/usr/local/lib/python2.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
[2018-05-22 19:11:06,306] {__init__.py:57} INFO - Using executor CeleryExecutor
/usr/local/lib/python2.7/site-packages/airflow/www/app.py:23: FlaskWTFDeprecationWarning: "flask_wtf.CsrfProtect" has been renamed to "CSRFProtect" and will be removed in 1.0.
  csrf = CsrfProtect()
[2018-05-22 19:11:06,917] {models.py:168} INFO - Filling up the DagBag from /app/dags
/usr/local/lib/python2.7/site-packages/airflow/utils/helpers.py:406: DeprecationWarning: Importing BashOperator directly from <module 'airflow.operators' from '/usr/local/lib/python2.7/site-packages/airflow/operators/__init__.pyc'> has been deprecated. Please import from '<module 'airflow.operators' from '/usr/local/lib/python2.7/site-packages/airflow/operators/__init__.pyc'>.[operator_module]' instead. Support for direct imports will be dropped entirely in Airflow 2.0.
  DeprecationWarning)
/usr/local/lib/python2.7/site-packages/airflow/utils/helpers.py:406: DeprecationWarning: Importing BaseHook directly from <module 'airflow.hooks' from '/usr/local/lib/python2.7/site-packages/airflow/hooks/__init__.pyc'> has been deprecated. Please import from '<module 'airflow.hooks' from '/usr/local/lib/python2.7/site-packages/airflow/hooks/__init__.pyc'>.[operator_module]' instead. Support for direct imports will be dropped entirely in Airflow 2.0.
  DeprecationWarning)
[2018-05-22 19:11:08,833] {models.py:1128} INFO - Dependencies all met for <TaskInstance: longitudinal.taar_lite_guidranking 2018-05-05 00:00:00 [None]>
[2018-05-22 19:11:08,837] {models.py:1128} INFO - Dependencies all met for <TaskInstance: longitudinal.taar_lite_guidranking 2018-05-05 00:00:00 [None]>
[2018-05-22 19:11:08,837] {models.py:1334} INFO -
--------------------------------------------------------------------------------
Starting attempt 1 of 3
--------------------------------------------------------------------------------

[2018-05-22 19:11:08,838] {models.py:1358} INFO - Executing <Task(EMRSparkOperator): taar_lite_guidranking> on 2018-05-05 00:00:00
[2018-05-22 19:11:08,856] {credentials.py:910} INFO - Found credentials in environment variables.
[2018-05-22 19:11:09,263] {connectionpool.py:735} INFO - Starting new HTTPS connection (1): us-west-2.elasticmapreduce.amazonaws.com
[2018-05-22 19:11:10,031] {emr_spark_operator.py:178} INFO - Running Spark Job TAARlite Addon Ranking with JobFlow ID j-2AIFPXVLIRDSP
[2018-05-22 19:11:10,032] {emr_spark_operator.py:189} INFO - Logs will be available at: https://console.aws.amazon.com/s3/home?region=us-west-2#&bucket=telemetry-test-bucket&prefix=logs/mlopatka@mozilla.com/TAARlite Addon Ranking/j-2AIFPXVLIRDSP
[2018-05-22 19:11:10,166] {emr_spark_operator.py:217} INFO - Spark Job 'TAARlite Addon Ranking' status' is STARTING
```