### PR TITLE
Migrate the TAAR collaborative recommender job 

### DIFF
--- a/dags/longitudinal.py
+++ b/dags/longitudinal.py
@@ -38,18 +38,6 @@ longitudinal = MozDatabricksSubmitRunOperator(
 
 register_status(longitudinal, "Longitudinal", "A 6-month longitudinal view of client history.")
 
-addon_recommender = EMRSparkOperator(
-    task_id="addon_recommender",
-    job_name="Train the Addon Recommender",
-    execution_timeout=timedelta(hours=10),
-    instance_count=20,
-    owner="mlopatka@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "mlopatka@mozilla.com", "vng@mozilla.com"],
-    env={"date": DS_WEEKLY,
-         "privateBucket": "{{ task.__class__.private_output_bucket }}",
-         "publicBucket": "{{ task.__class__.public_output_bucket }}"},
-    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addon_recommender.sh",
-    dag=dag)
 
 game_hw_survey = EMRSparkOperator(
     task_id="game_hw_survey",
@@ -80,6 +68,5 @@ taar_lite_guidranking = EMRSparkOperator(
     output_visibility="private",
     dag=dag)
 
-addon_recommender.set_upstream(longitudinal)
 game_hw_survey.set_upstream(longitudinal)
 taar_lite_guidranking.set_upstream(longitudinal)

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -362,6 +362,20 @@ taar_similarity = MozDatabricksSubmitRunOperator(
     output_visibility="private",
     dag=dag)
 
+taar_collaborative_recommender = EMRSparkOperator(
+    task_id="addon_recommender",
+    job_name="Train the Collaborative Addon Recommender",
+    execution_timeout=timedelta(hours=10),
+    instance_count=20,
+    owner="mlopatka@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "mlopatka@mozilla.com", "vng@mozilla.com"],
+    env={"date": "{{ ds_nodash }}",
+         "privateBucket": "{{ task.__class__.private_output_bucket }}",
+         "publicBucket": "{{ task.__class__.public_output_bucket }}"},
+    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/addon_recommender.sh",
+    dag=dag)
+
+
 main_summary_schema.set_upstream(main_summary)
 
 engagement_ratio.set_upstream(main_summary)
@@ -392,3 +406,4 @@ desktop_dau.set_upstream(client_count_daily_view)
 main_summary_glue.set_upstream(main_summary)
 
 taar_locale_job.set_upstream(clients_daily_v6)
+taar_collaborative_recommender.set_upstream(clients_daily_v6)


### PR DESCRIPTION
This migrates the TAAR collaborative model generation from the longitudinal DAG to main_summary.

This changes depends on https://github.com/mozilla/telemetry-batch-view/pull/518