### PR TITLE
Create incidents within DatasetStatusHook

### DIFF
--- a/plugins/statuspage/dataset_client.py
+++ b/plugins/statuspage/dataset_client.py
@@ -44,3 +44,30 @@ class DatasetStatus:
         """
         patch = {"component": {"status": status}}
         return self.client.update_component(component_id, patch)
+
+    def create_incident_investigation(
+        self, name, component_id, body=None, component_status="partial_outage"
+    ):
+        """Create a new incident given a list of affected component ids.
+
+        :param name:                The name of the dataset.
+        :component_id:              The component id of the dataset
+        :param body:                The initial message, created as the first incident update.
+        :param incident_status:     The status of the incident e.g. investigating, identified, resolved
+        :param component_status:    The status state to set the component.
+        :returns:                   The id of the incident
+        """
+        templated_title = "Investigating Errors in {name}".format(name=name)
+
+        default_body = (
+            "Automated monitoring has determined that {name} is experiencing errors. "
+            "Engineers have been notified to investigate the source of error. "
+        ).format(name=name)
+
+        return self.client.create_incident(
+            name=templated_title,
+            incident_status="Investigating",
+            body=body or default_body,
+            component_status=component_status,
+            affected_component_ids=[component_id],
+        )

--- a/plugins/statuspage/dataset_client.py
+++ b/plugins/statuspage/dataset_client.py
@@ -53,7 +53,6 @@ class DatasetStatus:
         :param name:                The name of the dataset.
         :component_id:              The component id of the dataset
         :param body:                The initial message, created as the first incident update.
-        :param incident_status:     The status of the incident e.g. investigating, identified, resolved
         :param component_status:    The status state to set the component.
         :returns:                   The id of the incident
         """
@@ -66,7 +65,7 @@ class DatasetStatus:
 
         return self.client.create_incident(
             name=templated_title,
-            incident_status="Investigating",
+            incident_status="Investigating",  # value derived from web-interface
             body=body or default_body,
             component_status=component_status,
             affected_component_ids=[component_id],

--- a/plugins/statuspage/schema.py
+++ b/plugins/statuspage/schema.py
@@ -2,6 +2,19 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+status_type = {
+    "type": "string",
+    "enum": [
+        "operational",
+        "under_maintenance",
+        "degraded_performance",
+        "partial_outage",
+        "major_outage",
+        "",
+    ],
+    "description": "Status of component",
+}
+
 component = {
     "type": "object",
     "properties": {
@@ -12,18 +25,7 @@ component = {
                     "type": "string",
                     "description": "More detailed description for component",
                 },
-                "status": {
-                    "type": "string",
-                    "enum": [
-                        "operational",
-                        "under_maintenance",
-                        "degraded_performance",
-                        "partial_outage",
-                        "major_outage",
-                        "",
-                    ],
-                    "description": "Status of component",
-                },
+                "status": status_type,
                 "name": {"type": "string", "description": "Display name for component"},
                 "only_show_if_degraded": {
                     "type": "boolean",
@@ -43,4 +45,23 @@ component = {
     },
     "additionalProperties": False,
     "required": ["component"],
+}
+
+
+# https://developer.statuspage.io/#operation/postPagesPageIdIncidents
+incident_request = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "description": "Incident Name"},
+        "status": {"type": "string", "description": "Incident Status"},
+        "body": {
+            "type": "string",
+            "description": "The initial message, created as the first incident update.",
+        },
+        "components": {
+            "type": "object",
+            "description": "Map of status changes to apply to affected components",
+            "properties": {"component_id": status_type},
+        },
+    },
 }

--- a/plugins/statuspage/schema.py
+++ b/plugins/statuspage/schema.py
@@ -61,6 +61,7 @@ incident_request = {
         "components": {
             "type": "object",
             "description": "Map of status changes to apply to affected components",
+            # based on the example payloads in the API documentation
             "properties": {"component_id": status_type},
         },
     },

