### PR TITLE
Add Event Ping Events dataset job

### DIFF
--- a/dags/event_ping_events.py
+++ b/dags/event_ping_events.py
@@ -1,0 +1,35 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from operators.emr_spark_operator import EMRSparkOperator
+from utils.deploy import get_artifact_url
+from utils.tbv import tbv_envvar
+
+
+slug = "{{ task.__class__.telemetry_streaming_slug }}"
+url = get_artifact_url(slug)
+
+default_args = {
+    'owner': 'ssuh@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2018, 6, 27),
+    'email': ['telemetry-alerts@mozilla.com', 'ssuh@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+dag = DAG('event_ping_events', default_args=default_args, schedule_interval='0 1 * * *')
+
+event_ping_events = EMRSparkOperator(
+    task_id="event_ping_events",
+    job_name="Event Ping Events Dataset",
+    execution_timeout=timedelta(hours=8),
+    instance_count=5,
+    env=tbv_envvar("com.mozilla.telemetry.streaming.EventPingEvents", {
+        "from": "{{ ds_nodash }}",
+        "to": "{{ ds_nodash }}",
+        "outputPath": "s3://{{ task.__class__.private_output_bucket }}/"
+    }, artifact_url=url),
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
+    dag=dag)

--- a/dags/utils/tbv.py
+++ b/dags/utils/tbv.py
@@ -2,7 +2,8 @@
 
 from utils.deploy import get_artifact_url
 
-def tbv_envvar(klass, options, branch=None, tag=None, other={}, metastore_location=None):
+
+def tbv_envvar(klass, options, branch=None, tag=None, other={}, metastore_location=None, artifact_url=None):
     """Set up environment variables for telemetry-batch-view jobs.
 
     The command line interface can read options from the environment. All
@@ -19,8 +20,11 @@ def tbv_envvar(klass, options, branch=None, tag=None, other={}, metastore_locati
 
     :returns: a dictionary that contains properly prefixed class and options
     """
-    slug = "{{ task.__class__.telemetry_batch_view_slug }}"
-    url = get_artifact_url(slug, branch=branch, tag=tag)
+    if artifact_url is None:
+        slug = "{{ task.__class__.telemetry_batch_view_slug }}"
+        url = get_artifact_url(slug, branch=branch, tag=tag)
+    else:
+        url = artifact_url
 
     prefixed_options = {
         "TBV_{}".format(key.replace("-", "_")): value


### PR DESCRIPTION
Scheduling the event ping events dataset from mozilla/telemetry-streaming#149 (tested locally and everything worked fine, and the urls for telemetry-batch-view jobs seem to be fine)