### PR TITLE
Disable retries for Databricks tasks

### DIFF
--- a/dags/landfill.py
+++ b/dags/landfill.py
@@ -21,6 +21,7 @@ dag = DAG('landfill', default_args=default_args, schedule_interval='0 1 * * *')
 landfill_sampler = MozDatabricksSubmitRunOperator(
     task_id="landfill_sampler",
     job_name="Landfill Sampler",
+    retries=0,
     execution_timeout=timedelta(hours=2),
     instance_count=3,
     iam_role="arn:aws:iam::144996185633:instance-profile/databricks-ec2-landfill",

--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -23,6 +23,7 @@ dag = DAG('longitudinal', default_args=default_args, schedule_interval='@weekly'
 longitudinal = MozDatabricksSubmitRunOperator(
     task_id="longitudinal",
     job_name="Longitudinal View",
+    retries=0,
     execution_timeout=timedelta(hours=12),
     instance_count=16,
     instance_type="i3.8xlarge",

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -26,6 +26,7 @@ dag = DAG('main_summary', default_args=default_args, schedule_interval='0 1 * * 
 main_summary_all_histograms = MozDatabricksSubmitRunOperator(
     task_id="main_summary_all_histograms",
     job_name="Main Summary View - All Histograms",
+    retries=0,
     execution_timeout=timedelta(hours=12),
     instance_count=5,
     max_instance_count=50,
@@ -51,6 +52,7 @@ main_summary_all_histograms = MozDatabricksSubmitRunOperator(
 main_summary = MozDatabricksSubmitRunOperator(
     task_id="main_summary",
     job_name="Main Summary View",
+    retries=0,
     execution_timeout=timedelta(hours=4),
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "main_summary_dataset@moz-svc-ops.pagerduty.com"],
     instance_count=5,
@@ -363,6 +365,7 @@ taar_similarity = MozDatabricksSubmitRunOperator(
     job_name="Taar Similarity model",
     owner="akomar@mozilla.com",
     email=["vng@mozilla.com", "mlopatka@mozilla.com", "akomar@mozilla.com"],
+    retries=0,
     execution_timeout=timedelta(hours=2),
     instance_count=11,
     instance_type="i3.8xlarge",


### PR DESCRIPTION
Databricks operator doesn't handle API throttling well. Until we switch to operator implementation that does,
we can disable retries. Then in case of job being started and API requests throttled, Airflow task will fail
and we will wait for it to finish and mark it as successful manually. This will let us avoid duplicated data.