### PR TITLE
Configure driver type in taar_similarity

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -384,6 +384,7 @@ taar_similarity = MozDatabricksSubmitRunOperator(
     execution_timeout=timedelta(hours=2),
     instance_count=11,
     instance_type="i3.8xlarge",
+    driver_instance_type="i3.xlarge",
     env=mozetl_envvar("taar_similarity",
         options={
             "date": "{{ ds_nodash }}",


### PR DESCRIPTION
Job works fine with smaller driver, this will make it a little cheaper.