### PR TITLE
Backport Databricks hook and operator from apache/airflow:v1-10-stable

### DIFF
--- a/plugins/databricks/__init__.py
+++ b/plugins/databricks/__init__.py
@@ -1,0 +1,11 @@
+from airflow.plugins_manager import AirflowPlugin
+from databricks import databricks_hook as hook, databricks_operator as operator
+
+
+class DatasetStatusPlugin(AirflowPlugin):
+    name = "dataset_status"
+    hooks = [hook.DatabricksHook]
+    operators = [
+        operator.DatabricksSubmitRunOperator,
+        operator.DatabricksRunNowOperator,
+    ]

--- a/plugins/databricks/__init__.py
+++ b/plugins/databricks/__init__.py
@@ -1,9 +1,23 @@
+"""
+A backport of the Databricks hooks and operators from apache/airflow v1.10 stable.
+
+The Mozilla Data Platform currently runs airflow v1.9, which includes a Databricks
+operator with a failure mode that can cause duplicate data. The operator intermittenly
+fails due to insufficient time between retries, leaving a zombie cluster that continues
+to run in the background. This plugin includes an operator that patches this bug and
+relieves mitigations around this bug, in particular [1] and [2].
+
+[1]
+[2] https://github.com/mozilla/telemetry-airflow/pull/417
+[3] https://github.com/mozilla/telemetry-airflow/pull/416
+"""
+
 from airflow.plugins_manager import AirflowPlugin
 from databricks import databricks_hook as hook, databricks_operator as operator
 
 
-class DatasetStatusPlugin(AirflowPlugin):
-    name = "dataset_status"
+class DatabricksPlugin(AirflowPlugin):
+    name = "databricks"
     hooks = [hook.DatabricksHook]
     operators = [
         operator.DatabricksSubmitRunOperator,

--- a/plugins/databricks/__init__.py
+++ b/plugins/databricks/__init__.py
@@ -1,13 +1,13 @@
 """
-A backport of the Databricks hooks and operators from apache/airflow v1.10 stable.
+A backport of the Databricks hooks and operators from apache/airflow v1.10 stable.[1]
 
 The Mozilla Data Platform currently runs airflow v1.9, which includes a Databricks
 operator with a failure mode that can cause duplicate data. The operator intermittenly
 fails due to insufficient time between retries, leaving a zombie cluster that continues
 to run in the background. This plugin includes an operator that patches this bug and
-relieves mitigations around this bug, in particular [1] and [2].
+relieves mitigations around this bug, in particular [2] and [3].
 
-[1]
+[1] https://github.com/apache/airflow/tree/v1-10-stable
 [2] https://github.com/mozilla/telemetry-airflow/pull/417
 [3] https://github.com/mozilla/telemetry-airflow/pull/416
 """

--- a/plugins/databricks/databricks_hook.py
+++ b/plugins/databricks/databricks_hook.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import requests
+
+from airflow import __version__
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+from requests import exceptions as requests_exceptions
+from requests.auth import AuthBase
+from time import sleep
+
+from airflow.utils.log.logging_mixin import LoggingMixin
+
+try:
+    from urllib import parse as urlparse
+except ImportError:
+    import urlparse
+
+RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/restart")
+START_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/start")
+TERMINATE_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/delete")
+
+RUN_NOW_ENDPOINT = ('POST', 'api/2.0/jobs/run-now')
+SUBMIT_RUN_ENDPOINT = ('POST', 'api/2.0/jobs/runs/submit')
+GET_RUN_ENDPOINT = ('GET', 'api/2.0/jobs/runs/get')
+CANCEL_RUN_ENDPOINT = ('POST', 'api/2.0/jobs/runs/cancel')
+USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v=__version__)}
+
+
+class DatabricksHook(BaseHook, LoggingMixin):
+    """
+    Interact with Databricks.
+    """
+    def __init__(
+            self,
+            databricks_conn_id='databricks_default',
+            timeout_seconds=180,
+            retry_limit=3,
+            retry_delay=1.0):
+        """
+        :param databricks_conn_id: The name of the databricks connection to use.
+        :type databricks_conn_id: string
+        :param timeout_seconds: The amount of time in seconds the requests library
+            will wait before timing-out.
+        :type timeout_seconds: int
+        :param retry_limit: The number of times to retry the connection in case of
+            service outages.
+        :type retry_limit: int
+        :param retry_delay: The number of seconds to wait between retries (it
+            might be a floating point number).
+        :type retry_delay: float
+        """
+        self.databricks_conn_id = databricks_conn_id
+        self.databricks_conn = self.get_connection(databricks_conn_id)
+        self.timeout_seconds = timeout_seconds
+        if retry_limit < 1:
+            raise ValueError('Retry limit must be greater than equal to 1')
+        self.retry_limit = retry_limit
+        self.retry_delay = retry_delay
+
+    @staticmethod
+    def _parse_host(host):
+        """
+        The purpose of this function is to be robust to improper connections
+        settings provided by users, specifically in the host field.
+
+
+        For example -- when users supply ``https://xx.cloud.databricks.com`` as the
+        host, we must strip out the protocol to get the host.
+        >>> h = DatabricksHook()
+        >>> assert h._parse_host('https://xx.cloud.databricks.com') == \
+            'xx.cloud.databricks.com'
+
+        In the case where users supply the correct ``xx.cloud.databricks.com`` as the
+        host, this function is a no-op.
+        >>> assert h._parse_host('xx.cloud.databricks.com') == 'xx.cloud.databricks.com'
+        """
+        urlparse_host = urlparse.urlparse(host).hostname
+        if urlparse_host:
+            # In this case, host = https://xx.cloud.databricks.com
+            return urlparse_host
+        else:
+            # In this case, host = xx.cloud.databricks.com
+            return host
+
+    def _do_api_call(self, endpoint_info, json):
+        """
+        Utility function to perform an API call with retries
+        :param endpoint_info: Tuple of method and endpoint
+        :type endpoint_info: (string, string)
+        :param json: Parameters for this API call.
+        :type json: dict
+        :return: If the api call returns a OK status code,
+            this function returns the response in JSON. Otherwise,
+            we throw an AirflowException.
+        :rtype: dict
+        """
+        method, endpoint = endpoint_info
+        url = 'https://{host}/{endpoint}'.format(
+            host=self._parse_host(self.databricks_conn.host),
+            endpoint=endpoint)
+        if 'token' in self.databricks_conn.extra_dejson:
+            self.log.info('Using token auth.')
+            auth = _TokenAuth(self.databricks_conn.extra_dejson['token'])
+        else:
+            self.log.info('Using basic auth.')
+            auth = (self.databricks_conn.login, self.databricks_conn.password)
+        if method == 'GET':
+            request_func = requests.get
+        elif method == 'POST':
+            request_func = requests.post
+        else:
+            raise AirflowException('Unexpected HTTP Method: ' + method)
+
+        attempt_num = 1
+        while True:
+            try:
+                response = request_func(
+                    url,
+                    json=json,
+                    auth=auth,
+                    headers=USER_AGENT_HEADER,
+                    timeout=self.timeout_seconds)
+                response.raise_for_status()
+                return response.json()
+            except requests_exceptions.RequestException as e:
+                if not _retryable_error(e):
+                    # In this case, the user probably made a mistake.
+                    # Don't retry.
+                    raise AirflowException('Response: {0}, Status Code: {1}'.format(
+                        e.response.content, e.response.status_code))
+
+                self._log_request_error(attempt_num, e)
+
+            if attempt_num == self.retry_limit:
+                raise AirflowException(('API requests to Databricks failed {} times. ' +
+                                        'Giving up.').format(self.retry_limit))
+
+            attempt_num += 1
+            sleep(self.retry_delay)
+
+    def _log_request_error(self, attempt_num, error):
+        self.log.error(
+            'Attempt %s API Request to Databricks failed with reason: %s',
+            attempt_num, error
+        )
+
+    def run_now(self, json):
+        """
+        Utility function to call the ``api/2.0/jobs/run-now`` endpoint.
+
+        :param json: The data used in the body of the request to the ``run-now`` endpoint.
+        :type json: dict
+        :return: the run_id as a string
+        :rtype: string
+        """
+        response = self._do_api_call(RUN_NOW_ENDPOINT, json)
+        return response['run_id']
+
+    def submit_run(self, json):
+        """
+        Utility function to call the ``api/2.0/jobs/runs/submit`` endpoint.
+
+        :param json: The data used in the body of the request to the ``submit`` endpoint.
+        :type json: dict
+        :return: the run_id as a string
+        :rtype: string
+        """
+        response = self._do_api_call(SUBMIT_RUN_ENDPOINT, json)
+        return response['run_id']
+
+    def get_run_page_url(self, run_id):
+        json = {'run_id': run_id}
+        response = self._do_api_call(GET_RUN_ENDPOINT, json)
+        return response['run_page_url']
+
+    def get_run_state(self, run_id):
+        json = {'run_id': run_id}
+        response = self._do_api_call(GET_RUN_ENDPOINT, json)
+        state = response['state']
+        life_cycle_state = state['life_cycle_state']
+        # result_state may not be in the state if not terminal
+        result_state = state.get('result_state', None)
+        state_message = state['state_message']
+        return RunState(life_cycle_state, result_state, state_message)
+
+    def cancel_run(self, run_id):
+        json = {'run_id': run_id}
+        self._do_api_call(CANCEL_RUN_ENDPOINT, json)
+
+    def restart_cluster(self, json):
+        self._do_api_call(RESTART_CLUSTER_ENDPOINT, json)
+
+    def start_cluster(self, json):
+        self._do_api_call(START_CLUSTER_ENDPOINT, json)
+
+    def terminate_cluster(self, json):
+        self._do_api_call(TERMINATE_CLUSTER_ENDPOINT, json)
+
+
+def _retryable_error(exception):
+    return isinstance(exception, requests_exceptions.ConnectionError) \
+        or isinstance(exception, requests_exceptions.Timeout) \
+        or exception.response is not None and exception.response.status_code >= 500
+
+
+RUN_LIFE_CYCLE_STATES = [
+    'PENDING',
+    'RUNNING',
+    'TERMINATING',
+    'TERMINATED',
+    'SKIPPED',
+    'INTERNAL_ERROR'
+]
+
+
+class RunState:
+    """
+    Utility class for the run state concept of Databricks runs.
+    """
+    def __init__(self, life_cycle_state, result_state, state_message):
+        self.life_cycle_state = life_cycle_state
+        self.result_state = result_state
+        self.state_message = state_message
+
+    @property
+    def is_terminal(self):
+        if self.life_cycle_state not in RUN_LIFE_CYCLE_STATES:
+            raise AirflowException(
+                ('Unexpected life cycle state: {}: If the state has '
+                 'been introduced recently, please check the Databricks user '
+                 'guide for troubleshooting information').format(
+                    self.life_cycle_state))
+        return self.life_cycle_state in ('TERMINATED', 'SKIPPED', 'INTERNAL_ERROR')
+
+    @property
+    def is_successful(self):
+        return self.result_state == 'SUCCESS'
+
+    def __eq__(self, other):
+        return self.life_cycle_state == other.life_cycle_state and \
+            self.result_state == other.result_state and \
+            self.state_message == other.state_message
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+
+class _TokenAuth(AuthBase):
+    """
+    Helper class for requests Auth field. AuthBase requires you to implement the __call__
+    magic function.
+    """
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r):
+        r.headers['Authorization'] = 'Bearer ' + self.token
+        return r