--- a/plugins/statuspage/statuspage_client.py
+++ b/plugins/statuspage/statuspage_client.py
@@ -97,7 +97,7 @@ class StatuspageClient:
 
         data = {
             "name": name,
-            "status": status,
+            "status": incident_status,
             "body": body,
             "components": {"component_id": component_status},
             "component_ids": affected_component_ids,

--- a/plugins/statuspage/statuspage_client.py
+++ b/plugins/statuspage/statuspage_client.py
@@ -75,3 +75,35 @@ class StatuspageClient:
         route = "pages/{}/components/{}".format(self.page_id, component_id)
         resp = self._request("patch", route, component)
         return resp.json().get("id")
+
+    def create_incident(
+        self, name, incident_status, body, component_status, affected_component_ids
+    ):
+        """"
+        Create an incident.
+
+        See https://developer.statuspage.io/#operation/postPagesPageIdIncidents for more details.
+
+        :param name:    The title name to give the incident.
+        :param incident_status: The status of the incident e.g. investigating, identified, resolved
+        :param body:    The initial message, created as the first incident update.
+        :param component_status:    The status state to set the component.
+        :param affected_component_ids:  A list of component id's that are affected by this incident.
+        :returns: The id of the incident
+        :raises jsonschema.exceptions.ValidationError:
+        """
+        if not isinstance(affected_component_ids, list):
+            affected_component_ids = [affected_component_ids]
+
+        data = {
+            "name": name,
+            "status": status,
+            "body": body,
+            "components": {"component_id": component_status},
+            "component_ids": affected_component_ids,
+        }
+        jsonschema.validate(data, schema.incident_request)
+        resp = self._request(
+            "post", "pages/{page_id}/incidents".format(page_id=self.page_id), data=data
+        )
+        return resp.json().get("id")

--- a/tests/test_dataset_status_client.py
+++ b/tests/test_dataset_status_client.py
@@ -29,7 +29,7 @@ def mock_statuspage_client(monkeypatch):
 
 
 def call_args(mocked_def):
-    """Assert that a call argument in a mocked definition is an expected value.
+    """Create an object with dot access to call arguments from a mocked definition.
 
     This is not expected for use with partial or lambda functions.
 

--- a/tests/test_dataset_status_client.py
+++ b/tests/test_dataset_status_client.py
@@ -24,7 +24,7 @@ def mock_statuspage_client(monkeypatch):
         "plugins.statuspage.dataset_client.StatuspageClient._request", _mock_request
     )
     monkeypatch.setattr(
-        "plugins.statuspage.dataset_client.StatuspageClient.get_id", _mock_request
+        "plugins.statuspage.dataset_client.StatuspageClient.get_id", _mock_id
     )
 
 

--- a/tests/test_dataset_status_client.py
+++ b/tests/test_dataset_status_client.py
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from collections import namedtuple
+from jsonschema.exceptions import ValidationError
+from plugins.statuspage.dataset_client import DatasetStatus
+
+
+@pytest.fixture(autouse=True)
+def mock_statuspage_client(monkeypatch):
+    def _mock_request(*args, **kwargs):
+        class MockResponse:
+            def json(self):
+                return {"id": 42}
+
+        return MockResponse()
+
+    def _mock_id(*args, **kwargs):
+        return 43
+
+    monkeypatch.setattr(
+        "plugins.statuspage.dataset_client.StatuspageClient._request", _mock_request
+    )
+    monkeypatch.setattr(
+        "plugins.statuspage.dataset_client.StatuspageClient.get_id", _mock_request
+    )
+
+
+def call_args(mocked_def):
+    """Assert that a call argument in a mocked definition is an expected value.
+
+    This is not expected for use with partial or lambda functions.
+
+    :param mocked_def:  A Mock object for a method or definition
+    :returns:           A namedtuple with definition parameters
+    """
+    # callargs is a two-tuple, with the arg dictionary in the second position
+    arg_dict = mocked_def.call_args[1]
+    CallArguments = namedtuple("CallArguments", arg_dict.keys())
+    return CallArguments(**arg_dict)
+
+
+def test_create_incident_investigation(mocker):
+    mocked = mocker.patch(
+        "plugins.statuspage.dataset_client.StatuspageClient.create_incident"
+    )
+    client = DatasetStatus("test_key")
+    client.create_incident_investigation("Test Dataset", "test_id")
+
+    mocked.assert_called_once()
+    args = call_args(mocked)
+    assert args.incident_status == "Investigating"
+    assert "Investigating Errors in Test Dataset" in args.name
+    assert "Test Dataset is experiencing errors." in args.body
+
+
+def test_create_incident_investigation_custom_body(mocker):
+    mocked = mocker.patch(
+        "plugins.statuspage.dataset_client.StatuspageClient.create_incident"
+    )
+    client = DatasetStatus("test_key")
+    client.create_incident_investigation(
+        "Test Dataset",
+        "test_id",
+        body="The dataset has been delayed.",
+        component_status="degraded_performance",
+    )
+
+    mocked.assert_called_once()
+    args = call_args(mocked)
+    assert args.body == "The dataset has been delayed."
+    assert args.component_status == "degraded_performance"
+
+
+def test_create_incident_investigation_raises_validation_error():
+    client = DatasetStatus("test_key")
+
+    with pytest.raises(ValidationError):
+        client.create_incident_investigation(
+            "Test Dataset", "test_id", component_status="bogus"
+        )


### PR DESCRIPTION
This adds support for the Statuspage `/pages/{page_id}/incidents` api endpoint. The DatasetStatusHook wraps this in `create_incident_investigation`.

This can be used to create or modify existing operators. 