### PR TITLE
Decrease timeout for Main Summary on Databricks

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -52,7 +52,7 @@ main_summary_all_histograms = MozDatabricksSubmitRunOperator(
 main_summary = MozDatabricksSubmitRunOperator(
     task_id="main_summary",
     job_name="Main Summary View",
-    execution_timeout=timedelta(hours=9),
+    execution_timeout=timedelta(hours=4),
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "main_summary_dataset@moz-svc-ops.pagerduty.com"],
     instance_count=5,
     max_instance_count=40,


### PR DESCRIPTION
The recent 2 days ran in 2.3 hours.