### PR TITLE
Bug 1465082: Up main_summary_glue timeout to 8 hours

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -250,7 +250,7 @@ client_count_daily_view = EMRSparkOperator(
 main_summary_glue = EMRSparkOperator(
     task_id="main_summary_glue",
     job_name="Main Summary Update Glue",
-    execution_timeout=timedelta(hours=2),
+    execution_timeout=timedelta(hours=8),
     owner="bimsland@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "bimsland@mozilla.com"],
     instance_count=1,


### PR DESCRIPTION
As described in the bug, it looks like it's normal operation for the glue job to take longer on days with schema changes.