### PR TITLE
Bug 1490099 - Add landfill sampler

### DIFF
--- a/bin/mozetl_runner.py
+++ b/bin/mozetl_runner.py
@@ -1,0 +1,17 @@
+from os import environ
+from pprint import pformat
+from mozetl import cli
+
+print(
+    pformat({
+        k: v for k, v in environ.items()
+        if k.startswith("MOZETL")
+    })
+)
+
+try:
+    cli.entry_point(auto_envvar_prefix="MOZETL")
+except SystemExit:
+    # avoid calling sys.exit() in databricks
+    # http://click.palletsprojects.com/en/7.x/api/?highlight=auto_envvar_prefix#click.BaseCommand.main
+    pass

--- a/bin/mozetl_runner.py
+++ b/bin/mozetl_runner.py
@@ -1,3 +1,18 @@
+"""A mozetl runner script for the MozDatabricksRunSubmit operator.
+
+A copy of this file may be found in `telemetry-airflow/bin`
+
+This file is used as an argument in the SparkPythonTask in the Databricks
+api.[0] The library is assumed to be installed on all of the machines in the
+cluster.  Arguments are passed to the script through `MOZETL_`-prefixed
+environment variables.
+
+This script is deployed to `s3://telemetry-airflow/steps/mozetl_runner.py`.[1]
+
+[0]: https://docs.databricks.com/api/latest/jobs.html#sparkpythontask
+[1]: https://bugzilla.mozilla.org/show_bug.cgi?id=1484331
+"""
+
 from os import environ
 from pprint import pformat
 from mozetl import cli

--- a/dags/landfill.py
+++ b/dags/landfill.py
@@ -23,6 +23,7 @@ landfill_sampler = MozDatabricksSubmitRunOperator(
     job_name="Landfill Sampler",
     execution_timeout=timedelta(hours=2),
     instance_count=3,
+    iam_role="arn:aws:iam::144996185633:instance-profile/databricks-ec2-landfill",
     env=mozetl_envvar("landfill_sampler", {
         "submission-date": "{{ ds_nodash }}",
         "bucket": "{{ task.__class__.private_output_bucket }}",

--- a/dags/landfill.py
+++ b/dags/landfill.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
+from utils.mozetl import mozetl_envvar
+
+default_args = {
+    'owner': 'amiyaguchi@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2018, 9, 10),
+    'email': ['telemetry-alerts@mozilla.com', 'amiyaguchi@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+dag = DAG('main_summary', default_args=default_args, schedule_interval='0 1 * * *')
+
+
+landfill_sampler = MozDatabricksSubmitRunOperator(
+    task_id="landfill_sampler",
+    job_name="Landfill Sampler",
+    execution_timeout=timedelta(hours=2),
+    instance_count=3,
+    env=mozetl_envvar("landfill_sampler", {
+        "submission-date": "{{ ds_nodash }}",
+        "bucket": "{{ task.__class__.private_output_bucket }}",
+        "prefix": "santitized-landfill-sample",
+    }),
+    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
+    dag=dag)

--- a/dags/landfill.py
+++ b/dags/landfill.py
@@ -15,7 +15,7 @@ default_args = {
     'retry_delay': timedelta(minutes=30),
 }
 
-dag = DAG('main_summary', default_args=default_args, schedule_interval='0 1 * * *')
+dag = DAG('landfill', default_args=default_args, schedule_interval='0 1 * * *')
 
 
 landfill_sampler = MozDatabricksSubmitRunOperator(


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1490099)

This adds the landfill sampler introduced in mozilla/python_mozetl#232 to airflow as it's own DAG. This is currently blocked by mozilla/python_mozetl#254 and [bug 1484334](https://bugzilla.mozilla.org/show_bug.cgi?id=1484334).

This job will eventually have 2 downstream dependencies:
1. A job for creating a tar.gz artifact with the json blobs in the same file-structure as mozilla-pipeline-schemas
2. A job for running the edge-validator and submitting the report to generic ingestion