### PR TITLE
Move Dockerfile ENV commands after lib installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,6 @@
 FROM python:2-slim
 MAINTAINER Jannis Leidel <jezdez@mozilla.com>
 
-ENV PYTHONUNBUFFERED=1 \
-    # AWS_REGION= \
-    # AWS_ACCESS_KEY_ID= \
-    # AWS_SECRET_ACCESS_KEY= \
-    # SPARK_BUCKET= \
-    # AIRFLOW_BUCKET= \
-    # PRIVATE_OUTPUT_BUCKET= \
-    # PUBLIC_OUTPUT_BUCKET= \
-    # EMR_KEY_NAME= \
-    # EMR_FLOW_ROLE= \
-    # EMR_SERVICE_ROLE= \
-    # EMR_INSTANCE_TYPE= \
-    # DEPLOY_ENVIRONMENT = \
-    # DEPLOY_TAG = \
-    # ARTIFACTS_BUCKET = \
-    PORT=8000
-
-ENV AIRFLOW_HOME=/app
-    # AIRFLOW_AUTHENTICATE= \
-    # AIRFLOW_AUTH_BACKEND= \
-    # AIRFLOW_BROKER_URL= \
-    # AIRFLOW_RESULT_URL= \
-    # AIRFLOW_FLOWER_PORT= \
-    # AIRFLOW_DATABASE_URL= \
-    # AIRFLOW_FERNET_KEY= \
-    # AIRFLOW_SECRET_KEY= \
-    # AIRFLOW_SMTP_HOST= \
-    # AIRFLOW_SMTP_USER= \
-    # AIRFLOW_SMTP_PASSWORD= \
-    # AIRFLOW_SMTP_FROM=
-
-EXPOSE $PORT
-
 # add a non-privileged user for installing and running the application
 RUN mkdir /app && \
     chown 10001:10001 /app && \
@@ -71,6 +38,39 @@ COPY . /app
 RUN chown -R 10001:10001 /app
 
 USER 10001
+
+ENV PYTHONUNBUFFERED=1 \
+    # AWS_REGION= \
+    # AWS_ACCESS_KEY_ID= \
+    # AWS_SECRET_ACCESS_KEY= \
+    # SPARK_BUCKET= \
+    # AIRFLOW_BUCKET= \
+    # PRIVATE_OUTPUT_BUCKET= \
+    # PUBLIC_OUTPUT_BUCKET= \
+    # EMR_KEY_NAME= \
+    # EMR_FLOW_ROLE= \
+    # EMR_SERVICE_ROLE= \
+    # EMR_INSTANCE_TYPE= \
+    # DEPLOY_ENVIRONMENT = \
+    # DEPLOY_TAG = \
+    # ARTIFACTS_BUCKET = \
+    PORT=8000
+
+ENV AIRFLOW_HOME=/app
+    # AIRFLOW_AUTHENTICATE= \
+    # AIRFLOW_AUTH_BACKEND= \
+    # AIRFLOW_BROKER_URL= \
+    # AIRFLOW_RESULT_URL= \
+    # AIRFLOW_FLOWER_PORT= \
+    # AIRFLOW_DATABASE_URL= \
+    # AIRFLOW_FERNET_KEY= \
+    # AIRFLOW_SECRET_KEY= \
+    # AIRFLOW_SMTP_HOST= \
+    # AIRFLOW_SMTP_USER= \
+    # AIRFLOW_SMTP_PASSWORD= \
+    # AIRFLOW_SMTP_FROM=
+
+EXPOSE $PORT
 
 # Using /bin/bash as the entrypoint works around some volume mount issues on Windows
 # where volume-mounted files do not have execute bits set.

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,34 @@
 FROM python:2-slim
 MAINTAINER Jannis Leidel <jezdez@mozilla.com>
 
+# add a non-privileged user for installing and running the application
+RUN mkdir /app && \
+    chown 10001:10001 /app && \
+    groupadd --gid 10001 app && \
+    useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
+
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        apt-transport-https build-essential curl git libpq-dev \
+        postgresql-client gettext sqlite3 libffi-dev libsasl2-dev && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Install Python dependencies
+COPY requirements.txt /tmp/
+# Switch to /tmp to install dependencies outside home dir
+WORKDIR /tmp
+
+RUN pip install pip==9.0.3
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Switch back to home directory
+WORKDIR /app
+
+USER 10001
+
 ENV PYTHONUNBUFFERED=1 \
     AWS_REGION=us-west-2 \
     # AWS_ACCESS_KEY_ID= \
@@ -39,34 +67,6 @@ ENV AIRFLOW_HOME=/app \
     AIRFLOW__SCHEDULER__CATCHUP_BY_DEFAULT=False
 
 EXPOSE $PORT
-
-# add a non-privileged user for installing and running the application
-RUN mkdir /app && \
-    chown 10001:10001 /app && \
-    groupadd --gid 10001 app && \
-    useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
-
-RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        apt-transport-https build-essential curl git libpq-dev \
-        postgresql-client gettext sqlite3 libffi-dev libsasl2-dev && \
-    apt-get autoremove -y && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Install Python dependencies
-COPY requirements.txt /tmp/
-# Switch to /tmp to install dependencies outside home dir
-WORKDIR /tmp
-
-RUN pip install pip==9.0.3
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Switch back to home directory
-WORKDIR /app
-
-USER 10001
 
 # Using /bin/bash as the entrypoint works around some volume mount issues on Windows
 # where volume-mounted files do not have execute bits set.


### PR DESCRIPTION
For local development, it's likely that you might want to
iterate on values of environment variables, leading to long
Docker builds. By keeping the expensive installation of libs
at the top of the Dockerfile, we can keep those layers cached
allowing quick builds when changing environment variables.