### PR TITLE
Bug 1465974 Enable metrics for events_to_amplitude clusters

### DIFF
--- a/dags/events_to_amplitude.py
+++ b/dags/events_to_amplitude.py
@@ -30,6 +30,7 @@ default_args = {
     'email_on_retry': True,
     'retries': 2,
     'retry_delay': timedelta(minutes=30),
+    'bootstrap_args': ['--metrics-provider', 'datadog'],
 }
 
 dag = DAG('events_to_amplitude', default_args=default_args, schedule_interval='0 1 * * *')

--- a/dags/operators/emr_spark_operator.py
+++ b/dags/operators/emr_spark_operator.py
@@ -77,7 +77,8 @@ class EMRSparkOperator(BaseOperator):
     def __init__(self, job_name, owner, uri, instance_count,
                  dev_instance_count=1, disable_on_dev=False,
                  release_label='emr-5.13.0', output_visibility='private',
-                 env=None, arguments='', *args, **kwargs):
+                 env=None, arguments='', bootstrap_args=(),
+                 *args, **kwargs):
         """
         Create an operator for launching EMR clusters.
 
@@ -93,6 +94,7 @@ class EMRSparkOperator(BaseOperator):
         :param env: A dictionary of environment variables to pass during runtime
         :param dev_env: Additional environment variables to pass in development
         :param arguments: Passed to `airflow.sh`
+        :param bootstrap_args: An iterable of arguments passed to `telemetry.sh`
         """
         is_dev = self.deploy_environment == 'dev'
 
@@ -110,6 +112,7 @@ class EMRSparkOperator(BaseOperator):
         self.uri = uri
         self.release_label = release_label
         self.arguments = arguments
+        self.bootstrap_args = bootstrap_args
         self.environment = self._format_envvar(env)
         self.job_flow_id = None
         self.instance_count = dev_instance_count if is_dev else instance_count
@@ -197,7 +200,8 @@ class EMRSparkOperator(BaseOperator):
                     'Path': (
                         's3://{}/bootstrap/telemetry.sh'
                         .format(EMRSparkOperator.spark_bucket)
-                    )
+                    ),
+                    'Args': self.bootstrap_args,
                 }
             }],
             Tags=[

--- a/dags/operators/emr_spark_operator.py
+++ b/dags/operators/emr_spark_operator.py
@@ -204,6 +204,8 @@ class EMRSparkOperator(BaseOperator):
                 {'Key': 'Owner', 'Value': self.owner},
                 {'Key': 'Application',
                  'Value': 'telemetry-analysis-worker-instance'},
+                {'Key': 'Environment',
+                 'Value': EMRSparkOperator.deploy_environment},
             ],
             Steps=self.steps
         )


### PR DESCRIPTION
There are a few atomic commits here:

- One adds an "Environment" tag to the cluster to match the tag on ATMO clusters (so that we get a Environment tag on the metrics sent to datadog)
- One adds a bootstrap_args param to EMRSparkOperator
- One sets bootstrap_args to enable datadog metrics for events_to_amplitude

I ran this locally and watched metrics flow all the way to Datadog:

<img width="1269" alt="screen shot 2018-09-25 at 11 24 30 am" src="https://user-images.githubusercontent.com/691060/46025755-a5529100-c0b7-11e8-97a3-ba4a6645a3fe.png">

The HttpSink metrics appear as `spark.driver.HttpSink.success.count`, etc.