### PR TITLE
Prevent backfill by default on local Airflow instance

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -31,7 +31,8 @@ ENV AIRFLOW_HOME=/app \
     # AIRFLOW_SMTP_HOST= \
     # AIRFLOW_SMTP_USER= \
     # AIRFLOW_SMTP_PASSWORD= \
-    AIRFLOW_SMTP_FROM=telemetry-alerts@airflow.dev.mozaws.net
+    AIRFLOW_SMTP_FROM=telemetry-alerts@airflow.dev.mozaws.net \
+    AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT=False
 
 EXPOSE $PORT
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,6 +19,10 @@ ENV PYTHONUNBUFFERED=1 \
     DEPLOY_TAG=master \
     ARTIFACTS_BUCKET=net-mozaws-data-us-west-2-ops-ci-artifacts
 
+# Airflow configuration can be set here using the following format:
+# $AIRFLOW__{SECTION}__{KEY}
+# See also: https://airflow.apache.org/configuration.html
+
 ENV AIRFLOW_HOME=/app \
     AIRFLOW_AUTHENTICATE=False \
     AIRFLOW_AUTH_BACKEND=airflow.contrib.auth.backends.password_auth \

--- a/README.md
+++ b/README.md
@@ -108,6 +108,20 @@ generating backfill runs based on the DAG's configured start date
 (set `schedule_interval=None` in your DAG definition to prevent these scheduled runs). 
 You'll likely want to toggle the DAG back to "Off" as soon as your desired task starts running.
 
+
+#### Workaround for permission issues
+
+Users on Linux distributions will encounter permission issues with `docker-compose`.
+This is because the local application folder is mounted as a volume into the running container.
+The Airflow user and group in the container is set to `10001`.
+
+To work around this, replace all instances of `10001` in `Dockerfile.dev` with the host user id.
+
+```bash
+sed -i "s/10001/$(id -u)/g" Dockerfile.dev
+
+```
+
 ### Testing Dev Changes
 
 *Note: This only works for `telemetry-batch-view` and `telemetry-streaming` jobs*

--- a/airflow.cfg
+++ b/airflow.cfg
@@ -170,6 +170,16 @@ child_process_log_directory = ${AIRFLOW_HOME}/logs/scheduler
 # associated task instance as failed and will re-schedule the task.
 scheduler_zombie_task_threshold = 300
 
+
+# Turn off scheduler catchup by setting this to False.
+# Default behavior is unchanged and
+# Command Line Backfills still work, but the scheduler
+# will not do scheduler catchup if this is False,
+# however it can be set on a per DAG basis in the
+# DAG definition (catchup)
+catchup_by_default = True
+
+
 # Statsd (https://github.com/etsy/statsd) integration settings
 # statsd_on =  False
 # statsd_host =  localhost

--- a/dags/debug.py
+++ b/dags/debug.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 default_args = {
     'owner': 'nobody@example.com',
     'depends_on_past': False,
-    'start_date': datetime(2099, 5, 31),
+    'start_date': datetime.now() - timedelta(3),
     'email': [],
     'email_on_failure': False,
     'email_on_retry': False,


### PR DESCRIPTION
I set the `catchup_by_default` configuration variable to False via the Dockerfile.dev environment. When I tried this last year, it wasn't working for me.

I tested this by rerunning `make build` and  setting the start date of the debug DAG to 3 days ago. When true, it started to run the tasks from the start date. When set false, it only ran the most recent day. I also tried this on `churn`, and it correctly ran only the most recent Wednesday. 

Also, I documented a workaround for Linux users where the user id causes permission errors with the mounted volume. 