### PR TITLE
Bug 1498231 - Register MainSummaryView with Statuspage

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -6,6 +6,7 @@ from operators.email_schema_change_operator import EmailSchemaChangeOperator
 from utils.deploy import get_artifact_url
 from utils.mozetl import mozetl_envvar
 from utils.tbv import tbv_envvar
+from utils.status import register_status
 from search_rollup import add_search_rollup
 
 
@@ -67,7 +68,9 @@ main_summary = EMRSparkOperator(
             "read-mode": "aligned", # more efficient RDD splitting for small datasets
         }),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
-dag=dag)
+    dag=dag)
+
+register_status(main_summary, "Main Summary", "A summary view of main pings.")
 
 main_summary_schema = EmailSchemaChangeOperator(
     task_id="main_summary_schema",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1498231)

This registers MainSummaryView failures with statuspage. If there does happen to be a failure, then someone will need to go into the statuspage management page and turn it back to operational after fixing it. This creates a component for the dataset, so incidents can be filed even if the node in the DAG doesn't trigger.

The second half of the bug will end up being a query from redash using email to alert on the dataset status outside of airflow.