### PR TITLE
Bump socorro_import to 10 nodes

### DIFF
--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -19,7 +19,7 @@ socorro_import = EMRSparkOperator(
     task_id="socorro_import",
     job_name="Import crash data",
     execution_timeout=timedelta(hours=4),
-    instance_count=5,
+    instance_count=10,
     env={"date": "{{ ds_nodash }}"},
     uri="https://raw.githubusercontent.com/mozilla-services/data-pipeline/master/reports/socorro_import/ImportCrashData.ipynb",
     output_visibility="public",


### PR DESCRIPTION
There seems to be new intermittent issues with the crash report import job. I just closed a [related bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1477001) where an bump to 10 nodes let the job complete. 

```
    Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 3 in stage 1.0 failed 4 times, most recent failure: Lost task 3.3 in stage 1.0 (TID 7243, ip-172-31-3-156.us-west-2.compute.internal, executor 5): ExecutorLostFailure (executor 5 exited caused by one of the running tasks) Reason: Container marked as failed: container_1532995648738_0001_01_000006 on host: ip-172-31-3-156.us-west-2.compute.internal. Exit status: 137. Diagnostics: Container killed on request. Exit code is 137
    Container exited with a non-zero exit code 137
    Killed by external signal
    
    Driver stacktrace:
    	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$failJobAndIndependentStages(DAGScheduler.scala:1750)
    	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1738)
    	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1737)
    	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
    	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
    	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:1737)
    	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:871)
    	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:871)
    	at scala.Option.foreach(Option.scala:257)
    	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:871)
    	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:1971)
    	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1920)
    	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1909)
    	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:48)
    	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:682)
    	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2027)
    	at org.apache.spark.sql.execution.datasources.FileFormatWriter$.write(FileFormatWriter.scala:194)
    	... 31 more
```