### PR TITLE
Revert "[hotfix] Set default python version to 2"

### DIFF
--- a/plugins/moz_databricks.py
+++ b/plugins/moz_databricks.py
@@ -39,7 +39,7 @@ class MozDatabricksSubmitRunOperator(DatabricksSubmitRunOperator):
                  output_visibility=None,
                  ebs_volume_count=None,
                  ebs_volume_size=None,
-                 python_version=2,
+                 python_version=3,
                  *args, **kwargs):
         """
         Generate parameters for running a job through the Databricks run-submit


### PR DESCRIPTION
Reverts mozilla/telemetry-airflow#441. The py3 import errors are fixed with mozilla/python_mozetl#319, which adds a `test_cli_import` that should prevent this from happening again. 