### PR TITLE
Bug 1462810 - Bump default EMR version to 5.13.0 for Spark 2.3.0

### DIFF
--- a/dags/events_to_amplitude.py
+++ b/dags/events_to_amplitude.py
@@ -35,7 +35,6 @@ events_to_amplitude = EMRSparkOperator(
     job_name="Focus Android Events to Amplitude",
     execution_timeout=timedelta(hours=8),
     instance_count=FOCUS_ANDROID_INSTANCES,
-    release_label="emr-5.13.0",
     env={
         "date": "{{ ds_nodash }}",
         "max_requests": FOCUS_ANDROID_INSTANCES * VCPUS_PER_INSTANCE,

--- a/dags/fx_usage_report.py
+++ b/dags/fx_usage_report.py
@@ -29,7 +29,6 @@ usage_report = EMRSparkOperator(
     job_name="Fx Usage Report",
     execution_timeout=timedelta(hours=4),
     instance_count=10,
-    release_label="emr-5.11.0",
     owner="frank@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "shong@mozilla.com"],
     env={"date": DS_WEEKLY,

--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -23,7 +23,6 @@ longitudinal = EMRSparkOperator(
     job_name="Longitudinal View",
     execution_timeout=timedelta(hours=12),
     instance_count=50,
-    release_label="emr-5.13.0",
     env=tbv_envvar(
         "com.mozilla.telemetry.views.LongitudinalView",
         {
@@ -84,7 +83,6 @@ taar_locale_job = EMRSparkOperator(
           "bucket": "{{ task.__class__.private_output_bucket }}",
           "prefix": "taar/locale/"
     }),
-    release_label="emr-5.8.0",
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     output_visibility="private",
     dag=dag)
@@ -101,7 +99,6 @@ taar_legacy_job = EMRSparkOperator(
           "bucket": "{{ task.__class__.private_output_bucket }}",
           "prefix": "taar/legacy/"
     }),
-    release_label="emr-5.8.0",
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     output_visibility="private",
     dag=dag)
@@ -116,7 +113,6 @@ taar_lite_guidranking = EMRSparkOperator(
     env=mozetl_envvar("taar_lite_guidranking",
                       {"date": "{{ ds_nodash }}"},
                       {'MOZETL_SUBMISSION_METHOD': 'spark'}),
-    release_label="emr-5.8.0",
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     output_visibility="private",
     dag=dag)

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -46,7 +46,6 @@ experiments_error_aggregates = EMRSparkOperator(
     job_name="Experiments Error Aggregates View",
     execution_timeout=timedelta(hours=5),
     instance_count=20,
-    release_label="emr-5.13.0",
     owner="frank@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com"],
     env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
@@ -136,7 +135,6 @@ experiments_aggregates = EMRSparkOperator(
     job_name="Experiments Aggregates View",
     execution_timeout=timedelta(hours=15),
     instance_count=20,
-    release_label="emr-5.8.0",
     owner="ssuh@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
     env=tbv_envvar("com.mozilla.telemetry.views.ExperimentAnalysisView", {

--- a/dags/operators/emr_spark_operator.py
+++ b/dags/operators/emr_spark_operator.py
@@ -70,7 +70,7 @@ class EMRSparkOperator(BaseOperator):
 
     @apply_defaults
     def __init__(self, job_name, owner, uri, instance_count,
-                 release_label='emr-5.9.0', output_visibility='private',
+                 release_label='emr-5.13.0', output_visibility='private',
                  env=None, arguments='', *args, **kwargs):
         super(EMRSparkOperator, self).__init__(*args, **kwargs)
         self.job_name = job_name

--- a/plugins/moz_emr/moz_emr_mixin.py
+++ b/plugins/moz_emr/moz_emr_mixin.py
@@ -3,7 +3,7 @@ import requests
 
 
 class MozEmrMixin:
-    DEFAULT_EMR_RELEASE = 'emr-5.9.0'
+    DEFAULT_EMR_RELEASE = 'emr-5.13.0'
 
     template_fields = ('environment',)
     region = environ['AWS_REGION']


### PR DESCRIPTION
[Bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1462810)

This PR contains a patch for bumping [EMR to 5.13.0](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-release-5x.html), which is the first version with support for [Spark 2.3.0](https://spark.apache.org/releases/spark-release-2-3-0.html).

@jklukas recently ran the Airflow dag against most of the jobs. I'm going to run the jobs against the new version. There shouldn't be any errors because the Spark release is backwards compatible.