--- a/plugins/databricks/databricks_hook.py
+++ b/plugins/databricks/databricks_hook.py
@@ -2,7 +2,7 @@
 #
 # This file has been sourced from the upstream Apache Airflow
 # project located in the following repository:
-# https://github.com/apache/airflow/blob/v1-10-stable/airflow/contrib/hooks/databricks_hook.py
+# https://github.com/apache/airflow/blob/f177b7fbe02304eaac68a204bd90071bf634136c/airflow/contrib/hooks/databricks_hook.py
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/plugins/databricks/databricks_hook.py
+++ b/plugins/databricks/databricks_hook.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 #
+# This file has been sourced from the upstream Apache Airflow
+# project located in the following repository:
+# https://github.com/apache/airflow/blob/v1-10-stable/airflow/contrib/hooks/databricks_hook.py
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/plugins/databricks/databricks_operator.py
+++ b/plugins/databricks/databricks_operator.py
@@ -1,0 +1,480 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import six
+import time
+
+from airflow.exceptions import AirflowException
+from airflow.contrib.hooks.databricks_hook import DatabricksHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+XCOM_RUN_ID_KEY = 'run_id'
+XCOM_RUN_PAGE_URL_KEY = 'run_page_url'
+
+
+def _deep_string_coerce(content, json_path='json'):
+    """
+    Coerces content or all values of content if it is a dict to a string. The
+    function will throw if content contains non-string or non-numeric types.
+
+    The reason why we have this function is because the ``self.json`` field must be a
+     dict with only string values. This is because ``render_template`` will fail
+    for numerical values.
+    """
+    c = _deep_string_coerce
+    if isinstance(content, six.string_types):
+        return content
+    elif isinstance(content, six.integer_types + (float,)):
+        # Databricks can tolerate either numeric or string types in the API backend.
+        return str(content)
+    elif isinstance(content, (list, tuple)):
+        return [c(e, '{0}[{1}]'.format(json_path, i)) for i, e in enumerate(content)]
+    elif isinstance(content, dict):
+        return {k: c(v, '{0}[{1}]'.format(json_path, k))
+                for k, v in list(content.items())}
+    else:
+        param_type = type(content)
+        msg = 'Type {0} used for parameter {1} is not a number or a string' \
+            .format(param_type, json_path)
+        raise AirflowException(msg)
+
+
+def _handle_databricks_operator_execution(operator, hook, log, context):
+    """
+    Handles the Airflow + Databricks lifecycle logic for a Databricks operator
+    :param operator: Databricks operator being handled
+    :param context: Airflow context
+    """
+    if operator.do_xcom_push:
+        context['ti'].xcom_push(key=XCOM_RUN_ID_KEY, value=operator.run_id)
+    log.info('Run submitted with run_id: %s', operator.run_id)
+    run_page_url = hook.get_run_page_url(operator.run_id)
+    if operator.do_xcom_push:
+        context['ti'].xcom_push(key=XCOM_RUN_PAGE_URL_KEY, value=run_page_url)
+
+    log.info('View run status, Spark UI, and logs at %s', run_page_url)
+    while True:
+        run_state = hook.get_run_state(operator.run_id)
+        if run_state.is_terminal:
+            if run_state.is_successful:
+                log.info('%s completed successfully.', operator.task_id)
+                log.info('View run status, Spark UI, and logs at %s', run_page_url)
+                return
+            else:
+                error_message = '{t} failed with terminal state: {s}'.format(
+                    t=operator.task_id,
+                    s=run_state)
+                raise AirflowException(error_message)
+        else:
+            log.info('%s in run state: %s', operator.task_id, run_state)
+            log.info('View run status, Spark UI, and logs at %s', run_page_url)
+            log.info('Sleeping for %s seconds.', operator.polling_period_seconds)
+            time.sleep(operator.polling_period_seconds)
+
+
+class DatabricksSubmitRunOperator(BaseOperator):
+    """
+    Submits a Spark job run to Databricks using the
+    `api/2.0/jobs/runs/submit
+    <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_
+    API endpoint.
+
+    There are two ways to instantiate this operator.
+
+    In the first way, you can take the JSON payload that you typically use
+    to call the ``api/2.0/jobs/runs/submit`` endpoint and pass it directly
+    to our ``DatabricksSubmitRunOperator`` through the ``json`` parameter.
+    For example ::
+        json = {
+          'new_cluster': {
+            'spark_version': '2.1.0-db3-scala2.11',
+            'num_workers': 2
+          },
+          'notebook_task': {
+            'notebook_path': '/Users/airflow@example.com/PrepareData',
+          },
+        }
+        notebook_run = DatabricksSubmitRunOperator(task_id='notebook_run', json=json)
+
+    Another way to accomplish the same thing is to use the named parameters
+    of the ``DatabricksSubmitRunOperator`` directly. Note that there is exactly
+    one named parameter for each top level parameter in the ``runs/submit``
+    endpoint. In this method, your code would look like this: ::
+        new_cluster = {
+          'spark_version': '2.1.0-db3-scala2.11',
+          'num_workers': 2
+        }
+        notebook_task = {
+          'notebook_path': '/Users/airflow@example.com/PrepareData',
+        }
+        notebook_run = DatabricksSubmitRunOperator(
+            task_id='notebook_run',
+            new_cluster=new_cluster,
+            notebook_task=notebook_task)
+
+    In the case where both the json parameter **AND** the named parameters
+    are provided, they will be merged together. If there are conflicts during the merge,
+    the named parameters will take precedence and override the top level ``json`` keys.
+
+    Currently the named parameters that ``DatabricksSubmitRunOperator`` supports are
+        - ``spark_jar_task``
+        - ``notebook_task``
+        - ``new_cluster``
+        - ``existing_cluster_id``
+        - ``libraries``
+        - ``run_name``
+        - ``timeout_seconds``
+
+    :param json: A JSON object containing API parameters which will be passed
+        directly to the ``api/2.0/jobs/runs/submit`` endpoint. The other named parameters
+        (i.e. ``spark_jar_task``, ``notebook_task``..) to this operator will
+        be merged with this json dictionary if they are provided.
+        If there are conflicts during the merge, the named parameters will
+        take precedence and override the top level json keys. (templated)
+
+        .. seealso::
+            For more information about templating see :ref:`jinja-templating`.
+            https://docs.databricks.com/api/latest/jobs.html#runs-submit
+    :type json: dict
+    :param spark_jar_task: The main class and parameters for the JAR task. Note that
+        the actual JAR is specified in the ``libraries``.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#jobssparkjartask
+    :type spark_jar_task: dict
+    :param notebook_task: The notebook path and parameters for the notebook task.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#jobsnotebooktask
+    :type notebook_task: dict
+    :param new_cluster: Specs for a new cluster on which this task will be run.
+        *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster
+    :type new_cluster: dict
+    :param existing_cluster_id: ID for existing cluster on which to run this task.
+        *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
+        This field will be templated.
+    :type existing_cluster_id: string
+    :param libraries: Libraries which this run will use.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/latest/libraries.html#managedlibrarieslibrary
+    :type libraries: list of dicts
+    :param run_name: The run name used for this task.
+        By default this will be set to the Airflow ``task_id``. This ``task_id`` is a
+        required parameter of the superclass ``BaseOperator``.
+        This field will be templated.
+    :type run_name: string
+    :param timeout_seconds: The timeout for this run. By default a value of 0 is used
+        which means to have no timeout.
+        This field will be templated.
+    :type timeout_seconds: int32
+    :param databricks_conn_id: The name of the Airflow connection to use.
+        By default and in the common case this will be ``databricks_default``. To use
+        token based authentication, provide the key ``token`` in the extra field for the
+        connection.
+    :type databricks_conn_id: string
+    :param polling_period_seconds: Controls the rate which we poll for the result of
+        this run. By default the operator will poll every 30 seconds.
+    :type polling_period_seconds: int
+    :param databricks_retry_limit: Amount of times retry if the Databricks backend is
+        unreachable. Its value must be greater than or equal to 1.
+    :type databricks_retry_limit: int
+    :param databricks_retry_delay: Number of seconds to wait between retries (it
+            might be a floating point number).
+    :type databricks_retry_delay: float
+    :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
+    :type do_xcom_push: boolean
+    """
+    # Used in airflow.models.BaseOperator
+    template_fields = ('json',)
+    # Databricks brand color (blue) under white text
+    ui_color = '#1CB1C2'
+    ui_fgcolor = '#fff'
+
+    @apply_defaults
+    def __init__(
+            self,
+            json=None,
+            spark_jar_task=None,
+            notebook_task=None,
+            new_cluster=None,
+            existing_cluster_id=None,
+            libraries=None,
+            run_name=None,
+            timeout_seconds=None,
+            databricks_conn_id='databricks_default',
+            polling_period_seconds=30,
+            databricks_retry_limit=3,
+            databricks_retry_delay=1,
+            do_xcom_push=False,
+            **kwargs):
+        """
+        Creates a new ``DatabricksSubmitRunOperator``.
+        """
+        super(DatabricksSubmitRunOperator, self).__init__(**kwargs)
+        self.json = json or {}
+        self.databricks_conn_id = databricks_conn_id
+        self.polling_period_seconds = polling_period_seconds
+        self.databricks_retry_limit = databricks_retry_limit
+        self.databricks_retry_delay = databricks_retry_delay
+        if spark_jar_task is not None:
+            self.json['spark_jar_task'] = spark_jar_task
+        if notebook_task is not None:
+            self.json['notebook_task'] = notebook_task
+        if new_cluster is not None:
+            self.json['new_cluster'] = new_cluster
+        if existing_cluster_id is not None:
+            self.json['existing_cluster_id'] = existing_cluster_id
+        if libraries is not None:
+            self.json['libraries'] = libraries
+        if run_name is not None:
+            self.json['run_name'] = run_name
+        if timeout_seconds is not None:
+            self.json['timeout_seconds'] = timeout_seconds
+        if 'run_name' not in self.json:
+            self.json['run_name'] = run_name or kwargs['task_id']
+
+        self.json = _deep_string_coerce(self.json)
+        # This variable will be used in case our task gets killed.
+        self.run_id = None
+        self.do_xcom_push = do_xcom_push
+
+    def get_hook(self):
+        return DatabricksHook(
+            self.databricks_conn_id,
+            retry_limit=self.databricks_retry_limit,
+            retry_delay=self.databricks_retry_delay)
+
+    def execute(self, context):
+        hook = self.get_hook()
+        self.run_id = hook.submit_run(self.json)
+        _handle_databricks_operator_execution(self, hook, self.log, context)
+
+    def on_kill(self):
+        hook = self.get_hook()
+        hook.cancel_run(self.run_id)
+        self.log.info(
+            'Task: %s with run_id: %s was requested to be cancelled.',
+            self.task_id, self.run_id
+        )
+
+
+class DatabricksRunNowOperator(BaseOperator):
+    """
+    Runs an existing Spark job run to Databricks using the
+    `api/2.0/jobs/run-now
+    <https://docs.databricks.com/api/latest/jobs.html#run-now>`_
+    API endpoint.
+
+    There are two ways to instantiate this operator.
+
+    In the first way, you can take the JSON payload that you typically use
+    to call the ``api/2.0/jobs/run-now`` endpoint and pass it directly
+    to our ``DatabricksRunNowOperator`` through the ``json`` parameter.
+    For example ::
+        json = {
+          "job_id": 42,
+          "notebook_params": {
+            "dry-run": "true",
+            "oldest-time-to-consider": "1457570074236"
+          }
+        }
+
+        notebook_run = DatabricksRunNowOperator(task_id='notebook_run', json=json)
+
+    Another way to accomplish the same thing is to use the named parameters
+    of the ``DatabricksRunNowOperator`` directly. Note that there is exactly
+    one named parameter for each top level parameter in the ``run-now``
+    endpoint. In this method, your code would look like this: ::
+
+        job_id=42
+
+        notebook_params = {
+            "dry-run": "true",
+            "oldest-time-to-consider": "1457570074236"
+        }
+
+        python_params = ["douglas adams", "42"]
+
+        spark_submit_params = ["--class", "org.apache.spark.examples.SparkPi"]
+
+        notebook_run = DatabricksRunNowOperator(
+            job_id=job_id,
+            notebook_params=notebook_params,
+            python_params=python_params,
+            spark_submit_params=spark_submit_params
+        )
+
+    In the case where both the json parameter **AND** the named parameters
+    are provided, they will be merged together. If there are conflicts during the merge,
+    the named parameters will take precedence and override the top level ``json`` keys.
+
+    Currently the named parameters that ``DatabricksRunNowOperator`` supports are
+        - ``job_id``
+        - ``json``
+        - ``notebook_params``
+        - ``python_params``
+        - ``spark_submit_params``
+
+
+    :param job_id: the job_id of the existing Databricks job.
+        This field will be templated.
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#run-now
+    :type job_id: string
+    :param json: A JSON object containing API parameters which will be passed
+        directly to the ``api/2.0/jobs/run-now`` endpoint. The other named parameters
+        (i.e. ``notebook_params``, ``spark_submit_params``..) to this operator will
+        be merged with this json dictionary if they are provided.
+        If there are conflicts during the merge, the named parameters will
+        take precedence and override the top level json keys. (templated)
+
+        .. seealso::
+            For more information about templating see :ref:`jinja-templating`.
+            https://docs.databricks.com/api/latest/jobs.html#run-now
+    :type json: dict
+    :param notebook_params: A dict from keys to values for jobs with notebook task,
+        e.g. "notebook_params": {"name": "john doe", "age":  "35"}.
+        The map is passed to the notebook and will be accessible through the
+        dbutils.widgets.get function. See Widgets for more information.
+        If not specified upon run-now, the triggered run will use the
+        job’s base parameters. notebook_params cannot be
+        specified in conjunction with jar_params. The json representation
+        of this field (i.e. {"notebook_params":{"name":"john doe","age":"35"}})
+        cannot exceed 10,000 bytes.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/user-guide/notebooks/widgets.html
+    :type notebook_params: dict
+    :param python_params: A list of parameters for jobs with python tasks,
+        e.g. "python_params": ["john doe", "35"].
+        The parameters will be passed to python file as command line parameters.
+        If specified upon run-now, it would overwrite the parameters specified in
+        job setting.
+        The json representation of this field (i.e. {"python_params":["john doe","35"]})
+        cannot exceed 10,000 bytes.
+        This field will be templated.
+
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#run-now
+    :type python_params: array of strings
+    :param spark_submit_params: A list of parameters for jobs with spark submit task,
+        e.g. "spark_submit_params": ["--class", "org.apache.spark.examples.SparkPi"].
+        The parameters will be passed to spark-submit script as command line parameters.
+        If specified upon run-now, it would overwrite the parameters specified
+        in job setting.
+        The json representation of this field cannot exceed 10,000 bytes.
+        This field will be templated.
+        .. seealso::
+            https://docs.databricks.com/api/latest/jobs.html#run-now
+    :type spark_submit_params: array of strings
+    :param timeout_seconds: The timeout for this run. By default a value of 0 is used
+        which means to have no timeout.
+        This field will be templated.
+    :type timeout_seconds: int32
+    :param databricks_conn_id: The name of the Airflow connection to use.
+        By default and in the common case this will be ``databricks_default``. To use
+        token based authentication, provide the key ``token`` in the extra field for the
+        connection.
+    :type databricks_conn_id: string
+    :param polling_period_seconds: Controls the rate which we poll for the result of
+        this run. By default the operator will poll every 30 seconds.
+    :type polling_period_seconds: int
+    :param databricks_retry_limit: Amount of times retry if the Databricks backend is
+        unreachable. Its value must be greater than or equal to 1.
+    :type databricks_retry_limit: int
+    :param do_xcom_push: Whether we should push run_id and run_page_url to xcom.
+    :type do_xcom_push: boolean
+    """
+    # Used in airflow.models.BaseOperator
+    template_fields = ('json',)
+    # Databricks brand color (blue) under white text
+    ui_color = '#1CB1C2'
+    ui_fgcolor = '#fff'
+
+    @apply_defaults
+    def __init__(
+            self,
+            job_id,
+            json=None,
+            notebook_params=None,
+            python_params=None,
+            spark_submit_params=None,
+            databricks_conn_id='databricks_default',
+            polling_period_seconds=30,
+            databricks_retry_limit=3,
+            databricks_retry_delay=1,
+            do_xcom_push=False,
+            **kwargs):
+
+        """
+        Creates a new ``DatabricksRunNowOperator``.
+        """
+        super(DatabricksRunNowOperator, self).__init__(**kwargs)
+        self.json = json or {}
+        self.databricks_conn_id = databricks_conn_id
+        self.polling_period_seconds = polling_period_seconds
+        self.databricks_retry_limit = databricks_retry_limit
+        self.databricks_retry_delay = databricks_retry_delay
+
+        if job_id is not None:
+            self.json['job_id'] = job_id
+        if notebook_params is not None:
+            self.json['notebook_params'] = notebook_params
+        if python_params is not None:
+            self.json['python_params'] = python_params
+        if spark_submit_params is not None:
+            self.json['spark_submit_params'] = spark_submit_params
+
+        self.json = _deep_string_coerce(self.json)
+        # This variable will be used in case our task gets killed.
+        self.run_id = None
+        self.do_xcom_push = do_xcom_push
+
+    def get_hook(self):
+        return DatabricksHook(
+            self.databricks_conn_id,
+            retry_limit=self.databricks_retry_limit,
+            retry_delay=self.databricks_retry_delay)
+
+    def execute(self, context):
+        hook = self.get_hook()
+        self.run_id = hook.run_now(self.json)
+        _handle_databricks_operator_execution(self, hook, self.log, context)
+
+    def on_kill(self):
+        hook = self.get_hook()
+        hook.cancel_run(self.run_id)
+        self.log.info(
+            'Task: %s with run_id: %s was requested to be cancelled.',
+            self.task_id, self.run_id
+        )

