### PR TITLE
Fix relative import in Databricks plugin

### DIFF
--- a/plugins/databricks/databricks_operator.py
+++ b/plugins/databricks/databricks_operator.py
@@ -26,7 +26,7 @@ import six
 import time
 
 from airflow.exceptions import AirflowException
-from .databricks_hook import DatabricksHook
+from databricks.databricks_hook import DatabricksHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 


### PR DESCRIPTION
Airflow is running on python 2, so relative imports are not valid syntax. This uses the relative module path. 