### PR TITLE
Add amo_mango_log_processing to statuspage

### DIFF
--- a/dags/mango_log_processing.py
+++ b/dags/mango_log_processing.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
 from airflow.contrib.sensors.emr_job_flow_sensor import EmrJobFlowSensor
+from utils.status import register_status
 
 
 DEFAULT_ARGS = {
@@ -165,6 +166,8 @@ amo_logs = EmrCreateJobFlowOperator(
     emr_conn_id='emr_data_iam_mango',
     dag=amo_dag
 )
+
+register_status(amo_logs, 'AMO Logs', 'Mango Processed AMO Logs')
 
 amo_job_sensor = EmrJobFlowSensor(
     task_id='amo_check_job_flow',


### PR DESCRIPTION
For the meantime to get this working I have it showing up in the "Data Engineering Datasets" section since the group is currently hard-coded in the Statuspage plugin, I've got a WIP branch locally I'd like to put up a PR for but I figure this is a much smaller change and it gets the job into Statuspage sooner.