### PR TITLE
Bug 1502235 - Add a statuspage operator to telemetry-airflow plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,14 +19,16 @@ jobs:
       - run: docker build -t app:build .
 
   test:
-    machine:
-      enable: true
+    docker:
+      - image: python:2.7
     working_directory: ~/mozilla/telemetry-airflow
     steps:
       - checkout
-      - run: sudo apt-get update
-      - run: sudo apt-get install python-dev
+      - run: pip install tox
       - run: python -m py_compile dags/*.py
+      - run: find . -name *.pyc -delete
+      - run: tox -e py27
+
 
   deploy:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,9 @@ stop:
 
 up:
 	docker-compose up
+
+test:
+	PYTHONPATH=$(PYTHON_PATH):plugins:dags \
+	AIRFLOW__CORE__SQL_ALCHEMY_CONN=sqlite:///$(HOME)/airflow/airflow.db \
+	AIRFLOW__CORE__UNIT_TEST_MODE=True \
+	python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,4 @@ up:
 	docker-compose up
 
 test:
-	PYTHONPATH=$(PYTHON_PATH):plugins:dags \
-	AIRFLOW__CORE__SQL_ALCHEMY_CONN=sqlite:///$(HOME)/airflow/airflow.db \
-	AIRFLOW__CORE__UNIT_TEST_MODE=True \
-	python -m pytest
+	tox

--- a/dags/example.py
+++ b/dags/example.py
@@ -3,6 +3,9 @@ from airflow.operators import BashOperator
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
 
+from airflow.operators.dataset_status import DatasetStatusOperator
+from operators.sleep_operator import SleepOperator
+
 default_args = {
     'owner': 'example@mozilla.com',
     'depends_on_past': False,
@@ -33,3 +36,27 @@ bash = EMRSparkOperator(
     env = {"date": "{{ ds_nodash }}"},
     uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/examples/spark/example_date.sh",
     dag = dag)
+
+
+
+statuspage_dag = DAG('example_statuspage', default_args=default_args)
+
+set_outage = DatasetStatusOperator(
+    task_id="outage",
+    name="Test Airflow Integration",
+    description="Testing an outage",
+    status = "partial_outage",
+    dag = statuspage_dag
+)
+
+sleep = SleepOperator(task_id="sleep", dag=statuspage_dag)
+
+set_operational = DatasetStatusOperator(
+    task_id="operational",
+    name="Test Airflow Integration",
+    description="Testing an outage",
+    status = "operational",
+    dag = statuspage_dag
+)
+
+set_outage >> sleep >> set_operational

--- a/dags/utils/status.py
+++ b/dags/utils/status.py
@@ -1,24 +1,30 @@
 from airflow.operators.dataset_status import DatasetStatusOperator
 
 
-def register_status(operator, name, description):
+def register_status(operator, name, description, on_success=False):
     """Wrap an operator with an external status page.
     
-    :param operator: An Airflow operator to set upstream
-    :type airflow.models.BaseOperator:
+    The default behavior will only set the state of a dataset to partial_outage.
 
-    :returns: The original airflow operator with downstream dependenc
+    :param airflow.models.BaseOperator operator: An Airflow operator to set upstream
+    :param str name:            The name of the dataset
+    :param str description:     A short (1-2 sentence) description of the dataset.
+    :param boolean on_success:  Indicator to set the dataset state to operational on success
+
+    :returns: The original airflow operator with downstream dependencies
     """
 
     kwargs = {"name": name, "description": description, "dag": operator.dag}
 
-    # create and operator on the success case
-    success = DatasetStatusOperator(
-        trigger_rule="all_success",
-        task_id="{}_success".format(operator.task_id),
-        status="operational",
-        **kwargs
-    )
+    if on_success:
+        # create and operator on the success case
+        success = DatasetStatusOperator(
+            trigger_rule="all_success",
+            task_id="{}_success".format(operator.task_id),
+            status="operational",
+            **kwargs
+        )
+        operator >> success
 
     # create an operator on the failure case
     failure = DatasetStatusOperator(
@@ -28,7 +34,6 @@ def register_status(operator, name, description):
         **kwargs
     )
 
-    operator >> success
     operator >> failure
 
     return operator

--- a/dags/utils/status.py
+++ b/dags/utils/status.py
@@ -1,0 +1,34 @@
+from airflow.operators.dataset_status import DatasetStatusOperator
+
+
+def register_status(operator, name, description):
+    """Wrap an operator with an external status page.
+    
+    :param operator: An Airflow operator to set upstream
+    :type airflow.models.BaseOperator:
+
+    :returns: The original airflow operator with downstream dependenc
+    """
+
+    kwargs = {"name": name, "description": description, "dag": operator.dag}
+
+    # create and operator on the success case
+    success = DatasetStatusOperator(
+        trigger_rule="all_success",
+        task_id="{}_success".format(operator.task_id),
+        status="operational",
+        **kwargs
+    )
+
+    # create an operator on the failure case
+    failure = DatasetStatusOperator(
+        trigger_rule="all_failed",
+        task_id="{}_failure".format(operator.task_id),
+        status="partial_outage",
+        **kwargs
+    )
+
+    operator >> success
+    operator >> failure
+
+    return operator

--- a/plugins/statuspage/__init__.py
+++ b/plugins/statuspage/__init__.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from airflow.plugins_manager import AirflowPlugin
-from . import hook, operator
+
+from statuspage import hook, operator
 
 
 class DatasetStatusPlugin(AirflowPlugin):

--- a/plugins/statuspage/__init__.py
+++ b/plugins/statuspage/__init__.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from statuspage import hook, operator
+
+class DatasetStatusPlugin(AirflowPlugin):
+    name = 'dataset_status'
+    hooks = [hook.DatasetStatusHook]
+    operators = [operator.DatasetStatusOperator]

--- a/plugins/statuspage/__init__.py
+++ b/plugins/statuspage/__init__.py
@@ -3,9 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from airflow.plugins_manager import AirflowPlugin
-from statuspage import hook, operator
+from . import hook, operator
+
 
 class DatasetStatusPlugin(AirflowPlugin):
-    name = 'dataset_status'
+    name = "dataset_status"
     hooks = [hook.DatasetStatusHook]
     operators = [operator.DatasetStatusOperator]

--- a/plugins/statuspage/__init__.py
+++ b/plugins/statuspage/__init__.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from airflow.plugins_manager import AirflowPlugin
 from statuspage import hook, operator
 
 class DatasetStatusPlugin(AirflowPlugin):

--- a/plugins/statuspage/client.py
+++ b/plugins/statuspage/client.py
@@ -8,7 +8,7 @@ import requests
 import jsonschema
 import logging
 
-from . import schema
+from statuspage import schema
 
 
 class StatuspageClient:

--- a/plugins/statuspage/client.py
+++ b/plugins/statuspage/client.py
@@ -1,0 +1,101 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Statuspage integration
+
+import requests
+import jsonschema
+import logging
+
+from statuspage import schema
+
+
+class StatuspageClient:
+    def __init__(self, api_key, page_name, group_name):
+        """A Statuspage client for a page and group"""
+
+        self.base_url = "https://api.statuspage.io/v1/"
+        self.api_key = api_key
+
+        self.page_id = self.get_page_id(page_name)
+        self.group_id = self.get_component_group_id(group_name)
+
+    def _request(self, method, path, data=None):
+        headers = {"Authorization": "OAuth {}".format(self.api_key)}
+        request_method = {
+            "get":     requests.get,
+            "post":    requests.post,
+            "delete":  requests.delete,
+            "put":     requests.put,
+            "patch":   requests.patch,
+        }.get(method)
+
+        if not request_method:
+            raise ValueError("Method {} not supported".format(method))
+
+        url = self.base_url + path
+        resp = request_method(url, json=data, headers=headers)
+        logging.info("status-code {} for {}".format(resp.status_code, url))
+        if resp.status_code != 200:
+            logging.error(resp.content)
+        return resp
+
+    def get_id(self, data, predicate):
+        for row in data:
+            if predicate(row):
+                return row['id']
+        return None
+
+    def get_page_id(self, name):
+        resp = self._request("get", "pages")
+        data = resp.json()
+        return self.get_id(data, lambda r: r['name'] == name)
+
+    def get_component_group_id(self, name):
+        resp = self._request("get", "pages/{}/component-groups".format(self.page_id))
+        data = resp.json()
+        return self.get_id(data, lambda r: r['name'] == name)
+
+    def get_component_id(self, name):
+        resp = self._request("get", "pages/{}/components".format(self.page_id))
+        data = resp.json()
+        return self.get_id(data, lambda r: r['name'] == name)
+
+    def create_component(self, component):
+        jsonschema.validate(component, schema.component)
+        resp = self._request("post", "pages/{}/components".format(self.page_id), component)
+        return resp.json().get('id')
+
+    def update_component(self, component_id, component):
+        jsonschema.validate(component, schema.component)
+        route = "pages/{}/components/{}".format(self.page_id, component_id)
+        resp = self._request("patch", route, component)
+        return resp.json().get('id')
+
+
+class DatasetStatus:
+    def __init__(self, api_key):
+        self.client = StatuspageClient(api_key, "Firefox Operations", "Data Engineering Datasets")
+
+    def _create(self, name, description="", status="operational"):
+        return self.client.create_component({
+            "component": {
+                "name": name,
+                "description": description,
+                "status": status,
+                "only_show_if_degraded": False,
+                "group_id": self.client.group_id,
+                "showcase": True,
+            }
+        })
+
+    def get_or_create(self, name, description=""):
+        cid = self.client.get_component_id(name)
+        if not cid:
+            cid = self._create(name, description)
+        return cid
+
+    def update(self, component_id, status):
+        patch = {"component": {"status": status}}
+        return self.client.update_component(component_id, patch)

--- a/plugins/statuspage/dataset_client.py
+++ b/plugins/statuspage/dataset_client.py
@@ -1,0 +1,46 @@
+from statuspage.statuspage_client import StatuspageClient
+
+
+class DatasetStatus:
+    """"A Statuspage client for setting the status of Data Engineering Datasets in Firefox Operations."""
+
+    def __init__(self, api_key):
+        self.client = StatuspageClient(
+            api_key, "Firefox Operations", "Data Engineering Datasets"
+        )
+
+    def _create(self, name, description="", status="operational"):
+        return self.client.create_component(
+            {
+                "component": {
+                    "name": name,
+                    "description": description,
+                    "status": status,
+                    "only_show_if_degraded": False,
+                    "group_id": self.client.group_id,
+                    "showcase": True,
+                }
+            }
+        )
+
+    def get_or_create(self, name, description=""):
+        """Get or create the component id of a statuspage. 
+        
+        :param name:        The name of the component
+        :param description: The description associated with the component
+        :returns:   A component id or None
+        """
+        cid = self.client.get_component_id(name)
+        if not cid:
+            cid = self._create(name, description)
+        return cid
+
+    def update(self, component_id, status):
+        """Set the state of a component.
+
+        :param component_id: The identifier of a component
+        :param status: one of [operational, under_maintenance, degraded_performance, partial_outage, major_outage]
+        :returns:   The component id if successful, None otherwise
+        """
+        patch = {"component": {"status": status}}
+        return self.client.update_component(component_id, patch)

--- a/plugins/statuspage/hook.py
+++ b/plugins/statuspage/hook.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from statuspage.client import DatasetStatus
+from statuspage.dataset_client import DatasetStatus
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
 import os

--- a/plugins/statuspage/hook.py
+++ b/plugins/statuspage/hook.py
@@ -11,15 +11,15 @@ import os
 class DatasetStatusHook(BaseHook):
     """Create and update the status of a dataset."""
 
-    def __init__(self, api_key=os.environ['STATUSPAGE_API_KEY'], statuspage_conn_id=None):
+    def __init__(self, api_key=os.environ.get('STATUSPAGE_API_KEY'), statuspage_conn_id=None):
         """Initialize the client with an API key.
 
         :param api_key: Statuspage API key
         :param statuspage_conn_id: connection with the API token in the password field
         """
         self.api_key = api_key or self.get_connection(statuspage_conn_id).password
-        if not api_key:
+        if not self.api_key:
             raise AirflowException("Missing an API key for Statuspage")
     
     def get_conn(self):
-        return DatasetStatusHook(self.api_key)
+        return DatasetStatus(self.api_key)

--- a/plugins/statuspage/hook.py
+++ b/plugins/statuspage/hook.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from .client import DatasetStatus
+from statuspage.client import DatasetStatus
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
 import os

--- a/plugins/statuspage/hook.py
+++ b/plugins/statuspage/hook.py
@@ -11,15 +11,18 @@ import os
 class DatasetStatusHook(BaseHook):
     """Create and update the status of a dataset."""
 
-    def __init__(
-        self, api_key=os.environ.get("STATUSPAGE_API_KEY"), statuspage_conn_id=None
-    ):
+    def __init__(self, api_key=None, statuspage_conn_id="statuspage_default"):
         """Initialize the client with an API key.
 
         :param api_key: Statuspage API key
         :param statuspage_conn_id: connection with the API token in the password field
         """
-        self.api_key = api_key or self.get_connection(statuspage_conn_id).password
+
+        self.api_key = (
+            api_key
+            or os.environ.get("STATUSPAGE_API_KEY")
+            or self.get_connection(statuspage_conn_id).password
+        )
         if not self.api_key:
             raise AirflowException("Missing an API key for Statuspage")
 

--- a/plugins/statuspage/hook.py
+++ b/plugins/statuspage/hook.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from statuspage.client import DatasetStatus
+from .client import DatasetStatus
 from airflow.hooks.base_hook import BaseHook
 from airflow.exceptions import AirflowException
 import os
@@ -11,7 +11,9 @@ import os
 class DatasetStatusHook(BaseHook):
     """Create and update the status of a dataset."""
 
-    def __init__(self, api_key=os.environ.get('STATUSPAGE_API_KEY'), statuspage_conn_id=None):
+    def __init__(
+        self, api_key=os.environ.get("STATUSPAGE_API_KEY"), statuspage_conn_id=None
+    ):
         """Initialize the client with an API key.
 
         :param api_key: Statuspage API key
@@ -20,6 +22,6 @@ class DatasetStatusHook(BaseHook):
         self.api_key = api_key or self.get_connection(statuspage_conn_id).password
         if not self.api_key:
             raise AirflowException("Missing an API key for Statuspage")
-    
+
     def get_conn(self):
         return DatasetStatus(self.api_key)

--- a/plugins/statuspage/hook.py
+++ b/plugins/statuspage/hook.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from statuspage.client import DatasetStatus
+from airflow.hooks.base_hook import BaseHook
+from airflow.exceptions import AirflowException
+import os
+
+
+class DatasetStatusHook(BaseHook):
+    """Create and update the status of a dataset."""
+
+    def __init__(self, api_key=os.environ['STATUSPAGE_API_KEY'], statuspage_conn_id=None):
+        """Initialize the client with an API key.
+
+        :param api_key: Statuspage API key
+        :param statuspage_conn_id: connection with the API token in the password field
+        """
+        self.api_key = api_key or self.get_connection(statuspage_conn_id).password
+        if not api_key:
+            raise AirflowException("Missing an API key for Statuspage")
+    
+    def get_conn(self):
+        return DatasetStatusHook(self.api_key)

--- a/plugins/statuspage/operator.py
+++ b/plugins/statuspage/operator.py
@@ -4,7 +4,7 @@
 
 from airflow.models import BaseOperator
 from airflow.exceptions import AirflowException
-from .hook import DatasetStatusHook
+from statuspage.hook import DatasetStatusHook
 
 
 class DatasetStatusOperator(BaseOperator):

--- a/plugins/statuspage/operator.py
+++ b/plugins/statuspage/operator.py
@@ -2,15 +2,24 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from airflow.models import BaseOperator
 from statuspage.hook import DatasetStatusHook
+from airflow.exceptions import AirflowException
 
 
 class DatasetStatusOperator(BaseOperator):
-    def __init__(self, name, description, status, statuspage_conn_id='statuspage_default'):
+    def __init__(self, name, description, status, statuspage_conn_id='statuspage_default', **kwargs):
         super(DatasetStatusOperator, self).__init__(**kwargs)
         self.statuspage_conn_id = statuspage_conn_id
+        self.name = name
+        self.description = description,
+        self.status = status
 
     def execute(self, context):
-        conn = DatasetStatusHook(self.statuspage_conn_id).get_conn()
-        
-        raise NotImplemented
+        conn = DatasetStatusHook(statuspage_conn_id=self.statuspage_conn_id).get_conn()
+        component_id = conn.get_or_create(self.name, self.description)
+        if not component_id:
+            raise AirflowException("DatasetStatus API failed to create or fetch components")
+        self.log.info("Setting status for {} ({}) to {}".format(self.name, component_id, self.status))
+        conn.update(component_id, self.status)
+

--- a/plugins/statuspage/operator.py
+++ b/plugins/statuspage/operator.py
@@ -16,6 +16,13 @@ class DatasetStatusOperator(BaseOperator):
         statuspage_conn_id="statuspage_default",
         **kwargs
     ):
+        """Create and update the status of a Data Engineering Dataset.
+
+        :param name: Name of the Statuspage
+        :param description: Description of the dataset
+        :param status: one of [operational, under_maintenance, degraded_performance, partial_outage, major_outage]
+        :param statuspage_conn_id: Airflow connection id for credentials
+        """
         super(DatasetStatusOperator, self).__init__(**kwargs)
         self.statuspage_conn_id = statuspage_conn_id
         self.name = name

--- a/plugins/statuspage/operator.py
+++ b/plugins/statuspage/operator.py
@@ -3,23 +3,35 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from airflow.models import BaseOperator
-from statuspage.hook import DatasetStatusHook
 from airflow.exceptions import AirflowException
+from .hook import DatasetStatusHook
 
 
 class DatasetStatusOperator(BaseOperator):
-    def __init__(self, name, description, status, statuspage_conn_id='statuspage_default', **kwargs):
+    def __init__(
+        self,
+        name,
+        description,
+        status,
+        statuspage_conn_id="statuspage_default",
+        **kwargs
+    ):
         super(DatasetStatusOperator, self).__init__(**kwargs)
         self.statuspage_conn_id = statuspage_conn_id
         self.name = name
-        self.description = description,
+        self.description = description
         self.status = status
 
     def execute(self, context):
         conn = DatasetStatusHook(statuspage_conn_id=self.statuspage_conn_id).get_conn()
         component_id = conn.get_or_create(self.name, self.description)
         if not component_id:
-            raise AirflowException("DatasetStatus API failed to create or fetch components")
-        self.log.info("Setting status for {} ({}) to {}".format(self.name, component_id, self.status))
+            raise AirflowException(
+                "DatasetStatus API failed to create or fetch components"
+            )
+        self.log.info(
+            "Setting status for {} ({}) to {}".format(
+                self.name, component_id, self.status
+            )
+        )
         conn.update(component_id, self.status)
-

--- a/plugins/statuspage/operator.py
+++ b/plugins/statuspage/operator.py
@@ -24,14 +24,15 @@ class DatasetStatusOperator(BaseOperator):
 
     def execute(self, context):
         conn = DatasetStatusHook(statuspage_conn_id=self.statuspage_conn_id).get_conn()
-        component_id = conn.get_or_create(self.name, self.description)
-        if not component_id:
-            raise AirflowException(
-                "DatasetStatus API failed to create or fetch components"
-            )
+        comp_id = conn.get_or_create(self.name, self.description)
+
+        if not comp_id:
+            raise AirflowException("Failed to create or fetch component")
+
         self.log.info(
-            "Setting status for {} ({}) to {}".format(
-                self.name, component_id, self.status
-            )
+            "Setting status for {} ({}) to {}".format(self.name, comp_id, self.status)
         )
-        conn.update(component_id, self.status)
+
+        comp_id = conn.update(comp_id, self.status)
+        if not comp_id:
+            raise AirflowException("Failed to update component")

--- a/plugins/statuspage/operator.py
+++ b/plugins/statuspage/operator.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from statuspage.hook import DatasetStatusHook
+
+
+class DatasetStatusOperator(BaseOperator):
+    def __init__(self, name, description, status, statuspage_conn_id='statuspage_default'):
+        super(DatasetStatusOperator, self).__init__(**kwargs)
+        self.statuspage_conn_id = statuspage_conn_id
+
+    def execute(self, context):
+        conn = DatasetStatusHook(self.statuspage_conn_id).get_conn()
+        
+        raise NotImplemented

--- a/plugins/statuspage/schema.py
+++ b/plugins/statuspage/schema.py
@@ -10,7 +10,7 @@ component = {
             "properties": {
                 "description": {
                     "type": "string",
-                    "description": "More detailed description for component"
+                    "description": "More detailed description for component",
                 },
                 "status": {
                     "type": "string",
@@ -20,30 +20,27 @@ component = {
                         "degraded_performance",
                         "partial_outage",
                         "major_outage",
-                        ""
+                        "",
                     ],
-                    "description": "Status of component"
+                    "description": "Status of component",
                 },
-                "name": {
-                    "type": "string",
-                    "description": "Display name for component"
-                },
+                "name": {"type": "string", "description": "Display name for component"},
                 "only_show_if_degraded": {
                     "type": "boolean",
-                    "description": "Requires a special feature flag to be enabled"
+                    "description": "Requires a special feature flag to be enabled",
                 },
                 "group_id": {
                     "type": "string",
-                    "description": "Component Group identifier"
+                    "description": "Component Group identifier",
                 },
                 "showcase": {
                     "type": "boolean",
-                    "description": "Should this component be showcased"
-                }
+                    "description": "Should this component be showcased",
+                },
             },
             "additionalProperties": False,
         }
     },
     "additionalProperties": False,
-    "required": ["component"]
+    "required": ["component"],
 }

--- a/plugins/statuspage/schema.py
+++ b/plugins/statuspage/schema.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+component = {
+    "type": "object",
+    "properties": {
+        "component": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string",
+                    "description": "More detailed description for component"
+                },
+                "status": {
+                    "type": "string",
+                    "enum": [
+                        "operational",
+                        "under_maintenance",
+                        "degraded_performance",
+                        "partial_outage",
+                        "major_outage",
+                        ""
+                    ],
+                    "description": "Status of component"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Display name for component"
+                },
+                "only_show_if_degraded": {
+                    "type": "boolean",
+                    "description": "Requires a special feature flag to be enabled"
+                },
+                "group_id": {
+                    "type": "string",
+                    "description": "Component Group identifier"
+                },
+                "showcase": {
+                    "type": "boolean",
+                    "description": "Should this component be showcased"
+                }
+            },
+            "additionalProperties": False,
+        }
+    },
+    "additionalProperties": False,
+    "required": ["component"]
+}

--- a/plugins/statuspage/statuspage_client.py
+++ b/plugins/statuspage/statuspage_client.py
@@ -74,34 +74,3 @@ class StatuspageClient:
         route = "pages/{}/components/{}".format(self.page_id, component_id)
         resp = self._request("patch", route, component)
         return resp.json().get("id")
-
-
-class DatasetStatus:
-    def __init__(self, api_key):
-        self.client = StatuspageClient(
-            api_key, "Firefox Operations", "Data Engineering Datasets"
-        )
-
-    def _create(self, name, description="", status="operational"):
-        return self.client.create_component(
-            {
-                "component": {
-                    "name": name,
-                    "description": description,
-                    "status": status,
-                    "only_show_if_degraded": False,
-                    "group_id": self.client.group_id,
-                    "showcase": True,
-                }
-            }
-        )
-
-    def get_or_create(self, name, description=""):
-        cid = self.client.get_component_id(name)
-        if not cid:
-            cid = self._create(name, description)
-        return cid
-
-    def update(self, component_id, status):
-        patch = {"component": {"status": status}}
-        return self.client.update_component(component_id, patch)

--- a/plugins/statuspage/statuspage_client.py
+++ b/plugins/statuspage/statuspage_client.py
@@ -39,6 +39,7 @@ class StatuspageClient:
         logging.info("status-code {} for {}".format(resp.status_code, url))
         if resp.status_code != 200:
             logging.error(resp.content)
+        resp.raise_for_status()
         return resp
 
     def get_id(self, data, predicate):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,3 @@ redis
 hiredis
 requests
 jsonschema
-
-pytest
-pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ retrying
 newrelic
 redis
 hiredis
+requests
+jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ redis
 hiredis
 requests
 jsonschema
+
+pytest
+pytest-mock

--- a/tests/test_dag_utils_status.py
+++ b/tests/test_dag_utils_status.py
@@ -57,45 +57,23 @@ def mock_hook(mocker):
     return mocker.patch("plugins.statuspage.operator.DatasetStatusHook")
 
 
-def test_subdag_structure(dag, mock_hook):
+def test_subdag_structure_default(dag, mock_hook):
     operator = PythonOperator(task_id="test", python_callable=lambda: True, dag=dag)
     _ = register_status(operator, "test", "test description")
+    assert {ti.task_id for ti in dag.topological_sort()} == {
+        "test",
+        "test_failure",
+    }
+
+
+def test_subdag_structure_on_success_opt_in(dag, mock_hook):
+    operator = PythonOperator(task_id="test", python_callable=lambda: True, dag=dag)
+    _ = register_status(operator, "test", "test description", on_success=True)
     assert {ti.task_id for ti in dag.topological_sort()} == {
         "test",
         "test_success",
         "test_failure",
     }
-
-
-def test_execute_success(dag, mock_hook):
-    testing_component_id = 42
-
-    mock_conn = mock_hook.return_value.get_conn()
-    mock_conn.get_or_create.return_value = testing_component_id
-
-    success_op = PythonOperator(task_id="test", python_callable=lambda: True, dag=dag)
-    _ = register_status(success_op, "Test Success", "Testing operational status")
-
-    # run each of the operators in order
-    for operator in dag.topological_sort():
-        operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
-    # get the dag state
-    dagrun = dag.create_dagrun(
-        run_id="manual__",
-        start_date=datetime.utcnow(),
-        execution_date=DEFAULT_DATE,
-        state=State.RUNNING,
-    )
-
-    expected = {
-        "test": State.SUCCESS,
-        "test_success": State.SUCCESS,
-        "test_failure": State.NONE,
-    }
-
-    assert all([expected[ti.task_id] == ti.state for ti in dagrun.get_task_instances()])
-    mock_conn.update.assert_called_once_with(testing_component_id, "operational")
 
 
 def test_execute_failure(dag, mock_hook):
@@ -161,3 +139,34 @@ def test_no_execution_on_retry(dag, mock_hook):
 
     assert all([expected[ti.task_id] == ti.state for ti in dagrun.get_task_instances()])
     assert not mock_hook.return_value.get_conn().update.called
+
+
+def test_execute_success_opt_in(dag, mock_hook):
+    testing_component_id = 42
+
+    mock_conn = mock_hook.return_value.get_conn()
+    mock_conn.get_or_create.return_value = testing_component_id
+
+    success_op = PythonOperator(task_id="test", python_callable=lambda: True, dag=dag)
+    _ = register_status(success_op, "Test Success", "Testing operational status", on_success=True)
+
+    # run each of the operators in order
+    for operator in dag.topological_sort():
+        operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+    # get the dag state
+    dagrun = dag.create_dagrun(
+        run_id="manual__",
+        start_date=datetime.utcnow(),
+        execution_date=DEFAULT_DATE,
+        state=State.RUNNING,
+    )
+
+    expected = {
+        "test": State.SUCCESS,
+        "test_success": State.SUCCESS,
+        "test_failure": State.NONE,
+    }
+
+    assert all([expected[ti.task_id] == ti.state for ti in dagrun.get_task_instances()])
+    mock_conn.update.assert_called_once_with(testing_component_id, "operational")

--- a/tests/test_dag_utils_status.py
+++ b/tests/test_dag_utils_status.py
@@ -1,0 +1,161 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+
+from airflow import configuration
+from airflow.exceptions import AirflowException
+from airflow.models import DAG, DagRun
+from airflow.models import TaskInstance as TI
+from airflow.operators.python_operator import PythonOperator
+from airflow.settings import Session
+from airflow.utils.state import State
+
+# fix relative path errors -- ordering is important in this section
+import plugins.statuspage.operator
+
+sys.modules["airflow.operators.dataset_status"] = plugins.statuspage.operator
+from dags.utils.status import register_status
+
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+END_DATE = datetime(2016, 1, 2)
+INTERVAL = timedelta(hours=12)
+
+
+def clear_session():
+    """Manage airflow database state for tests"""
+    session = Session()
+    session.query(DagRun).delete()
+    session.query(TI).delete()
+    session.commit()
+    session.close()
+
+
+@pytest.fixture
+def dag(mocker):
+    clear_session()
+    configuration.load_test_config()
+    dag = DAG(
+        "test_dag",
+        default_args=dict(owner="airflow", start_date=DEFAULT_DATE),
+        schedule_interval=INTERVAL,
+    )
+    yield dag
+    dag.clear()
+    clear_session()
+
+
+@pytest.fixture
+def mock_hook(mocker):
+    return mocker.patch("plugins.statuspage.operator.DatasetStatusHook")
+
+
+def test_subdag_structure(dag, mock_hook):
+    operator = PythonOperator(task_id="test", python_callable=lambda: True, dag=dag)
+    _ = register_status(operator, "test", "test description")
+    assert {ti.task_id for ti in dag.topological_sort()} == {
+        "test",
+        "test_success",
+        "test_failure",
+    }
+
+
+def test_execute_success(dag, mock_hook):
+    testing_component_id = 42
+
+    mock_conn = mock_hook.return_value.get_conn()
+    mock_conn.get_or_create.return_value = testing_component_id
+
+    success_op = PythonOperator(task_id="test", python_callable=lambda: True, dag=dag)
+    _ = register_status(success_op, "Test Success", "Testing operational status")
+
+    # run each of the operators in order
+    for operator in dag.topological_sort():
+        operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+    # get the dag state
+    dagrun = dag.create_dagrun(
+        run_id="manual__",
+        start_date=datetime.utcnow(),
+        execution_date=DEFAULT_DATE,
+        state=State.RUNNING,
+    )
+
+    expected = {
+        "test": State.SUCCESS,
+        "test_success": State.SUCCESS,
+        "test_failure": State.NONE,
+    }
+
+    assert all([expected[ti.task_id] == ti.state for ti in dagrun.get_task_instances()])
+    mock_conn.update.assert_called_once_with(testing_component_id, "operational")
+
+
+def test_execute_failure(dag, mock_hook):
+    testing_component_id = 42
+
+    mock_conn = mock_hook.return_value.get_conn()
+    mock_conn.get_or_create.return_value = testing_component_id
+
+    def exception():
+        raise Exception()
+
+    failure_op = PythonOperator(task_id="test", python_callable=exception, dag=dag)
+    _ = register_status(failure_op, "Test Failure", "Testing partial_outage status")
+
+    # run each of the operators in order
+    for operator in dag.topological_sort():
+        try:
+            operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        except Exception:
+            continue
+
+    # get the dag state
+    dagrun = dag.create_dagrun(
+        run_id="manual__",
+        start_date=datetime.utcnow(),
+        execution_date=DEFAULT_DATE,
+        state=State.RUNNING,
+    )
+
+    expected = {
+        "test": State.FAILED,
+        "test_success": State.NONE,
+        "test_failure": State.SUCCESS,
+    }
+
+    assert all([expected[ti.task_id] == ti.state for ti in dagrun.get_task_instances()])
+    mock_conn.update.assert_called_once_with(testing_component_id, "partial_outage")
+
+
+def test_no_execution_on_retry(dag, mock_hook):
+    operator = PythonOperator(task_id="test", python_callable=lambda: True, dag=dag)
+    _ = register_status(operator, "test", "test no trigger on retry")
+
+    # get the dag state
+    dagrun = dag.create_dagrun(
+        run_id="manual__",
+        start_date=DEFAULT_DATE,
+        execution_date=DEFAULT_DATE,
+        state=State.RUNNING,
+    )
+
+    dagrun.get_task_instance("test").set_state(State.UP_FOR_RETRY, Session())
+
+    # run the test operator dependencies
+    for dep in operator.get_direct_relatives():
+        dep.run(start_date=DEFAULT_DATE, end_date=END_DATE)
+
+    expected = {
+        "test": State.UP_FOR_RETRY,
+        "test_success": State.NONE,
+        "test_failure": State.NONE,
+    }
+
+    assert all([expected[ti.task_id] == ti.state for ti in dagrun.get_task_instances()])
+    assert not mock_hook.return_value.get_conn().update.called

--- a/tests/test_dag_utils_status.py
+++ b/tests/test_dag_utils_status.py
@@ -18,6 +18,8 @@ from airflow.utils.state import State
 # fix relative path errors -- ordering is important in this section
 import plugins.statuspage.operator
 
+# Airflow dynamically registers DAGs and plugins by overwriting the sys modules.
+# Add an entry pointing to the module in `plugins/` for testing in `dags/`
 sys.modules["airflow.operators.dataset_status"] = plugins.statuspage.operator
 from dags.utils.status import register_status
 

--- a/tests/test_dataset_status_hook.py
+++ b/tests/test_dataset_status_hook.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from plugins.statuspage.hook import DatasetStatusHook
+from airflow.exceptions import AirflowException
+
+
+API_KEY = "test_key"
+
+
+def test_hook_reads_environment(monkeypatch):
+    monkeypatch.setenv("STATUSPAGE_API_KEY", API_KEY)
+    hook = DatasetStatusHook()
+    assert hook.api_key == API_KEY
+
+
+def test_hook_reads_connection(mocker):
+    test_connection = "test_statuspage_conn"
+    mock_get_conn = mocker.patch("airflow.hooks.base_hook.BaseHook.get_connection")
+    mock_get_conn.return_value.password.return_value = API_KEY
+
+    hook = DatasetStatusHook(statuspage_conn_id=test_connection)
+    hook.api_key == API_KEY
+
+    mock_get_conn.assert_called_once_with(test_connection)

--- a/tests/test_dataset_status_operator.py
+++ b/tests/test_dataset_status_operator.py
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from plugins.statuspage.operator import DatasetStatusOperator
+from airflow.exceptions import AirflowException
+
+
+@pytest.fixture
+def mock_hook(mocker):
+    return mocker.patch("plugins.statuspage.operator.DatasetStatusHook")
+
+
+def test_execute(mock_hook):
+    testing_component_id = 42
+
+    mock_conn = mock_hook.return_value.get_conn()
+    mock_conn.get_or_create.return_value = testing_component_id
+
+    operator = DatasetStatusOperator(
+        task_id="test_status",
+        name="airflow",
+        description="testing status",
+        status="operational",
+    )
+    operator.execute(None)
+
+    mock_conn.get_or_create.assert_called_once_with("airflow", "testing status")
+    mock_conn.update.assert_called_once_with(testing_component_id, "operational")
+
+
+def test_conn_get_or_create_failure(mock_hook):
+    mock_hook.return_value.get_conn().get_or_create.return_value = None
+
+    with pytest.raises(AirflowException, match="create or fetch component"):
+        operator = DatasetStatusOperator(
+            task_id="test_status",
+            name="airflow",
+            description="testing status",
+            status="operational",
+        )
+        operator.execute(None)
+
+
+def test_conn_update_failure(mock_hook):
+    mock_hook.return_value.get_conn().update.return_value = None
+
+    with pytest.raises(AirflowException, match="update component"):
+        operator = DatasetStatusOperator(
+            task_id="test_status",
+            name="airflow",
+            description="testing status",
+            status="operational",
+        )
+        operator.execute(None)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27, py36
+skipsdist = True
+
+[testenv]
+deps=
+    pytest
+    pytest-mock
+    -r{toxinidir}/requirements.txt
+setenv =
+    PYTHONPATH = {toxinidir}/plugins:{toxinidir}/dags
+    AIRFLOW__CORE__SQL_ALCHEMY_CONN = sqlite:///{toxworkdir}/airflow.db
+    AIRFLOW__CORE__UNIT_TEST_MODE = True
+commands=
+    airflow resetdb -y
+    python -m pytest


### PR DESCRIPTION
This adds [Statuspage](https://firefoxoperations.statuspage.io/) support for datasets through a `DatasetStatusOperator`. This is a first pass that will be tested against `MainSummary`.

There are a suite of unit-tests that cover the hook, operator, and utility function. The client library has been tested by hand.

To manually test the `example_statuspage` dag:

1. `make build && make up`
2. Create a new connection `statuspage_default` and put the statuspage api key in the password field
3. Enable the `example_statuspage` dag
4. Manually run each job in order.
5. In the statuspage component page
    - watch the status for the correct behavior
    - delete the "Test Airflow Integration" component