### PR TITLE
Increase number of api retries for main summary

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -72,6 +72,7 @@ main_summary = MozDatabricksSubmitRunOperator(
         dev_options={
             "channel": "nightly",   # run on smaller nightly data rather than release
         }),
+    databricks_retry_limit=20, # at a default polling rate of once every 30 seconds, this is 10 min of retries
     dag=dag)
 
 register_status(main_summary, "Main Summary", "A summary view of main pings.")


### PR DESCRIPTION
Quick bandaid fix for the databricks API issues -- sets the retry limit to 20, which means we'll keep retrying every 30 seconds for 10 minutes. DatabricksSubmitRunOperator doesn't implement exponential backoff, as far as I can tell :/ Possible contribution upstream?