### PR TITLE
Add an operator to check for _SUCCESS files

### DIFF
--- a/dags/dataset_alerts.py
+++ b/dags/dataset_alerts.py
@@ -1,6 +1,6 @@
 from airflow import DAG
 from datetime import datetime, timedelta
-from airflow.operators.s3fs_check_success import S3FSCheckSuccessSensor
+from airflow.sensors.s3fs_check_success import S3FSCheckSuccessSensor
 from airflow.operators.dataset_status import DatasetStatusOperator
 
 default_args = {

--- a/plugins/s3fs_check_success.py
+++ b/plugins/s3fs_check_success.py
@@ -16,7 +16,7 @@ def check_s3fs_success(bucket, prefix, num_partitions):
     objects = s3.Bucket(bucket).objects.filter(Prefix=prefix)
     success = set([obj.key for obj in objects if "_SUCCESS" in obj.key])
     logging.info("Found {n_success} files".format(n_success=len(success)))
-    return len(success) == num_partitions
+    return len(success) >= num_partitions
 
 
 class S3FSCheckSuccessOperator(BaseOperator):

--- a/plugins/s3fs_check_success.py
+++ b/plugins/s3fs_check_success.py
@@ -2,7 +2,7 @@ import logging
 
 import boto3
 from airflow.exceptions import AirflowException
-from airflow.operators import BaseSensorOperator
+from airflow.operators import BaseOperator, BaseSensorOperator
 from airflow.plugins_manager import AirflowPlugin
 
 
@@ -15,8 +15,27 @@ def check_s3fs_success(bucket, prefix, num_partitions):
     s3 = boto3.resource("s3")
     objects = s3.Bucket(bucket).objects.filter(Prefix=prefix)
     success = set([obj.key for obj in objects if "_SUCCESS" in obj.key])
-
+    logging.info("Found {n_success} files".format(n_success=len(success)))
     return len(success) == num_partitions
+
+
+class S3FSCheckSuccessOperator(BaseOperator):
+    template_fields = ("prefix",)
+
+    def __init__(self, bucket, prefix, num_partitions, *args, **kwargs):
+        self.bucket = bucket
+        self.prefix = prefix
+        self.num_partitions = num_partitions
+        super(S3FSCheckSuccessOperator, self).__init__(*args, **kwargs)
+
+    def execute(self, context):
+        logging.info(
+            "Running check against s3:/{}/{} with {} partitions".format(
+                self.bucket, self.prefix, self.num_partitions
+            )
+        )
+        if not check_s3fs_success(self.bucket, self.prefix, self.num_partitions):
+            raise ValueError("Wrong number of _SUCCESS files")
 
 
 class S3FSCheckSuccessSensor(BaseSensorOperator):
@@ -39,4 +58,5 @@ class S3FSCheckSuccessSensor(BaseSensorOperator):
 
 class S3FSCheckSuccessPlugin(AirflowPlugin):
     name = "s3fs_check_success"
-    operators = [S3FSCheckSuccessSensor]
+    operators = [S3FSCheckSuccessOperator]
+    sensors = [S3FSCheckSuccessSensor]

--- a/tests/test_s3fs_check_success_operator.py
+++ b/tests/test_s3fs_check_success_operator.py
@@ -37,3 +37,21 @@ def test_single_partition_not_contains_success():
     )
     with pytest.raises(ValueError):
         operator.execute(None)
+
+
+@mock_s3
+def test_single_partition_contains_extra_success():
+    bucket = "test"
+    prefix = "dataset/v1/submission_date=20190101"
+
+    client = boto3.client("s3")
+    client.create_bucket(Bucket=bucket)
+    client.put_object(Bucket=bucket, Body="", Key=prefix + "/part=1/_SUCCESS")
+    client.put_object(Bucket=bucket, Body="", Key=prefix + "/part=2/_SUCCESS")
+    client.put_object(Bucket=bucket, Body="", Key=prefix + "/part=__extra__/_SUCCESS")
+
+
+    operator = S3FSCheckSuccessOperator(
+        task_id="test_failure", bucket=bucket, prefix=prefix, num_partitions=2
+    )
+    operator.execute(None)

--- a/tests/test_s3fs_check_success_operator.py
+++ b/tests/test_s3fs_check_success_operator.py
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+import boto3
+from moto import mock_s3
+from plugins.s3fs_check_success import S3FSCheckSuccessOperator
+
+
+@mock_s3
+def test_single_partition_contains_success():
+    bucket = "test"
+    prefix = "dataset/v1/submission_date=20190101"
+
+    client = boto3.client("s3")
+    client.create_bucket(Bucket=bucket)
+    client.put_object(Bucket=bucket, Body="", Key=prefix + "/_SUCCESS")
+
+    operator = S3FSCheckSuccessOperator(
+        task_id="test_success", bucket=bucket, prefix=prefix, num_partitions=1
+    )
+    operator.execute(None)
+
+
+@mock_s3
+def test_single_partition_not_contains_success():
+    bucket = "test"
+    prefix = "dataset/v1/submission_date=20190101"
+
+    client = boto3.client("s3")
+    client.create_bucket(Bucket=bucket)
+
+    operator = S3FSCheckSuccessOperator(
+        task_id="test_failure", bucket=bucket, prefix=prefix, num_partitions=1
+    )
+    with pytest.raises(ValueError):
+        operator.execute(None)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This PR adds an operator version of a sensor written in #395. This works in the same way as the `S3FSCheckSuccessSensor`, except it is not a long lived job.

I noticed a few things when watching the sensor last night.

* The sensor worked as expected during a catch-up backfill when other jobs were not being run
* The sensor would fail when it ran into unexpected partitions (the `__HIVE_DEFAULT_PARTITION__` of #404)
* The sensor timed out during the run for `2019-01-07`. The logs show that the poke method was never called during the lifetime of the sensor.
  - This might be caused by the low concurrency limit, where the pokes are treated as a low-priority and is never given a chance to run.

In light of this, I've disabled the `dataset_alerts` DAG. Instead of using a long-lived sensor, I think a better solution in our current Airflow configuration is to run an operator once (with a few retries), when the dataset should definitely be written to disk. This way, the scheduler should pick up the task to be run once another task has finished. This reuses most of the code from the last PR.

There are a couple of small things in this PR too:

* Adding a sensor to the plugins imports `snakebite`, breaking python 3 support in pre-1.10.1. I've disabled py36 tests in tox. See https://issues.apache.org/jira/browse/AIRFLOW-2474. 
* I've fixed #404 so the expected number of partitions is a lower bound.