### PR TITLE
Bug 1506252 - Register socorro crash reports with Statuspage

### DIFF
--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -31,6 +31,6 @@ crash_report_parquet = EMRSparkOperator(
 
 register_status(
     crash_report_parquet,
-    "Socorro Crash Reports Parquet",
+    crash_report_parquet.job_name,
     "Convert processed crash reports into parquet for analysis",
 )

--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -1,26 +1,36 @@
 from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
+from utils.status import register_status
 
 default_args = {
-    'owner': 'amiyaguchi@mozilla.com',
-    'depends_on_past': False,
-    'start_date': datetime(2016, 11, 11),
-    'email': ['telemetry-alerts@mozilla.com', 'amiyaguchi@mozilla.com'],
-    'email_on_failure': True,
-    'email_on_retry': True,
-    'retries': 2,
-    'retry_delay': timedelta(minutes=30),
+    "owner": "amiyaguchi@mozilla.com",
+    "depends_on_past": False,
+    "start_date": datetime(2016, 11, 11),
+    "email": ["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com"],
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=30),
 }
 
-dag = DAG('socorro_import', default_args=default_args, schedule_interval='@daily')
+dag = DAG("socorro_import", default_args=default_args, schedule_interval="@daily")
 
-socorro_import = EMRSparkOperator(
-    task_id="socorro_import",
-    job_name="Import crash data",
+# input: crashstats-telemetry-crashes-prod-us-west-2/v1/crash_report
+# output: telemetry-parquet/socorro_crash/v2
+crash_report_parquet = EMRSparkOperator(
+    task_id="crash_report_parquet",
+    job_name="Socorro Crash Reports Parquet",
     execution_timeout=timedelta(hours=4),
     instance_count=10,
     env={"date": "{{ ds_nodash }}"},
     uri="https://raw.githubusercontent.com/mozilla-services/data-pipeline/master/reports/socorro_import/ImportCrashData.ipynb",
     output_visibility="public",
-    dag=dag)
+    dag=dag,
+)
+
+register_status(
+    crash_report_parquet,
+    "Socorro Crash Reports Parquet",
+    "Convert processed crash reports into parquet for analysis",
+)


### PR DESCRIPTION
[buglink](https://bugzilla.mozilla.org/show_bug.cgi?id=1506252)

This renames `socorro_import` to `crash_reports_parquet`. The dag name and the resulting dataset name are still `socorro_import`. The registered name will be "Socorro Crash Reports Parquet" on statuspage.

[Bug 1498228](https://bugzilla.mozilla.org/show_bug.cgi?id=1498228) is blocking.