### PR TITLE
Bug 1479580 - Log which JAR is being used in telemetry-batch-view

### DIFF
--- a/jobs/telemetry_batch_view.py
+++ b/jobs/telemetry_batch_view.py
@@ -4,7 +4,7 @@ import requests
 from os import chdir
 from os import environ
 from subprocess import call, PIPE, Popen
-
+from urlparse import urlparse
 
 artifact_file = "artifact.jar"
 
@@ -21,6 +21,42 @@ def retrieve_jar():
 
     if jar_url is None:
         exit(1)
+
+
+    print("Retrieving JAR: {}".format(jar_url))
+
+    # Check to see if this is an alias for a full jar path
+    # If it's an alias, it should be accompanied by a .txt
+    # file whose contents point to the aliased location.
+    #
+    # The associated .txt files have two lines [0]:
+    # 1. The query string to get to the aliased jar
+    # 2. The associated build URL for that jar
+    #
+    # Historical version only had the query string [1],
+    # so we need to handle that case separately.
+    #
+    # [0] https://github.com/mozilla/telemetry-batch-view/blob/master/.circleci/deploy.sh#L37
+    # [1] https://github.com/mozilla/telemetry-batch-view/blob/14741db20dd3873b94944b8238dfc48a003c744d/deploy.sh#L50
+
+    txt_url = jar_url.replace(".jar", ".txt")
+    response = requests.get(txt_url)
+
+    if response.status_code != 404:
+        stripped = response.content.strip()
+        if len(stripped.split("\n")) == 1:
+            # Handle historical version
+            uri_query = stripped
+            build_url = "Build URL not available"
+        else:
+            # Output both query string and build URL
+            uri_query, build_url = stripped.split("\n")
+
+        parsed_uri = urlparse(jar_url)
+        full_url = "{uri.scheme}://{uri.netloc}/{uri_query}".format(uri=parsed_uri, uri_query=uri_query)
+
+        print("Alias: {}".format(full_url))
+        print("Build URL: {}".format(build_url))
 
     response = requests.get(jar_url)
     with open(artifact_file, 'wb') as f:

--- a/jobs/telemetry_batch_view.py
+++ b/jobs/telemetry_batch_view.py
@@ -43,20 +43,16 @@ def retrieve_jar():
     response = requests.get(txt_url)
 
     if response.status_code != 404:
-        stripped = response.content.strip()
-        if len(stripped.split("\n")) == 1:
+        uri_query, _, build_url = response.content.partition("\n")
+        if not build_url:
             # Handle historical version
-            uri_query = stripped
             build_url = "Build URL not available"
-        else:
-            # Output both query string and build URL
-            uri_query, build_url = stripped.split("\n")
 
         parsed_uri = urlparse(jar_url)
         full_url = "{uri.scheme}://{uri.netloc}/{uri_query}".format(uri=parsed_uri, uri_query=uri_query)
 
-        print("Alias: {}".format(full_url))
-        print("Build URL: {}".format(build_url))
+        print("  Alias: {}".format(full_url))
+        print("  Build URL: {}".format(build_url.strip()))
 
     response = requests.get(jar_url)
     with open(artifact_file, 'wb') as f:


### PR DESCRIPTION
Previously, there were no logs about which artifact
was being used. That made it hard to debug problems.
This change will make it obvious which JAR is being
used to run a job.