### PR TITLE
Bug 1505583: Use tbv_envvar for devtools release e2a job

### DIFF
--- a/dags/events_to_amplitude.py
+++ b/dags/events_to_amplitude.py
@@ -2,7 +2,7 @@ from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
 from utils.constants import DS_WEEKLY
-from utils.mozetl import mozetl_envvar
+from utils.tbv import tbv_envvar
 from utils.deploy import get_artifact_url
 
 FOCUS_ANDROID_INSTANCES = 10
@@ -15,6 +15,12 @@ environment = "{{ task.__class__.deploy_environment }}"
 def key_file(project):
     return (
         "s3://telemetry-airflow/config/amplitude/{}/{}/apiKey"
+        .format(environment, project)
+    )
+
+def key_path(project):
+    return (
+        "config/amplitude/{}/{}/apiKey"
         .format(environment, project)
     )
 
@@ -56,13 +62,13 @@ devtools_prerelease_events_to_amplitude = EMRSparkOperator(
     execution_timeout=timedelta(hours=8),
     instance_count=DEVTOOLS_INSTANCES,
     email=['ssuh@mozilla.com', 'telemetry-alerts@mozilla.com'],
+    owner='ssuh@mozilla.com',
     env={
         "date": "{{ ds_nodash }}",
         "max_requests": DEVTOOLS_INSTANCES * VCPUS_PER_INSTANCE,
         "key_file": key_file("devtools"),
         "artifact": get_artifact_url(slug, branch="master"),
         "config_filename": "devtools_prerelease_schemas.json",
-        "owner": "ssuh@mozilla.com"
     },
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
     dag=dag)
@@ -84,3 +90,33 @@ rocket_android_events_to_amplitude = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
     dag=dag
 )
+
+devtools_release_events_to_amplitude = EMRSparkOperator(
+    task_id="devtools_release_events_to_amplitude",
+    job_name="DevTools Release Events to Amplitude",
+    execution_timeout=timedelta(hours=8),
+    instance_count=DEVTOOLS_INSTANCES,
+    dev_instance_count=DEVTOOLS_INSTANCES,
+    email=['ssuh@mozilla.com', 'telemetry-alerts@mozilla.com'],
+    owner='ssuh@mozilla.com',
+    env=tbv_envvar(
+        "com.mozilla.telemetry.streaming.EventsToAmplitude",
+        {
+            "from": "{{ ds_nodash }}",
+            "to": "{{ ds_nodash }}",
+            "max_parallel_requests": str(DEVTOOLS_INSTANCES * VCPUS_PER_INSTANCE),
+            "config_file_path": "devtools_release_schemas.json",
+            "url": "https://api.amplitude.com/httpapi",
+            "sample": "0.5",
+            "partition_multiplier": "5"
+        },
+        artifact_url=get_artifact_url(slug, branch="remove-main-pings"),
+        other={
+            "KEY_BUCKET": "telemetry-airflow",
+            "KEY_PATH": key_path("devtools"),
+            "DO_EVENTS_TO_AMPLITUDE_SETUP": "True"
+        }
+    ),
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
+    start_date=datetime(2018, 12, 4),
+    dag=dag)

--- a/jobs/telemetry_batch_view.py
+++ b/jobs/telemetry_batch_view.py
@@ -15,7 +15,7 @@ def call_exit_errors(command):
     print("+ {}".format(" ".join(command)))
     rc = call(command, env=environ.copy())
     if rc > 0:
-        exit(rc)
+       exit(rc)
 
 
 def retrieve_jar():
@@ -62,7 +62,11 @@ def retrieve_jar():
         f.write(response.content)
 
 
-def events_to_amplitude_setup(config_filename, api_key_bucket, api_key_path):
+def events_to_amplitude_setup():
+    config_filename = environ.get("TBV_config_file_path")
+    api_key_bucket = environ.get("KEY_BUCKET")
+    api_key_path = environ.get("KEY_PATH")
+
     print("Extracting config file {}".format(config_filename))
 
     zfile = zipfile.ZipFile(artifact_file)
@@ -111,7 +115,7 @@ if environ.get("DO_RETRIEVE", "True") == "True":
     retrieve_jar()
 
 if environ.get("DO_EVENTS_TO_AMPLITUDE_SETUP") == "True":
-    events_to_amplitude_setup(environ.get("TBV_config_file_path"), environ.get("KEY_BUCKET"), environ.get("KEY_PATH"))
+    events_to_amplitude_setup()
 
 if environ.get("DO_SUBMIT", "True") == "True":
     submit_job()

--- a/jobs/telemetry_batch_view.py
+++ b/jobs/telemetry_batch_view.py
@@ -5,13 +5,15 @@ from os import chdir
 from os import environ
 from subprocess import call, PIPE, Popen
 from urlparse import urlparse
+import zipfile
+import boto3
 
 artifact_file = "artifact.jar"
 
 
 def call_exit_errors(command):
     print("+ {}".format(" ".join(command)))
-    rc = call(command)
+    rc = call(command, env=environ.copy())
     if rc > 0:
         exit(rc)
 
@@ -60,6 +62,22 @@ def retrieve_jar():
         f.write(response.content)
 
 
+def events_to_amplitude_setup(config_filename, api_key_bucket, api_key_path):
+    print("Extracting config file {}".format(config_filename))
+
+    zfile = zipfile.ZipFile(artifact_file)
+    data = zfile.read(config_filename)
+    with open(config_filename, "w") as outfile:
+        outfile.write(data)
+
+    print("Setting amplitude key to contents of {}/{}".format(api_key_bucket,
+                                                              api_key_path))
+    s3 = boto3.resource('s3')
+    obj = s3.Object(api_key_bucket, api_key_path)
+    key = obj.get()['Body'].read().decode('utf-8').strip()
+    environ["AMPLITUDE_API_KEY"] = key
+
+
 def submit_job():
     opts = [
         ["--{}".format(key[4:].replace("_", "-")), value]
@@ -91,6 +109,9 @@ def update_metastore(location, hive_server):
 
 if environ.get("DO_RETRIEVE", "True") == "True":
     retrieve_jar()
+
+if environ.get("DO_EVENTS_TO_AMPLITUDE_SETUP") == "True":
+    events_to_amplitude_setup(environ.get("TBV_config_file_path"), environ.get("KEY_BUCKET"), environ.get("KEY_PATH"))
 
 if environ.get("DO_SUBMIT", "True") == "True":
     submit_job()


### PR DESCRIPTION
Adding the devtools release events to amplitude job sampled at 50% to the dag -- the other events to amplitude jobs use a custom job script but I've made the changes needed to use the generic tbv job script instead. I'll start with the new release job using the generic runner and move the rest of the jobs next week after this has run for a few days (and when it's not all-hands :))