### PR TITLE
Bug 1476047 - Use correct buckets for `main_summary` dependencies when running in dev

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -105,6 +105,7 @@ addon_aggregates = EMRSparkOperator(
     instance_count=10,
     env=mozetl_envvar("addon_aggregates", {
         "date": "{{ ds_nodash }}",
+        "input-bucket": "{{ task.__class__.private_output_bucket }}",
         "output-bucket": "{{ task.__class__.private_output_bucket }}"
     }),
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -227,6 +227,7 @@ clients_daily_v6 = EMRSparkOperator(
     instance_count=10,
     env=tbv_envvar("com.mozilla.telemetry.views.ClientsDailyView", {
         "date": "{{ ds_nodash }}",
+        "input-bucket": "{{ task.__class__.private_output_bucket }}",
         "output-bucket": "{{ task.__class__.private_output_bucket }}"
     }),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -174,6 +174,7 @@ search_dashboard = EMRSparkOperator(
     email=["telemetry-alerts@mozilla.com", "harterrt@mozilla.com", "wlachance@mozilla.com"],
     env=mozetl_envvar("search_dashboard", {
         "submission_date": "{{ ds_nodash }}",
+        "input_bucket": "{{ task.__class__.private_output_bucket }}",
         "bucket": "{{ task.__class__.private_output_bucket }}",
         "prefix": "harter/searchdb",
         "save_mode": "overwrite"
@@ -191,6 +192,7 @@ search_clients_daily = EMRSparkOperator(
     email=["telemetry-alerts@mozilla.com", "harterrt@mozilla.com", "wlachance@mozilla.com"],
     env=mozetl_envvar("search_clients_daily", {
         "submission_date": "{{ ds_nodash }}",
+        "input_bucket": "{{ task.__class__.private_output_bucket }}",
         "bucket": "{{ task.__class__.private_output_bucket }}",
         "prefix": "search_clients_daily",
         "save_mode": "overwrite"

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -242,6 +242,7 @@ retention = EMRSparkOperator(
     instance_count=10,
     env=mozetl_envvar("retention", {
         "start_date": "{{ ds_nodash }}",
+        "input_bucket": "{{ task.__class__.private_output_bucket }}",
         "bucket": "{{ task.__class__.private_output_bucket }}",
         "slack": 4
     }),

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -212,6 +212,7 @@ clients_daily = EMRSparkOperator(
         # See the clients_daily code in the python_mozetl
         # repo for more details.
         "date": "{{ ds }}",
+        "input-bucket": "{{ task.__class__.private_output_bucket }}",
         "output-bucket": "{{ task.__class__.private_output_bucket }}"
     }),
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",

--- a/jobs/client_count_daily_view.sh
+++ b/jobs/client_count_daily_view.sh
@@ -40,7 +40,7 @@ spark-submit --master yarn \
              --output-partition "submission_date=$date" \
              --from $date \
              --to $date \
-             --files "s3://telemetry-parquet/main_summary/v4/" \
+             --files "s3://$bucket/main_summary/v4/" \
              --count-column "client_id" \
              --select "$select" \
              --grouping-columns "$group" \

--- a/jobs/retention.sh
+++ b/jobs/retention.sh
@@ -17,6 +17,7 @@ MOZETL_COMMAND=${MOZETL_COMMAND:-retention}
 # `auto_envvar_prefix` convention.
 export MOZETL_RETENTION_START_DATE=${MOZETL_RETENTION_START_DATE?"start_date must be set"}
 export MOZETL_RETENTION_BUCKET=${MOZETL_RETENTION_BUCKET?"output bucket must be set"}
+export MOZETL_RETENTION_INPUT_BUCKET=${MOZETL_RETENTION_INPUT_BUCKET:-MOZETL_RETENTION_BUCKET}
 export MOZETL_RETENTION_PATH="intermediate_path"
 
 # NOTE: the development branch is under acmiyaguchi/<repo>:bug-1381840-retention


### PR DESCRIPTION
This PR fixes most of the issues found in #316 ([bug mirror](https://bugzilla.mozilla.org/show_bug.cgi?id=1476047)). 

One side-effect of these changes is that downstream jobs require some data in `telemetry-test-bucket/main_summary/v4` before running, instead of relying on the latest main_summary data.