### PR TITLE
[hotfix] Set default python version to 2

### DIFF
--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -39,7 +39,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
                  output_visibility=None,
                  ebs_volume_count=None,
                  ebs_volume_size=None,
-                 python_version=3,
+                 python_version=2,
                  *args, **kwargs):
         """
         Generate parameters for running a job through the Databricks run-submit


### PR DESCRIPTION
The tab_spinner job in mozetl is breaking all of the jobs in python 3 due to an import error. This will prevent the landfill job and the taar jobs from failing over the weekend.

```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<command--1> in <module>()
     13 
     14 with open(filename, "rb") as f:
---> 15   exec(f.read())
     16 

<string> in <module>()

/databricks/python/lib/python3.5/site-packages/mozetl/cli.py in <module>()
     11 from mozetl.search.aggregates import search_aggregates_click, search_clients_daily_click
     12 from mozetl.sync import bookmark_validation
---> 13 from mozetl.tab_spinner import tab_spinner
     14 from mozetl.taar import (
     15     taar_locale,

/databricks/python/lib/python3.5/site-packages/mozetl/tab_spinner/tab_spinner.py in <module>()
      1 import click
      2 from pyspark.sql import SparkSession
----> 3 from generate_counts import run_spinner_etl
      4 
      5 

ImportError: No module named 'generate_counts'
```