### PR TITLE
Bug 1517013 - Separate telemetry aggregates

### DIFF
--- a/dags/prerelease_telemetry_aggregates.py
+++ b/dags/prerelease_telemetry_aggregates.py
@@ -1,0 +1,30 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from operators.emr_spark_operator import EMRSparkOperator
+
+default_args = {
+    'owner': 'frank@mozilla.com',
+    'depends_on_past': True,
+    'start_date': datetime(2018, 12, 23),
+    'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 3,
+    'retry_delay': timedelta(minutes=30),
+}
+
+dag = DAG('prerelease_telemetry_aggregates', default_args=default_args, schedule_interval='@daily')
+
+prerelease_telemetry_aggregate_view = EMRSparkOperator(
+    task_id = "prerelease_telemetry_aggregate_view",
+    job_name = "Prerelease Telemetry Aggregate View",
+    instance_count = 10,
+    execution_timeout=timedelta(hours=12),
+    env = {
+      "date": "{{ ds_nodash }}",
+      "channels": "nightly,aurora,beta"
+    },
+    uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/run_telemetry_aggregator.sh",
+    dag = dag)
+
+

--- a/dags/release_telemetry_aggregates.py
+++ b/dags/release_telemetry_aggregates.py
@@ -5,7 +5,7 @@ from operators.emr_spark_operator import EMRSparkOperator
 default_args = {
     'owner': 'frank@mozilla.com',
     'depends_on_past': True,
-    'start_date': datetime(2018, 11, 28),
+    'start_date': datetime(2018, 12, 17),
     'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
@@ -13,19 +13,7 @@ default_args = {
     'retry_delay': timedelta(minutes=30),
 }
 
-dag = DAG('telemetry_aggregates', default_args=default_args, schedule_interval='@daily')
-
-prerelease_telemetry_aggregate_view = EMRSparkOperator(
-    task_id = "prerelease_telemetry_aggregate_view",
-    job_name = "Prerelease Telemetry Aggregate View",
-    instance_count = 10,
-    execution_timeout=timedelta(hours=12),
-    env = {
-      "date": "{{ ds_nodash }}",
-      "channels": "nightly,aurora,beta"
-    },
-    uri = "https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/run_telemetry_aggregator.sh",
-    dag = dag)
+dag = DAG('release_telemetry_aggregates', default_args=default_args, schedule_interval='@daily')
 
 release_telemetry_aggregate_view = EMRSparkOperator(
     task_id = "release_telemetry_aggregate_view",


### PR DESCRIPTION
Previously, telemetry aggregates were part of the same DAG. However,
they are not dependent on one another; so when one fails, the other
eventually stops running (due to an airflow).

This is not the behavior we want -  we want the other to run when
one is failing. This way they are totally independent on the other
one running.