### PR TITLE
Add python3 support to moz_databricks and set it to default

### DIFF
--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -39,6 +39,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
                  output_visibility=None,
                  ebs_volume_count=None,
                  ebs_volume_size=None,
+                 python_version=2,
                  *args, **kwargs):
         """
         Generate parameters for running a job through the Databricks run-submit
@@ -70,6 +71,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
         :param output_visibility: argument from EMRSparkOperator for compatibility
         :param ebs_volume_count: number of ebs volumes to attach to each node
         :param ebs_volume_size: size of ebs volumes attached to each node
+        :param python_version: the default python runtime on the cluster
 
         :param kwargs: Keyword arguments to pass to DatabricksSubmitRunOperator
         """
@@ -108,6 +110,8 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
         if ebs_volume_size is not None:
             aws_attributes["ebs_volume_size"] = ebs_volume_size
 
+        if python_version == 3:
+            env["PYSPARK_VERSION"] = "/databricks/python3/bin/python3"
 
         # Create the cluster configuration
         new_cluster = {

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -39,7 +39,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
                  output_visibility=None,
                  ebs_volume_count=None,
                  ebs_volume_size=None,
-                 python_version=2,
+                 python_version=3,
                  *args, **kwargs):
         """
         Generate parameters for running a job through the Databricks run-submit

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -71,10 +71,16 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
         :param output_visibility: argument from EMRSparkOperator for compatibility
         :param ebs_volume_count: number of ebs volumes to attach to each node
         :param ebs_volume_size: size of ebs volumes attached to each node
-        :param python_version: the default python runtime on the cluster
+        :param python_version: the default python runtime on the cluster (python 3.5.2)
+            See https://docs.databricks.com/release-notes/runtime/4.3.html#system-environment
+            for more details.
 
         :param kwargs: Keyword arguments to pass to DatabricksSubmitRunOperator
         """
+        if python_version not in (2, 3):
+            raise ValueError("Only Python versions 2 or 3 allowed")
+        elif python_version == 3:
+            env["PYSPARK_PYTHON"] = "/databricks/python3/bin/python3"
 
         if enable_autoscale:
             if not max_instance_count:
@@ -109,9 +115,6 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
 
         if ebs_volume_size is not None:
             aws_attributes["ebs_volume_size"] = ebs_volume_size
-
-        if python_version == 3:
-            env["PYSPARK_PYTHON"] = "/databricks/python3/bin/python3"
 
         # Create the cluster configuration
         new_cluster = {

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -111,7 +111,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
             aws_attributes["ebs_volume_size"] = ebs_volume_size
 
         if python_version == 3:
-            env["PYSPARK_VERSION"] = "/databricks/python3/bin/python3"
+            env["PYSPARK_PYTHON"] = "/databricks/python3/bin/python3"
 
         # Create the cluster configuration
         new_cluster = {

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -52,3 +52,34 @@ def test_tbv_success(mock_hook):
 
     json = mock_hook.submit_run.call_args[0][0]
     assert json.get("spark_jar_task") is not None
+
+
+def test_default_python_version(mock_hook):
+    # run with default
+    operator = MozDatabricksSubmitRunOperator(
+        task_id="test_databricks",
+        job_name="test_databricks",
+        env={"MOZETL_COMMAND": "test"},
+        instance_count=1,
+    )
+    operator.execute(None)
+    mock_hook.submit_run.assert_called_once()
+
+    json = mock_hook.submit_run.call_args[0][0]
+    assert (
+        json["new_cluster"]["spark_env_vars"]["PYSPARK_VERSION"]
+        == "/databricks/python3/bin/python3"
+    )
+
+    # run with python 2 specifically
+    operator = MozDatabricksSubmitRunOperator(
+        task_id="test_databricks",
+        job_name="test_databricks",
+        env={"MOZETL_COMMAND": "test"},
+        python_version=2,
+        instance_count=1,
+    )
+    operator.execute(None)
+
+    json = mock_hook.submit_run.call_args[0][0]
+    assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_VERSION") is None

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -36,6 +36,9 @@ def test_mozetl_success(mock_hook):
     operator.execute(None)
     mock_hook.submit_run.assert_called_once()
 
+    # https://docs.python.org/3.3/library/unittest.mock.html#unittest.mock.Mock.call_args
+    # call_args is a tuple where the first element is a list of elements. The first element
+    # in `submit_run` is the constructed json blob.
     json = mock_hook.submit_run.call_args[0][0]
     assert json.get("spark_python_task") is not None
 
@@ -83,3 +86,12 @@ def test_default_python_version(mock_hook):
 
     json = mock_hook.submit_run.call_args[0][0]
     assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_PYTHON") is None
+
+    with pytest.raises(ValueError):
+        MozDatabricksSubmitRunOperator(
+            task_id="test_databricks",
+            job_name="test_databricks",
+            env={"MOZETL_COMMAND": "test"},
+            python_version=4,
+            instance_count=1,
+        ).execute(None)

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -21,6 +21,9 @@ def test_missing_tbv_or_mozetl_env(mocker):
 
 def test_mozetl_success(mocker):
     mock_hook = mocker.patch("plugins.databricks.databricks_operator.DatabricksHook")
+    mock_hook_instance = mock_hook.return_value
+    mock_hook_instance.submit_run.return_value = 1
+
     operator = MozDatabricksSubmitRunOperator(
         task_id="test_databricks",
         job_name="test_databricks",
@@ -28,11 +31,17 @@ def test_mozetl_success(mocker):
         instance_count=1,
     )
     operator.execute(None)
-    assert mock_hook.called
+    mock_hook_instance.submit_run.assert_called_once()
+
+    json = mock_hook_instance.submit_run.call_args[0][0]
+    assert json.get("spark_python_task") is not None
 
 
 def test_tbv_success(mocker):
     mock_hook = mocker.patch("plugins.databricks.databricks_operator.DatabricksHook")
+    mock_hook_instance = mock_hook.return_value
+    mock_hook_instance.submit_run.return_value = 1
+
     operator = MozDatabricksSubmitRunOperator(
         task_id="test_databricks",
         job_name="test_databricks",
@@ -40,4 +49,7 @@ def test_tbv_success(mocker):
         instance_count=1,
     )
     operator.execute(None)
-    assert mock_hook.called
+    mock_hook_instance.submit_run.assert_called_once()
+
+    json = mock_hook_instance.submit_run.call_args[0][0]
+    assert json.get("spark_jar_task") is not None

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -67,7 +67,7 @@ def test_default_python_version(mock_hook):
 
     json = mock_hook.submit_run.call_args[0][0]
     assert (
-        json["new_cluster"]["spark_env_vars"]["PYSPARK_VERSION"]
+        json["new_cluster"]["spark_env_vars"]["PYSPARK_PYTHON"]
         == "/databricks/python3/bin/python3"
     )
 
@@ -82,4 +82,4 @@ def test_default_python_version(mock_hook):
     operator.execute(None)
 
     json = mock_hook.submit_run.call_args[0][0]
-    assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_VERSION") is None
+    assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_PYTHON") is None


### PR DESCRIPTION
This will run mozetl jobs on Python 3 by default on databricks clusters. [This page](https://docs.databricks.com/api/latest/examples.html#python-3-example) shows how to create a new cluster with python 3 set as the default.

This also modifies the test so the json payload can be inspected and values can be asserted.