--- a/plugins/databricks/databricks_operator.py
+++ b/plugins/databricks/databricks_operator.py
@@ -22,7 +22,7 @@ import six
 import time
 
 from airflow.exceptions import AirflowException
-from airflow.contrib.hooks.databricks_hook import DatabricksHook
+from .databricks_hook import DatabricksHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 

--- a/plugins/databricks/databricks_operator.py
+++ b/plugins/databricks/databricks_operator.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 #
+# This file has been sourced from the upstream Apache Airflow
+# project located in the following repository:
+# https://github.com/apache/airflow/blob/v1-10-stable/airflow/contrib/hooks/databricks_hook.py
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/plugins/databricks/databricks_operator.py
+++ b/plugins/databricks/databricks_operator.py
@@ -2,7 +2,7 @@
 #
 # This file has been sourced from the upstream Apache Airflow
 # project located in the following repository:
-# https://github.com/apache/airflow/blob/v1-10-stable/airflow/contrib/hooks/databricks_hook.py
+# https://github.com/apache/airflow/blob/98ee454f5d84b8c96f6318e87fad31f527a0716c/airflow/contrib/operators/databricks_operator.py
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/tests/test_databricks_hook.py
+++ b/tests/test_databricks_hook.py
@@ -2,7 +2,7 @@
 #
 # This file has been sourced from the upstream Apache Airflow
 # project located in the following repository:
