### PR TITLE
Run tab spinner job on Databricks

### DIFF
--- a/dags/spinner_severity_generator.py
+++ b/dags/spinner_severity_generator.py
@@ -1,6 +1,6 @@
 from airflow import DAG
+from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
 from datetime import datetime, timedelta
-from operators.emr_spark_operator import EMRSparkOperator
 from utils.mozetl import mozetl_envvar
 
 default_args = {
@@ -16,7 +16,7 @@ default_args = {
 
 dag = DAG('tab_spinner_severity', default_args=default_args, schedule_interval='@daily')
 
-update_tab_spinner_severity = EMRSparkOperator(
+update_tab_spinner_severity = MozDatabricksSubmitRunOperator(
     task_id="update_tab_spinner_severity",
     job_name="Tab Spinner Severity Job",
     execution_timeout=timedelta(hours=12),


### PR DESCRIPTION
This moves tab spinner job to Databricks.
Test run(succeeded): https://dbc-caf9527b-e073.cloud.databricks.com/#job/1299/run/1