### PR TITLE
fixup! Add sensor-plugins to operators

### DIFF
--- a/dags/dataset_alerts.py
+++ b/dags/dataset_alerts.py
@@ -1,6 +1,6 @@
 from airflow import DAG
 from datetime import datetime, timedelta
-from airflow.sensors.s3fs_check_success import S3FSCheckSuccessSensor
+from airflow.operators.s3fs_check_success import S3FSCheckSuccessSensor
 from airflow.operators.dataset_status import DatasetStatusOperator
 
 default_args = {

--- a/plugins/s3fs_check_success.py
+++ b/plugins/s3fs_check_success.py
@@ -58,5 +58,4 @@ class S3FSCheckSuccessSensor(BaseSensorOperator):
 
 class S3FSCheckSuccessPlugin(AirflowPlugin):
     name = "s3fs_check_success"
-    operators = [S3FSCheckSuccessOperator]
-    sensors = [S3FSCheckSuccessSensor]
+    operators = [S3FSCheckSuccessOperator, S3FSCheckSuccessSensor]


### PR DESCRIPTION
Sensors are not part of the plugin API in airflow 1.9, which is why the module doesn't exist. 

https://github.com/apache/airflow/blob/a592e732356427b4fd1ed27c890cf82e9cf495f0/airflow/plugins_manager.py#L115-L125
