### PR TITLE
Revert "Increase databricks retries and retry delay to avoid api errors"

### DIFF
--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -2,7 +2,7 @@ from os import environ
 from pprint import pformat
 
 from airflow.plugins_manager import AirflowPlugin
-from databricks.databricks_operator import DatabricksSubmitRunOperator
+from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
 
 
 class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
@@ -186,12 +186,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
             "libraries": libraries
         }
         json = {k: v for k, v in json.items() if v}
-        super(MozDatabricksSubmitRunOperator, self).__init__(
-            json,
-            databricks_retry_limit=20,
-            databricks_retry_delay=30,
-            **kwargs
-        )
+        super(MozDatabricksSubmitRunOperator, self).__init__(json, **kwargs)
 
     def execute(self, context):
         self.log.info("Running {} with parameters:\n{}"


### PR DESCRIPTION
Reverts mozilla/telemetry-airflow#421

```
Broken DAG: [/home/airflow/gcs/dags/main_summary.py] Use keyword arguments when initializing operators
Broken DAG: [/home/airflow/gcs/dags/landfill.py] Use keyword arguments when initializing operators
Broken DAG: [/home/airflow/gcs/dags/longitudinal.py] Use keyword arguments when initializing operators 
```