### PR TITLE
Remove newrelic from container for running in GKE

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -33,18 +33,18 @@ wait_for() {
 
 case $1 in
   flower)
-    exec newrelic-admin run-program airflow flower
+    exec airflow flower
     ;;
   web)
-    newrelic-admin run-program airflow initdb
-    newrelic-admin run-program airflow upgradedb
-    exec newrelic-admin run-program airflow webserver -p ${PORT} --workers 4
+    airflow initdb
+    airflow upgradedb
+    exec airflow webserver -p ${PORT} --workers 4
     ;;
   worker)
-    exec newrelic-admin run-program airflow worker
+    exec airflow worker
     ;;
   scheduler)
-    exec newrelic-admin run-program airflow scheduler
+    exec airflow scheduler
     ;;
   *)
     exec "$@"


### PR DESCRIPTION
Since we're moving this to GKE, the container wont need newrelic