-# https://github.com/apache/airflow/blob/v1-10-stable/tests/contrib/hooks/test_databricks_hook.py
+# https://github.com/apache/airflow/blob/b09f8cc4064507d8743f0f275d249e79c11adc3e/tests/contrib/hooks/test_databricks_hook.py
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/tests/test_databricks_hook.py
+++ b/tests/test_databricks_hook.py
@@ -1,0 +1,453 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import itertools
+import json
+import unittest
+
+from requests import exceptions as requests_exceptions
+
+from airflow import __version__
+from airflow.contrib.hooks.databricks_hook import (
+    DatabricksHook,
+    RunState,
+    SUBMIT_RUN_ENDPOINT
+)
+from airflow.exceptions import AirflowException
+from airflow.models import Connection
+from airflow.utils import db
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+TASK_ID = 'databricks-operator'
+DEFAULT_CONN_ID = 'databricks_default'
+NOTEBOOK_TASK = {
+    'notebook_path': '/test'
+}
+NEW_CLUSTER = {
+    'spark_version': '2.0.x-scala2.10',
+    'node_type_id': 'r3.xlarge',
+    'num_workers': 1
+}
+CLUSTER_ID = 'cluster_id'
+RUN_ID = 1
+JOB_ID = 42
+HOST = 'xx.cloud.databricks.com'
+HOST_WITH_SCHEME = 'https://xx.cloud.databricks.com'
+LOGIN = 'login'
+PASSWORD = 'password'
+TOKEN = 'token'
+USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v=__version__)}
+RUN_PAGE_URL = 'https://XX.cloud.databricks.com/#jobs/1/runs/1'
+LIFE_CYCLE_STATE = 'PENDING'
+STATE_MESSAGE = 'Waiting for cluster'
+GET_RUN_RESPONSE = {
+    'run_page_url': RUN_PAGE_URL,
+    'state': {
+        'life_cycle_state': LIFE_CYCLE_STATE,
+        'state_message': STATE_MESSAGE
+    }
+}
+NOTEBOOK_PARAMS = {
+    "dry-run": "true",
+    "oldest-time-to-consider": "1457570074236"
+}
+JAR_PARAMS = ["param1", "param2"]
+RESULT_STATE = None
+
+
+def run_now_endpoint(host):
+    """
+    Utility function to generate the run now endpoint given the host.
+    """
+    return 'https://{}/api/2.0/jobs/run-now'.format(host)
+
+
+def submit_run_endpoint(host):
+    """
+    Utility function to generate the submit run endpoint given the host.
+    """
+    return 'https://{}/api/2.0/jobs/runs/submit'.format(host)
+
+
+def get_run_endpoint(host):
+    """
+    Utility function to generate the get run endpoint given the host.
+    """
+    return 'https://{}/api/2.0/jobs/runs/get'.format(host)
+
+
+def cancel_run_endpoint(host):
+    """
+    Utility function to generate the get run endpoint given the host.
+    """
+    return 'https://{}/api/2.0/jobs/runs/cancel'.format(host)
+
+
+def start_cluster_endpoint(host):
+    """
+    Utility function to generate the get run endpoint given the host.
+    """
+    return 'https://{}/api/2.0/clusters/start'.format(host)
+
+
+def restart_cluster_endpoint(host):
+    """
+    Utility function to generate the get run endpoint given the host.
+    """
+    return 'https://{}/api/2.0/clusters/restart'.format(host)
+
+
+def terminate_cluster_endpoint(host):
+    """
+    Utility function to generate the get run endpoint given the host.
+    """
+    return 'https://{}/api/2.0/clusters/delete'.format(host)
+
+
+def create_valid_response_mock(content):
+    response = mock.MagicMock()
+    response.json.return_value = content
+    return response
+
+
+def create_post_side_effect(exception, status_code=500):
+    if exception != requests_exceptions.HTTPError:
+        return exception()
+    else:
+        response = mock.MagicMock()
+        response.status_code = status_code
+        response.raise_for_status.side_effect = exception(response=response)
+        return response
+
+
+def setup_mock_requests(mock_requests,
+                        exception,
+                        status_code=500,
+                        error_count=None,
+                        response_content=None):
+    side_effect = create_post_side_effect(exception, status_code)
+
+    if error_count is None:
+        # POST requests will fail indefinitely
+        mock_requests.post.side_effect = itertools.repeat(side_effect)
+    else:
+        # POST requests will fail 'error_count' times, and then they will succeed (once)
+        mock_requests.post.side_effect = \
+            [side_effect] * error_count + [create_valid_response_mock(response_content)]
+
+
+class DatabricksHookTest(unittest.TestCase):
+    """
+    Tests for DatabricksHook.
+    """
+
+    @db.provide_session
+    def setUp(self, session=None):
+        conn = session.query(Connection) \
+            .filter(Connection.conn_id == DEFAULT_CONN_ID) \
+            .first()
+        conn.host = HOST
+        conn.login = LOGIN
+        conn.password = PASSWORD
+        conn.extra = None
+        session.commit()
+
+        self.hook = DatabricksHook(retry_delay=0)
+
+    def test_parse_host_with_proper_host(self):
+        host = self.hook._parse_host(HOST)
+        self.assertEquals(host, HOST)
+
+    def test_parse_host_with_scheme(self):
+        host = self.hook._parse_host(HOST_WITH_SCHEME)
+        self.assertEquals(host, HOST)
+
+    def test_init_bad_retry_limit(self):
+        with self.assertRaises(ValueError):
+            DatabricksHook(retry_limit=0)
+
+    def test_do_api_call_retries_with_retryable_error(self):
+        for exception in [requests_exceptions.ConnectionError,
+                          requests_exceptions.SSLError,
+                          requests_exceptions.Timeout,
+                          requests_exceptions.ConnectTimeout,
+                          requests_exceptions.HTTPError]:
+            with mock.patch('airflow.contrib.hooks.databricks_hook.requests') as mock_requests:
+                with mock.patch.object(self.hook.log, 'error') as mock_errors:
+                    setup_mock_requests(mock_requests, exception)
+
+                    with self.assertRaises(AirflowException):
+                        self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
+
+                    self.assertEquals(mock_errors.call_count, self.hook.retry_limit)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_do_api_call_does_not_retry_with_non_retryable_error(self, mock_requests):
+        setup_mock_requests(
+            mock_requests, requests_exceptions.HTTPError, status_code=400
+        )
+
+        with mock.patch.object(self.hook.log, 'error') as mock_errors:
+            with self.assertRaises(AirflowException):
+                self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
+
+            mock_errors.assert_not_called()
+
+    def test_do_api_call_succeeds_after_retrying(self):
+        for exception in [requests_exceptions.ConnectionError,
+                          requests_exceptions.SSLError,
+                          requests_exceptions.Timeout,
+                          requests_exceptions.ConnectTimeout,
+                          requests_exceptions.HTTPError]:
+            with mock.patch('airflow.contrib.hooks.databricks_hook.requests') as mock_requests:
+                with mock.patch.object(self.hook.log, 'error') as mock_errors:
+                    setup_mock_requests(
+                        mock_requests,
+                        exception,
+                        error_count=2,
+                        response_content={'run_id': '1'}
+                    )
+
+                    response = self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
+
+                    self.assertEquals(mock_errors.call_count, 2)
+                    self.assertEquals(response, {'run_id': '1'})
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.sleep')
+    def test_do_api_call_waits_between_retries(self, mock_sleep):
+        retry_delay = 5
+        self.hook = DatabricksHook(retry_delay=retry_delay)
+
+        for exception in [requests_exceptions.ConnectionError,
+                          requests_exceptions.SSLError,
+                          requests_exceptions.Timeout,
+                          requests_exceptions.ConnectTimeout,
+                          requests_exceptions.HTTPError]:
+            with mock.patch('airflow.contrib.hooks.databricks_hook.requests') as mock_requests:
+                with mock.patch.object(self.hook.log, 'error'):
+                    mock_sleep.reset_mock()
+                    setup_mock_requests(mock_requests, exception)
+
+                    with self.assertRaises(AirflowException):
+                        self.hook._do_api_call(SUBMIT_RUN_ENDPOINT, {})
+
+                    self.assertEquals(len(mock_sleep.mock_calls), self.hook.retry_limit - 1)
+                    mock_sleep.assert_called_with(retry_delay)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_submit_run(self, mock_requests):
+        mock_requests.post.return_value.json.return_value = {'run_id': '1'}
+        json = {
+            'notebook_task': NOTEBOOK_TASK,
+            'new_cluster': NEW_CLUSTER
+        }
+        run_id = self.hook.submit_run(json)
+
+        self.assertEquals(run_id, '1')
+        mock_requests.post.assert_called_once_with(
+            submit_run_endpoint(HOST),
+            json={
+                'notebook_task': NOTEBOOK_TASK,
+                'new_cluster': NEW_CLUSTER,
+            },
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_run_now(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.post.return_value.json.return_value = {'run_id': '1'}
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
+        json = {
+            'notebook_params': NOTEBOOK_PARAMS,
+            'jar_params': JAR_PARAMS,
+            'job_id': JOB_ID
+        }
+        run_id = self.hook.run_now(json)
+
+        self.assertEquals(run_id, '1')
+
+        mock_requests.post.assert_called_once_with(
+            run_now_endpoint(HOST),
+            json={
+                'notebook_params': NOTEBOOK_PARAMS,
+                'jar_params': JAR_PARAMS,
+                'job_id': JOB_ID
+            },
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_get_run_page_url(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+
+        run_page_url = self.hook.get_run_page_url(RUN_ID)
+
+        self.assertEquals(run_page_url, RUN_PAGE_URL)
+        mock_requests.get.assert_called_once_with(
+            get_run_endpoint(HOST),
+            json={'run_id': RUN_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_get_run_state(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+
+        run_state = self.hook.get_run_state(RUN_ID)
+
+        self.assertEquals(run_state, RunState(
+            LIFE_CYCLE_STATE,
+            RESULT_STATE,
+            STATE_MESSAGE))
+        mock_requests.get.assert_called_once_with(
+            get_run_endpoint(HOST),
+            json={'run_id': RUN_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_cancel_run(self, mock_requests):
+        mock_requests.post.return_value.json.return_value = GET_RUN_RESPONSE
+
+        self.hook.cancel_run(RUN_ID)
+
+        mock_requests.post.assert_called_once_with(
+            cancel_run_endpoint(HOST),
+            json={'run_id': RUN_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_start_cluster(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.post.return_value.json.return_value = {}
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
+
+        self.hook.start_cluster({"cluster_id": CLUSTER_ID})
+
+        mock_requests.post.assert_called_once_with(
+            start_cluster_endpoint(HOST),
+            json={'cluster_id': CLUSTER_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_restart_cluster(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.post.return_value.json.return_value = {}
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
+
+        self.hook.restart_cluster({"cluster_id": CLUSTER_ID})
+
+        mock_requests.post.assert_called_once_with(
+            restart_cluster_endpoint(HOST),
+            json={'cluster_id': CLUSTER_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_terminate_cluster(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.post.return_value.json.return_value = {}
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
+
+        self.hook.terminate_cluster({"cluster_id": CLUSTER_ID})
+
+        mock_requests.post.assert_called_once_with(
+            terminate_cluster_endpoint(HOST),
+            json={'cluster_id': CLUSTER_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds)
+
+
+class DatabricksHookTokenTest(unittest.TestCase):
+    """
+    Tests for DatabricksHook when auth is done with token.
+    """
+
+    @db.provide_session
+    def setUp(self, session=None):
+        conn = session.query(Connection) \
+            .filter(Connection.conn_id == DEFAULT_CONN_ID) \
+            .first()
+        conn.extra = json.dumps({'token': TOKEN})
+        session.commit()
+
+        self.hook = DatabricksHook()
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_submit_run(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.post.return_value.json.return_value = {'run_id': '1'}
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
+        json = {
+            'notebook_task': NOTEBOOK_TASK,
+            'new_cluster': NEW_CLUSTER
+        }
+        run_id = self.hook.submit_run(json)
+
+        self.assertEquals(run_id, '1')
+        args = mock_requests.post.call_args
+        kwargs = args[1]
+        self.assertEquals(kwargs['auth'].token, TOKEN)
+
+
+class RunStateTest(unittest.TestCase):
+    def test_is_terminal_true(self):
+        terminal_states = ['TERMINATED', 'SKIPPED', 'INTERNAL_ERROR']
+        for state in terminal_states:
+            run_state = RunState(state, '', '')
+            self.assertTrue(run_state.is_terminal)
+
+    def test_is_terminal_false(self):
+        non_terminal_states = ['PENDING', 'RUNNING', 'TERMINATING']
+        for state in non_terminal_states:
+            run_state = RunState(state, '', '')
+            self.assertFalse(run_state.is_terminal)
+
+    def test_is_terminal_with_nonexistent_life_cycle_state(self):
+        run_state = RunState('blah', '', '')
+        with self.assertRaises(AirflowException):
+            run_state.is_terminal
+
+    def test_is_successful(self):
+        run_state = RunState('TERMINATED', 'SUCCESS', '')
+        self.assertTrue(run_state.is_successful)

--- a/tests/test_databricks_hook.py
+++ b/tests/test_databricks_hook.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 #
+# This file has been sourced from the upstream Apache Airflow
+# project located in the following repository:
+# https://github.com/apache/airflow/blob/v1-10-stable/tests/contrib/hooks/test_databricks_hook.py
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/test_databricks_hook.py
+++ b/tests/test_databricks_hook.py
@@ -25,7 +25,7 @@ import unittest
 from requests import exceptions as requests_exceptions
 
 from airflow import __version__
-from airflow.contrib.hooks.databricks_hook import (
+from plugins.databricks.databricks_hook import (
     DatabricksHook,
     RunState,
     SUBMIT_RUN_ENDPOINT
@@ -196,7 +196,7 @@ class DatabricksHookTest(unittest.TestCase):
                           requests_exceptions.Timeout,
                           requests_exceptions.ConnectTimeout,
                           requests_exceptions.HTTPError]:
-            with mock.patch('airflow.contrib.hooks.databricks_hook.requests') as mock_requests:
+            with mock.patch('plugins.databricks.databricks_hook.requests') as mock_requests:
                 with mock.patch.object(self.hook.log, 'error') as mock_errors:
                     setup_mock_requests(mock_requests, exception)
 
@@ -205,7 +205,7 @@ class DatabricksHookTest(unittest.TestCase):
 
                     self.assertEquals(mock_errors.call_count, self.hook.retry_limit)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_do_api_call_does_not_retry_with_non_retryable_error(self, mock_requests):
         setup_mock_requests(
             mock_requests, requests_exceptions.HTTPError, status_code=400
@@ -223,7 +223,7 @@ class DatabricksHookTest(unittest.TestCase):
                           requests_exceptions.Timeout,
                           requests_exceptions.ConnectTimeout,
                           requests_exceptions.HTTPError]:
-            with mock.patch('airflow.contrib.hooks.databricks_hook.requests') as mock_requests:
+            with mock.patch('plugins.databricks.databricks_hook.requests') as mock_requests:
                 with mock.patch.object(self.hook.log, 'error') as mock_errors:
                     setup_mock_requests(
                         mock_requests,
@@ -237,7 +237,7 @@ class DatabricksHookTest(unittest.TestCase):
                     self.assertEquals(mock_errors.call_count, 2)
                     self.assertEquals(response, {'run_id': '1'})
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.sleep')
+    @mock.patch('plugins.databricks.databricks_hook.sleep')
     def test_do_api_call_waits_between_retries(self, mock_sleep):
         retry_delay = 5
         self.hook = DatabricksHook(retry_delay=retry_delay)
@@ -247,7 +247,7 @@ class DatabricksHookTest(unittest.TestCase):
                           requests_exceptions.Timeout,
                           requests_exceptions.ConnectTimeout,
                           requests_exceptions.HTTPError]:
-            with mock.patch('airflow.contrib.hooks.databricks_hook.requests') as mock_requests:
+            with mock.patch('plugins.databricks.databricks_hook.requests') as mock_requests:
                 with mock.patch.object(self.hook.log, 'error'):
                     mock_sleep.reset_mock()
                     setup_mock_requests(mock_requests, exception)
@@ -258,7 +258,7 @@ class DatabricksHookTest(unittest.TestCase):
                     self.assertEquals(len(mock_sleep.mock_calls), self.hook.retry_limit - 1)
                     mock_sleep.assert_called_with(retry_delay)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_submit_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = {'run_id': '1'}
         json = {
@@ -278,7 +278,7 @@ class DatabricksHookTest(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_run_now(self, mock_requests):
         mock_requests.codes.ok = 200
         mock_requests.post.return_value.json.return_value = {'run_id': '1'}
@@ -304,7 +304,7 @@ class DatabricksHookTest(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_get_run_page_url(self, mock_requests):
         mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
 
@@ -318,7 +318,7 @@ class DatabricksHookTest(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_get_run_state(self, mock_requests):
         mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
 
@@ -335,7 +335,7 @@ class DatabricksHookTest(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_cancel_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = GET_RUN_RESPONSE
 
@@ -348,7 +348,7 @@ class DatabricksHookTest(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_start_cluster(self, mock_requests):
         mock_requests.codes.ok = 200
         mock_requests.post.return_value.json.return_value = {}
@@ -364,7 +364,7 @@ class DatabricksHookTest(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_restart_cluster(self, mock_requests):
         mock_requests.codes.ok = 200
         mock_requests.post.return_value.json.return_value = {}
@@ -380,7 +380,7 @@ class DatabricksHookTest(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds)
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_terminate_cluster(self, mock_requests):
         mock_requests.codes.ok = 200
         mock_requests.post.return_value.json.return_value = {}
@@ -412,7 +412,7 @@ class DatabricksHookTokenTest(unittest.TestCase):
 
         self.hook = DatabricksHook()
 
-    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    @mock.patch('plugins.databricks.databricks_hook.requests')
     def test_submit_run(self, mock_requests):
         mock_requests.codes.ok = 200
         mock_requests.post.return_value.json.return_value = {'run_id': '1'}

--- a/tests/test_databricks_operator.py
+++ b/tests/test_databricks_operator.py
@@ -21,10 +21,10 @@
 import unittest
 from datetime import datetime
 
-from airflow.contrib.hooks.databricks_hook import RunState
-import airflow.contrib.operators.databricks_operator as databricks_operator
-from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
-from airflow.contrib.operators.databricks_operator import DatabricksRunNowOperator
+from plugins.databricks.databricks_hook import RunState
+import plugins.databricks.databricks_operator as databricks_operator
+from plugins.databricks.databricks_operator import DatabricksSubmitRunOperator
+from plugins.databricks.databricks_operator import DatabricksRunNowOperator
 from airflow.exceptions import AirflowException
 from airflow.models import DAG
 
@@ -190,7 +190,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         with self.assertRaisesRegexp(AirflowException, exception_message):
             DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
 
-    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    @mock.patch('plugins.databricks.databricks_operator.DatabricksHook')
     def test_exec_success(self, db_mock_class):
         """
         Test the execute function in case where the run is successful.
@@ -221,7 +221,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
         self.assertEquals(RUN_ID, op.run_id)
 
-    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    @mock.patch('plugins.databricks.databricks_operator.DatabricksHook')
     def test_exec_failure(self, db_mock_class):
         """
         Test the execute function in case where the run failed.
@@ -252,7 +252,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
         self.assertEquals(RUN_ID, op.run_id)
 
-    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    @mock.patch('plugins.databricks.databricks_operator.DatabricksHook')
     def test_on_kill(self, db_mock_class):
         run = {
             'new_cluster': NEW_CLUSTER,
@@ -357,7 +357,7 @@ class DatabricksRunNowOperatorTest(unittest.TestCase):
         with self.assertRaisesRegexp(AirflowException, exception_message):
             DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=json)
 
-    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    @mock.patch('plugins.databricks.databricks_operator.DatabricksHook')
     def test_exec_success(self, db_mock_class):
         """
         Test the execute function in case where the run is successful.
@@ -390,7 +390,7 @@ class DatabricksRunNowOperatorTest(unittest.TestCase):
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
         self.assertEquals(RUN_ID, op.run_id)
 
-    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    @mock.patch('plugins.databricks.databricks_operator.DatabricksHook')
     def test_exec_failure(self, db_mock_class):
         """
         Test the execute function in case where the run failed.
@@ -423,7 +423,7 @@ class DatabricksRunNowOperatorTest(unittest.TestCase):
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
         self.assertEquals(RUN_ID, op.run_id)
 
-    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    @mock.patch('plugins.databricks.databricks_operator.DatabricksHook')
     def test_on_kill(self, db_mock_class):
         run = {
             'notebook_params': NOTEBOOK_PARAMS,

--- a/tests/test_databricks_operator.py
+++ b/tests/test_databricks_operator.py
@@ -1,0 +1,438 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+from datetime import datetime
+
+from airflow.contrib.hooks.databricks_hook import RunState
+import airflow.contrib.operators.databricks_operator as databricks_operator
+from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
+from airflow.contrib.operators.databricks_operator import DatabricksRunNowOperator
+from airflow.exceptions import AirflowException
+from airflow.models import DAG
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+DATE = '2017-04-20'
+TASK_ID = 'databricks-operator'
+DEFAULT_CONN_ID = 'databricks_default'
+NOTEBOOK_TASK = {
+    'notebook_path': '/test'
+}
+TEMPLATED_NOTEBOOK_TASK = {
+    'notebook_path': '/test-{{ ds }}'
+}
+RENDERED_TEMPLATED_NOTEBOOK_TASK = {
+    'notebook_path': '/test-{0}'.format(DATE)
+}
+SPARK_JAR_TASK = {
+    'main_class_name': 'com.databricks.Test'
+}
+NEW_CLUSTER = {
+    'spark_version': '2.0.x-scala2.10',
+    'node_type_id': 'development-node',
+    'num_workers': 1
+}
+EXISTING_CLUSTER_ID = 'existing-cluster-id'
+RUN_NAME = 'run-name'
+RUN_ID = 1
+JOB_ID = 42
+NOTEBOOK_PARAMS = {
+    "dry-run": "true",
+    "oldest-time-to-consider": "1457570074236"
+}
+JAR_PARAMS = ["param1", "param2"]
+RENDERED_TEMPLATED_JAR_PARAMS = [
+    '/test-{0}'.format(DATE)
+]
+TEMPLATED_JAR_PARAMS = [
+    '/test-{{ ds }}'
+]
+PYTHON_PARAMS = ["john doe", "35"]
+SPARK_SUBMIT_PARAMS = ["--class", "org.apache.spark.examples.SparkPi"]
+
+
+class DatabricksOperatorSharedFunctions(unittest.TestCase):
+    def test_deep_string_coerce(self):
+        test_json = {
+            'test_int': 1,
+            'test_float': 1.0,
+            'test_dict': {'key': 'value'},
+            'test_list': [1, 1.0, 'a', 'b'],
+            'test_tuple': (1, 1.0, 'a', 'b')
+        }
+
+        expected = {
+            'test_int': '1',
+            'test_float': '1.0',
+            'test_dict': {'key': 'value'},
+            'test_list': ['1', '1.0', 'a', 'b'],
+            'test_tuple': ['1', '1.0', 'a', 'b']
+        }
+        self.assertDictEqual(databricks_operator._deep_string_coerce(test_json), expected)
+
+
+class DatabricksSubmitRunOperatorTest(unittest.TestCase):
+    def test_init_with_named_parameters(self):
+        """
+        Test the initializer with the named parameters.
+        """
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID,
+                                         new_cluster=NEW_CLUSTER,
+                                         notebook_task=NOTEBOOK_TASK)
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+            'run_name': TASK_ID
+        })
+
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_json(self):
+        """
+        Test the initializer with json data.
+        """
+        json = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+            'run_name': TASK_ID
+        })
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_specified_run_name(self):
+        """
+        Test the initializer with a specified run_name.
+        """
+        json = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+            'run_name': RUN_NAME
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+            'run_name': RUN_NAME
+        })
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_merging(self):
+        """
+        Test the initializer when json and other named parameters are both
+        provided. The named parameters should override top level keys in the
+        json dict.
+        """
+        override_new_cluster = {'workers': 999}
+        json = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID,
+                                         json=json,
+                                         new_cluster=override_new_cluster)
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': override_new_cluster,
+            'notebook_task': NOTEBOOK_TASK,
+            'run_name': TASK_ID,
+        })
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_templating(self):
+        json = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': TEMPLATED_NOTEBOOK_TASK,
+        }
+        dag = DAG('test', start_date=datetime.now())
+        op = DatabricksSubmitRunOperator(dag=dag, task_id=TASK_ID, json=json)
+        op.json = op.render_template('json', op.json, {'ds': DATE})
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': RENDERED_TEMPLATED_NOTEBOOK_TASK,
+            'run_name': TASK_ID,
+        })
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_bad_type(self):
+        json = {
+            'test': datetime.now()
+        }
+        # Looks a bit weird since we have to escape regex reserved symbols.
+        exception_message = 'Type \<(type|class) \'datetime.datetime\'\> used ' + \
+                            'for parameter json\[test\] is not a number or a string'
+        with self.assertRaisesRegexp(AirflowException, exception_message):
+            DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_exec_success(self, db_mock_class):
+        """
+        Test the execute function in case where the run is successful.
+        """
+        run = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+            'run_name': TASK_ID
+        })
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay)
+
+        db_mock.submit_run.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+        self.assertEquals(RUN_ID, op.run_id)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_exec_failure(self, db_mock_class):
+        """
+        Test the execute function in case where the run failed.
+        """
+        run = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'FAILED', '')
+
+        with self.assertRaises(AirflowException):
+            op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce({
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+            'run_name': TASK_ID,
+        })
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay)
+        db_mock.submit_run.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+        self.assertEquals(RUN_ID, op.run_id)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_on_kill(self, db_mock_class):
+        run = {
+            'new_cluster': NEW_CLUSTER,
+            'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=run)
+        db_mock = db_mock_class.return_value
+        op.run_id = RUN_ID
+
+        op.on_kill()
+
+        db_mock.cancel_run.assert_called_once_with(RUN_ID)
+
+
+class DatabricksRunNowOperatorTest(unittest.TestCase):
+
+    def test_init_with_named_parameters(self):
+        """
+        Test the initializer with the named parameters.
+        """
+        op = DatabricksRunNowOperator(job_id=JOB_ID, task_id=TASK_ID)
+        expected = databricks_operator._deep_string_coerce({
+            'job_id': 42
+        })
+
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_json(self):
+        """
+        Test the initializer with json data.
+        """
+        json = {
+            'notebook_params': NOTEBOOK_PARAMS,
+            'jar_params': JAR_PARAMS,
+            'python_params': PYTHON_PARAMS,
+            'spark_submit_params': SPARK_SUBMIT_PARAMS
+        }
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=json)
+
+        expected = databricks_operator._deep_string_coerce({
+            'notebook_params': NOTEBOOK_PARAMS,
+            'jar_params': JAR_PARAMS,
+            'python_params': PYTHON_PARAMS,
+            'spark_submit_params': SPARK_SUBMIT_PARAMS,
+            'job_id': JOB_ID
+        })
+
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_merging(self):
+        """
+        Test the initializer when json and other named parameters are both
+        provided. The named parameters should override top level keys in the
+        json dict.
+        """
+        override_notebook_params = {'workers': 999}
+        json = {
+            'notebook_params': NOTEBOOK_PARAMS,
+            'jar_params': JAR_PARAMS
+        }
+
+        op = DatabricksRunNowOperator(task_id=TASK_ID,
+                                      json=json,
+                                      job_id=JOB_ID,
+                                      notebook_params=override_notebook_params,
+                                      python_params=PYTHON_PARAMS,
+                                      spark_submit_params=SPARK_SUBMIT_PARAMS)
+
+        expected = databricks_operator._deep_string_coerce({
+            'notebook_params': override_notebook_params,
+            'jar_params': JAR_PARAMS,
+            'python_params': PYTHON_PARAMS,
+            'spark_submit_params': SPARK_SUBMIT_PARAMS,
+            'job_id': JOB_ID
+        })
+
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_templating(self):
+        json = {
+            'notebook_params': NOTEBOOK_PARAMS,
+            'jar_params': TEMPLATED_JAR_PARAMS
+        }
+
+        dag = DAG('test', start_date=datetime.now())
+        op = DatabricksRunNowOperator(dag=dag, task_id=TASK_ID, job_id=JOB_ID, json=json)
+        op.json = op.render_template('json', op.json, {'ds': DATE})
+        expected = databricks_operator._deep_string_coerce({
+            'notebook_params': NOTEBOOK_PARAMS,
+            'jar_params': RENDERED_TEMPLATED_JAR_PARAMS,
+            'job_id': JOB_ID
+        })
+        self.assertDictEqual(expected, op.json)
+
+    def test_init_with_bad_type(self):
+        json = {
+            'test': datetime.now()
+        }
+        # Looks a bit weird since we have to escape regex reserved symbols.
+        exception_message = 'Type \<(type|class) \'datetime.datetime\'\> used ' + \
+                            'for parameter json\[test\] is not a number or a string'
+        with self.assertRaisesRegexp(AirflowException, exception_message):
+            DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=json)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_exec_success(self, db_mock_class):
+        """
+        Test the execute function in case where the run is successful.
+        """
+        run = {
+            'notebook_params': NOTEBOOK_PARAMS,
+            'notebook_task': NOTEBOOK_TASK,
+            'jar_params': JAR_PARAMS
+        }
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.run_now.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce({
+            'notebook_params': NOTEBOOK_PARAMS,
+            'notebook_task': NOTEBOOK_TASK,
+            'jar_params': JAR_PARAMS,
+            'job_id': JOB_ID
+        })
+
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay)
+        db_mock.run_now.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+        self.assertEquals(RUN_ID, op.run_id)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_exec_failure(self, db_mock_class):
+        """
+        Test the execute function in case where the run failed.
+        """
+        run = {
+            'notebook_params': NOTEBOOK_PARAMS,
+            'notebook_task': NOTEBOOK_TASK,
+            'jar_params': JAR_PARAMS
+        }
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=run)
+        db_mock = db_mock_class.return_value
+        db_mock.run_now.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'FAILED', '')
+
+        with self.assertRaises(AirflowException):
+            op.execute(None)
+
+        expected = databricks_operator._deep_string_coerce({
+            'notebook_params': NOTEBOOK_PARAMS,
+            'notebook_task': NOTEBOOK_TASK,
+            'jar_params': JAR_PARAMS,
+            'job_id': JOB_ID
+        })
+        db_mock_class.assert_called_once_with(
+            DEFAULT_CONN_ID,
+            retry_limit=op.databricks_retry_limit,
+            retry_delay=op.databricks_retry_delay)
+        db_mock.run_now.assert_called_once_with(expected)
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+        self.assertEquals(RUN_ID, op.run_id)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_on_kill(self, db_mock_class):
+        run = {
+            'notebook_params': NOTEBOOK_PARAMS,
+            'notebook_task': NOTEBOOK_TASK,
+            'jar_params': JAR_PARAMS
+        }
+        op = DatabricksRunNowOperator(task_id=TASK_ID, job_id=JOB_ID, json=run)
+        db_mock = db_mock_class.return_value
+        op.run_id = RUN_ID
+
+        op.on_kill()
+        db_mock.cancel_run.assert_called_once_with(RUN_ID)

--- a/tests/test_databricks_operator.py
+++ b/tests/test_databricks_operator.py
@@ -2,7 +2,7 @@
 #
 # This file has been sourced from the upstream Apache Airflow
 # project located in the following repository:
-# https://github.com/apache/airflow/blob/v1-10-stable/tests/contrib/operators/test_databricks_operator.py
+# https://github.com/apache/airflow/blob/5f8f305d17a6322817019b756b581150c436b1db/tests/contrib/operators/test_databricks_operator.py
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/tests/test_databricks_operator.py
+++ b/tests/test_databricks_operator.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 #
+# This file has been sourced from the upstream Apache Airflow
+# project located in the following repository:
+# https://github.com/apache/airflow/blob/v1-10-stable/tests/contrib/operators/test_databricks_operator.py
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
This backports patches made to the Databricks hook and operator as a separately maintained plugin. We should be able to access the operator like any other plugin. We can modify the `MozDatabricksRunSubmitOperator` to use the plugin instead of the one from within the tree.

The backport process was a 3 part process (broken down by commit).

1. Copy the relevant files from https://github.com/apache/airflow/tree/v1-10-stable
2. Fix the imports and mocks to reference the plugins directory e.g. `plugins.databricks.databricks_hook` instead of `airflow.contrib.hooks.databricks_hook`.
3. Export the plugin in the module initialization.

Other than the minor fixes entailed in step 2, the tests and backported functionality should be plug and play. 
