### PR TITLE
 Fix #433 - Add support for alternative git path and branch in mozetl jobs

### DIFF
--- a/dags/churn.py
+++ b/dags/churn.py
@@ -41,6 +41,8 @@ churn_v2 = MozDatabricksSubmitRunOperator(
     }, other={
         "MOZETL_GIT_BRANCH": "churn-v2"
     }),
+    # the mozetl branch was forked before python 3 support
+    python_version=2,
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     output_visibility="public",
     dag=dag)

--- a/dags/churn.py
+++ b/dags/churn.py
@@ -2,6 +2,7 @@ from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
 from utils.mozetl import mozetl_envvar
+from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
 
 default_args = {
     'owner': 'amiyaguchi@mozilla.com',
@@ -29,7 +30,7 @@ churn = EMRSparkOperator(
     output_visibility="public",
     dag=dag)
 
-churn_v2 = EMRSparkOperator(
+churn_v2 = MozDatabricksSubmitRunOperator(
     task_id="churn_v2",
     job_name="churn 7-day v2",
     execution_timeout=timedelta(hours=4),

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -39,6 +39,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
                  output_visibility=None,
                  ebs_volume_count=None,
                  ebs_volume_size=None,
+                 python_version=2,
                  *args, **kwargs):
         """
         Generate parameters for running a job through the Databricks run-submit
@@ -70,6 +71,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
         :param output_visibility: argument from EMRSparkOperator for compatibility
         :param ebs_volume_count: number of ebs volumes to attach to each node
         :param ebs_volume_size: size of ebs volumes attached to each node
+        :param python_version: the default python runtime on the cluster
 
         :param kwargs: Keyword arguments to pass to DatabricksSubmitRunOperator
         """
@@ -108,6 +110,8 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
         if ebs_volume_size is not None:
             aws_attributes["ebs_volume_size"] = ebs_volume_size
 
+        if python_version == 3:
+            env["PYSPARK_VERSION"] = "/databricks/python3/bin/python3"
 
         # Create the cluster configuration
         new_cluster = {

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -39,7 +39,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
                  output_visibility=None,
                  ebs_volume_count=None,
                  ebs_volume_size=None,
-                 python_version=2,
+                 python_version=3,
                  *args, **kwargs):
         """
         Generate parameters for running a job through the Databricks run-submit

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -111,7 +111,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
             aws_attributes["ebs_volume_size"] = ebs_volume_size
 
         if python_version == 3:
-            env["PYSPARK_VERSION"] = "/databricks/python3/bin/python3"
+            env["PYSPARK_PYTHON"] = "/databricks/python3/bin/python3"
 
         # Create the cluster configuration
         new_cluster = {

--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -174,11 +174,20 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
             # Proper pip dependencies in Databricks is only supported via pypi.
             # Dependencies for source/binary distributions need to be added
             # manually.
-            libraries.append({
-                "pypi": {
-                    "package": "git+https://github.com/mozilla/python_mozetl.git"
+            path = env.get(
+                "MOZETL_GIT_PATH", "https://github.com/mozilla/python_mozetl.git"
+            )
+            branch = env.get("MOZETL_GIT_BRANCH", "master")
+
+            libraries.append(
+                {
+                    "pypi": {
+                        "package": "git+{path}@{branch}".format(
+                            path=path, branch=branch
+                        )
+                    }
                 }
-            })
+            )
         else:
             raise ValueError("Missing options for running tbv or mozetl tasks")
 

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -52,3 +52,34 @@ def test_tbv_success(mock_hook):
 
     json = mock_hook.submit_run.call_args[0][0]
     assert json.get("spark_jar_task") is not None
+
+
+def test_default_python_version(mock_hook):
+    # run with default
+    operator = MozDatabricksSubmitRunOperator(
+        task_id="test_databricks",
+        job_name="test_databricks",
+        env={"MOZETL_COMMAND": "test"},
+        instance_count=1,
+    )
+    operator.execute(None)
+    mock_hook.submit_run.assert_called_once()
+
+    json = mock_hook.submit_run.call_args[0][0]
+    assert (
+        json["new_cluster"]["spark_env_vars"]["PYSPARK_VERSION"]
+        == "/databricks/python3/bin/python3"
+    )
+
+    # run with python 2 specifically
+    operator = MozDatabricksSubmitRunOperator(
+        task_id="test_databricks",
+        job_name="test_databricks",
+        env={"MOZETL_COMMAND": "test"},
+        python_version=2,
+        instance_count=1,
+    )
+    operator.execute(None)
+
+    json = mock_hook.submit_run.call_args[0][0]
+    assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_VERSION") is None

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -83,3 +83,33 @@ def test_default_python_version(mock_hook):
 
     json = mock_hook.submit_run.call_args[0][0]
     assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_PYTHON") is None
+
+
+def test_set_mozetl_path_and_branch(mock_hook):
+    def mocked_run_submit_args(env):
+        MozDatabricksSubmitRunOperator(
+            task_id="test_databricks",
+            job_name="test_databricks",
+            env=env,
+            instance_count=1,
+        ).execute(None)
+        return mock_hook.submit_run.call_args[0][0]
+
+    json = mocked_run_submit_args(
+        {
+            "MOZETL_COMMAND": "test",
+            "MOZETL_GIT_PATH": "https://custom.com/repo.git",
+            "MOZETL_GIT_BRANCH": "dev",
+        }
+    )
+    assert (
+        json["libraries"][0]["pypi"]["package"] == "git+https://custom.com/repo.git@dev"
+    )
+
+    json = mocked_run_submit_args(
+        {"MOZETL_COMMAND": "test", "MOZETL_GIT_BRANCH": "dev"}
+    )
+    assert (
+        json["libraries"][0]["pypi"]["package"]
+        == "git+https://github.com/mozilla/python_mozetl.git@dev"
+    )

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -21,6 +21,9 @@ def test_missing_tbv_or_mozetl_env(mocker):
 
 def test_mozetl_success(mocker):
     mock_hook = mocker.patch("plugins.databricks.databricks_operator.DatabricksHook")
+    mock_hook_instance = mock_hook.return_value
+    mock_hook_instance.submit_run.return_value = 1
+
     operator = MozDatabricksSubmitRunOperator(
         task_id="test_databricks",
         job_name="test_databricks",
@@ -28,11 +31,17 @@ def test_mozetl_success(mocker):
         instance_count=1,
     )
     operator.execute(None)
-    assert mock_hook.called
+    mock_hook_instance.submit_run.assert_called_once()
+
+    json = mock_hook_instance.submit_run.call_args[0][0]
+    assert json.get("spark_python_task") is not None
 
 
 def test_tbv_success(mocker):
     mock_hook = mocker.patch("plugins.databricks.databricks_operator.DatabricksHook")
+    mock_hook_instance = mock_hook.return_value
+    mock_hook_instance.submit_run.return_value = 1
+
     operator = MozDatabricksSubmitRunOperator(
         task_id="test_databricks",
         job_name="test_databricks",
@@ -40,4 +49,7 @@ def test_tbv_success(mocker):
         instance_count=1,
     )
     operator.execute(None)
-    assert mock_hook.called
+    mock_hook_instance.submit_run.assert_called_once()
+
+    json = mock_hook_instance.submit_run.call_args[0][0]
+    assert json.get("spark_jar_task") is not None

--- a/tests/test_moz_databricks_operator.py
+++ b/tests/test_moz_databricks_operator.py
@@ -67,7 +67,7 @@ def test_default_python_version(mock_hook):
 
     json = mock_hook.submit_run.call_args[0][0]
     assert (
-        json["new_cluster"]["spark_env_vars"]["PYSPARK_VERSION"]
+        json["new_cluster"]["spark_env_vars"]["PYSPARK_PYTHON"]
         == "/databricks/python3/bin/python3"
     )
 
@@ -82,4 +82,4 @@ def test_default_python_version(mock_hook):
     operator.execute(None)
 
     json = mock_hook.submit_run.call_args[0][0]
-    assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_VERSION") is None
+    assert json["new_cluster"]["spark_env_vars"].get("PYSPARK_PYTHON") is None


### PR DESCRIPTION
This adds support for `MOZETL_GIT_PATH` and `MOZETL_GIT_BRANCH`, which is used in the `churn_v2` job. These arguments are documented within the `mozetl-submit.sh` script:

https://github.com/mozilla/python_mozetl/blob/6991b5c9be0c0a916f5e2d5abc6c35e8f19f57ca/bin/mozetl-submit.sh#L12-L13

This PR is based on #432, and adds cases on the modified test suite. 