### PR TITLE
Update instructions for running the main_summary DAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,29 +62,15 @@ order of their dependencies.
 
 ### Testing main_summary
 
-`main_summary` can be a good test case for any large changes to telemetry-batch-view,
-but you'll likely want to make some modifications before launching a test to keep runtime reasonable.
-
-Edit the `EMRSparkOperator` definition for the `main_summary` task in `dags/main_summary.py`
-to add some additional parameters to the `tbv_envvar` dictionary:
-
-```python
-        "channel": "nightly",   # run on smaller nightly data rather than release
-        "read-mode": "aligned", # more efficient RDD splitting for small datasets
-```
-
-Then launch in dev as:
+`main_summary` can be a good test case for any large changes to telemetry-batch-view, launch in dev as:
 
 ```bash
 export AWS_SECRET_ACCESS_KEY=...
 export AWS_ACCESS_KEY_ID=...
-make run COMMAND="test main_summary main_summary 20180523"
+make run COMMAND="test main_summary main_summary 20180803"
 ```
 
-To run the full `main_summary` DAG via local Airflow, you'll need to remove
-the `main_summary_glue` task definition and all references to it, since
-your local instance doesn't have the proper credentials set up to access
-AWS Glue. See the next section for info on how to configure a full DAG run,
+See the next section for info on how to configure a full DAG run,
 though this should only be needed to significant changes affecting many view definitions.
 
 ### Local Deployment
@@ -102,10 +88,7 @@ You can now connect to your local Airflow web console at
 `http://localhost:8000/`.
 
 All DAGs are paused by default for local instances and our staging instance of Airflow.
-In order to submit a DAG via the UI, you'll need to toggle the DAG from "Off" to "On",
-but be very careful to check what DAG runs are generated (Browse > DAG Runs), since it may start
-generating backfill runs based on the DAG's configured start date, which could get very expensive
-(set `schedule_interval=None` in your DAG definition to prevent these scheduled runs).
+In order to submit a DAG via the UI, you'll need to toggle the DAG from "Off" to "On".
 You'll likely want to toggle the DAG back to "Off" as soon as your desired task starts running.
 
 

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -161,6 +161,7 @@ experiments_aggregates = EMRSparkOperator(
     job_name="Experiments Aggregates View",
     execution_timeout=timedelta(hours=15),
     instance_count=20,
+    dev_instance_count=3,
     owner="ssuh@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
     env=tbv_envvar("com.mozilla.telemetry.views.ExperimentAnalysisView", {
@@ -175,7 +176,6 @@ experiments_aggregates_import = EMRSparkOperator(
     job_name="Experiments Aggregates Import",
     execution_timeout=timedelta(hours=10),
     instance_count=1,
-    dev_instance_count=3,
     disable_on_dev=True,
     owner="robhudson@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "robhudson@mozilla.com"],


### PR DESCRIPTION
I updated the README to reflect the current state of testing in Airflow. It's not required to edit the DAG in order to run a full test of `main_summary`.

This also updates the experiment_aggregates job to use 3 nodes in dev. 