### PR TITLE
Use Miniconda for Py 3.7

### DIFF
--- a/jobs/probe_scraper.sh
+++ b/jobs/probe_scraper.sh
@@ -7,17 +7,31 @@ BUCKET="net-mozaws-prod-us-west-2-data-pitmo"
 CACHE_DIR="probe_cache"
 OUTPUT_DIR="probe_data"
 
+ANACONDA_PATH=/mnt/miniconda3
+ANACONDA_SCRIPT=Miniconda3-4.5.12-Linux-x86_64.sh
+
+wget --no-clobber --no-verbose -P /mnt https://repo.anaconda.com/miniconda/$ANACONDA_SCRIPT
+rm -rf $ANACONDA_PATH
+bash /mnt/$ANACONDA_SCRIPT -b -p $ANACONDA_PATH
+
+export PATH=$ANACONDA_PATH/bin:$PATH
+rm /mnt/$ANACONDA_SCRIPT
+
+# Just to ensure, when looking at logs, we are using the correct python binary
+echo $(which python3)
+
 # Clone and setup the scraper
 git clone https://github.com/mozilla/probe-scraper.git
 cd probe-scraper
-python setup.py bdist_egg
-pip install -r requirements.txt
+python3 setup.py bdist_egg
+python3 -m pip install -r requirements.txt
 
 # Create the output and cache directories.
 mkdir $CACHE_DIR $OUTPUT_DIR
 
 # Finally run the scraper.
-python probe_scraper/runner.py --out-dir $OUTPUT_DIR --cache-dir $CACHE_DIR
+# Using -m allows for relative imports in runner.py
+python3 -m probe_scraper.runner --out-dir $OUTPUT_DIR --cache-dir $CACHE_DIR
 
 if [ -n "$(find $OUTPUT_DIR -prune -empty 2>/dev/null)" ]
 then


### PR DESCRIPTION
We need Python 3.7 for the `glean_parser`, and also then the probe-scraper. I don't think I want to make these changes for everyone though.