### PR TITLE
Increase databricks retries and retry delay to avoid api errors

### DIFF
--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -2,7 +2,7 @@ from os import environ
 from pprint import pformat
 
 from airflow.plugins_manager import AirflowPlugin
-from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
+from databricks.databricks_operator import DatabricksSubmitRunOperator
 
 
 class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -186,7 +186,12 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
             "libraries": libraries
         }
         json = {k: v for k, v in json.items() if v}
-        super(MozDatabricksSubmitRunOperator, self).__init__(json, **kwargs)
+        super(MozDatabricksSubmitRunOperator, self).__init__(
+            json,
+            databricks_retry_limit=20,
+            databricks_retry_delay=30,
+            **kwargs
+        )
 
     def execute(self, context):
         self.log.info("Running {} with parameters:\n{}"

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -187,7 +187,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
         }
         json = {k: v for k, v in json.items() if v}
         super(MozDatabricksSubmitRunOperator, self).__init__(
-            json,
+            json=json,
             databricks_retry_limit=20,
             databricks_retry_delay=30,
             **kwargs

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from plugins.moz_databricks import MozDatabricksSubmitRunOperator
+
+# The environment variables required by the MozDatabricks operator must be available
+# in the environment dictionary during module import time because they are class
+# variables that are used at templating time. Monkey-patching the variables occurs
+# too late in the process, so the variables are defined in `tox.ini` instead.
+
+
+def test_missing_tbv_or_mozetl_env(mocker):
+    mock_hook = mocker.patch("plugins.databricks.databricks_operator.DatabricksHook")
+    with pytest.raises(ValueError):
+        MozDatabricksSubmitRunOperator(
+            job_name="test_databricks", env={}, instance_count=1
+        )
+
+
+def test_mozetl_success(mocker):
+    mock_hook = mocker.patch("plugins.databricks.databricks_operator.DatabricksHook")
+    operator = MozDatabricksSubmitRunOperator(
+        task_id="test_databricks",
+        job_name="test_databricks",
+        env={"MOZETL_COMMAND": "test"},
+        instance_count=1,
+    )
+    operator.execute(None)
+    assert mock_hook.called
+
+
+def test_tbv_success(mocker):
+    mock_hook = mocker.patch("plugins.databricks.databricks_operator.DatabricksHook")
+    operator = MozDatabricksSubmitRunOperator(
+        task_id="test_databricks",
+        job_name="test_databricks",
+        env={"TBV_CLASS": "test", "ARTIFACT_URL": "https://test.amazonaws.com/test"},
+        instance_count=1,
+    )
+    operator.execute(None)
+    assert mock_hook.called

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -6,9 +6,9 @@ import pytest
 from plugins.moz_databricks import MozDatabricksSubmitRunOperator
 
 # The environment variables required by the MozDatabricks operator must be available
-# in the environment dictionary during module import time because they are class
-# variables that are used at templating time. Monkey-patching the variables occurs
-# too late in the process, so the variables are defined in `tox.ini` instead.
+# at module import because the `os.environ` is accessed in the class scope. These
+# variables are used by Airflow to template variables. Monkeypatch occurs after import,
+# so the variables are defined in `tox.ini` instead.
 
 
 def test_missing_tbv_or_mozetl_env(mocker):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,17 @@ setenv =
     AIRFLOW__CORE__UNIT_TEST_MODE = True
     AWS_ACCESS_KEY_ID=test
     AWS_SECRET_ACCESS_KEY=test
+    # required by test_moz_databricks_operator
+    AWS_REGION = test
+    SPARK_BUCKET = test
+    PRIVATE_OUTPUT_BUCKET = test
+    PUBLIC_OUTPUT_BUCKET = test
+    DEPLOY_ENVIRONMENT = test
+    DEPLOY_TAG = test
+    ARTIFACTS_BUCKET = test
+    DATABRICKS_DEFAULT_IAM = test
+    EMR_INSTANCE_TYPE = test
+
 commands=
     airflow resetdb -y
     python -m pytest {posargs}


### PR DESCRIPTION
This is the corrected version of PR #421, which was missing a keyword argument for `json`. This time around, I've added unit tests and tested the operator locally. 