### PR TITLE
Add load_to_bigquery and migrate tasks from cloud composer.

### DIFF
--- a/dags/churn.py
+++ b/dags/churn.py
@@ -1,8 +1,10 @@
 from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
+from utils.gcp import load_to_bigquery
 from utils.mozetl import mozetl_envvar
 from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
+from airflow.operators.subdag_operator import SubDagOperator
 
 default_args = {
     'owner': 'amiyaguchi@mozilla.com',
@@ -30,6 +32,21 @@ churn = EMRSparkOperator(
     output_visibility="public",
     dag=dag)
 
+churn_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="churn_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="churn",
+        dataset_version="v3",
+        date_submission_col="week_start",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="churn_bigquery_load",
+    dag=dag)
+
 churn_v2 = MozDatabricksSubmitRunOperator(
     task_id="churn_v2",
     job_name="churn 7-day v2",
@@ -47,6 +64,21 @@ churn_v2 = MozDatabricksSubmitRunOperator(
     output_visibility="public",
     dag=dag)
 
+churn_v2_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="churn_v2_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="churn",
+        dataset_version="v2",
+        date_submission_col="week_start",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="churn_v2_bigquery_load",
+    dag=dag)
+
 churn_to_csv = EMRSparkOperator(
     task_id="churn_to_csv",
     job_name="Convert Churn v2 to csv",
@@ -56,4 +88,7 @@ churn_to_csv = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     dag=dag)
 
+churn_bigquery_load.set_upstream(churn)
+
 churn_to_csv.set_upstream(churn_v2)
+churn_v2_bigquery_load.set_upstream(churn_v2)

--- a/dags/crash_summary.py
+++ b/dags/crash_summary.py
@@ -1,6 +1,8 @@
 from airflow import DAG
+from airflow.operators.subdag_operator import SubDagOperator
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
+from utils.gcp import load_to_bigquery
 from utils.tbv import tbv_envvar
 
 default_args = {
@@ -27,3 +29,21 @@ crash_summary_view = EMRSparkOperator(
         "outputBucket": "{{ task.__class__.private_output_bucket }}"}),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
     dag=dag)
+
+crash_summary_view_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="crash_summary_view_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        ds_type="ds",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="crash_summary",
+        dataset_version="v1",
+        date_submission_col="submission_date",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="crash_summary_view_bigquery_load",
+    dag=dag)
+
+crash_summary_view >> crash_summary_view_bigquery_load

--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -1,0 +1,85 @@
+import datetime
+
+from airflow import models
+from airflow.contrib.operators.bigquery_operator import BigQueryOperator
+
+default_args = {
+    'start_date': datetime.datetime(2019, 3, 1),
+    'email': ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'depends_on_past': True,
+    # If a task fails, retry it once after waiting at least 5 minutes
+    'retries': 1,
+    'retry_delay': datetime.timedelta(minutes=10),
+}
+
+dag_name = 'fxa_events'
+
+with models.DAG(
+        dag_name,
+        # Continue to run DAG once per day
+        schedule_interval='0 10 * * *',
+        default_args=default_args) as dag:
+
+    fxa_auth_events = BigQueryOperator(
+        task_id='fxa_auth_events',
+        bql='sql/fxa_auth_events_v1.sql',
+        destination_dataset_table='telemetry.fxa_auth_events_v1${{ds_nodash}}',
+        write_disposition='WRITE_TRUNCATE',
+        use_legacy_sql=False,
+        bigquery_conn_id="google_cloud_derived_datasets",
+    )
+
+    fxa_auth_bounce_events = BigQueryOperator(
+        task_id='fxa_auth_bounce_events',
+        bql='sql/fxa_auth_bounce_events_v1.sql',
+        destination_dataset_table='telemetry.fxa_auth_bounce_events_v1${{ds_nodash}}', ## noqa
+        write_disposition='WRITE_TRUNCATE',
+        use_legacy_sql=False,
+        bigquery_conn_id="google_cloud_derived_datasets",
+    )
+
+    fxa_content_events = BigQueryOperator(
+        task_id='fxa_content_events',
+        bql='sql/fxa_content_events_v1.sql',
+        destination_dataset_table='telemetry.fxa_content_events_v1${{ds_nodash}}', ## noqa
+        write_disposition='WRITE_TRUNCATE',
+        use_legacy_sql=False,
+        bigquery_conn_id="google_cloud_derived_datasets",
+    )
+
+    fxa_users_daily = BigQueryOperator(
+        task_id='fxa_users_daily',
+        bql='sql/fxa_users_daily_v1.sql',
+        destination_dataset_table='telemetry.fxa_users_daily_v1${{ds_nodash}}',
+        write_disposition='WRITE_TRUNCATE',
+        use_legacy_sql=False,
+        bigquery_conn_id="google_cloud_derived_datasets",
+    )
+
+    fxa_users_daily << fxa_auth_events
+    fxa_users_daily << fxa_auth_bounce_events
+    fxa_users_daily << fxa_content_events
+
+    fxa_users_last_seen = BigQueryOperator(
+        task_id='fxa_users_last_seen',
+        bql='sql/fxa_users_last_seen_v1.sql',
+        destination_dataset_table='telemetry.fxa_users_last_seen_v1${{ds_nodash}}', ## noqa
+        write_disposition='WRITE_TRUNCATE',
+        use_legacy_sql=False,
+        bigquery_conn_id="google_cloud_derived_datasets",
+    )
+
+    fxa_users_daily >> fxa_users_last_seen
+
+    firefox_accounts_exact_mau28_raw = BigQueryOperator(
+        task_id='firefox_accounts_exact_mau28_raw',
+        bql='sql/firefox_accounts_exact_mau28_raw_v1.sql',
+        destination_dataset_table='telemetry.firefox_accounts_exact_mau28_raw_v1${{ds_nodash}}', ## noqa
+        write_disposition='WRITE_TRUNCATE',
+        use_legacy_sql=False,
+        bigquery_conn_id="google_cloud_derived_datasets",
+    )
+
+    fxa_users_last_seen >> firefox_accounts_exact_mau28_raw

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -2,10 +2,13 @@ from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
 from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
+from airflow.operators.subdag_operator import SubDagOperator
+from airflow.contrib.operators.bigquery_operator import BigQueryOperator
 from operators.email_schema_change_operator import EmailSchemaChangeOperator
 from utils.mozetl import mozetl_envvar
 from utils.tbv import tbv_envvar
 from utils.status import register_status
+from utils.gcp import load_to_bigquery
 
 
 default_args = {
@@ -83,6 +86,20 @@ main_summary_schema = EmailSchemaChangeOperator(
     key_prefix='schema/main_summary/submission_date_s3=',
     dag=dag)
 
+main_summary_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="main_summary_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="main_summary",
+        dataset_version="v4",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="main_summary_bigquery_load",
+    dag=dag)
+
 engagement_ratio = EMRSparkOperator(
     task_id="engagement_ratio",
     job_name="Update Engagement Ratio",
@@ -112,6 +129,20 @@ addons = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
     dag=dag)
 
+addons_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="addons_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="addons",
+        dataset_version="v2",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="addons_bigquery_load",
+    dag=dag)
+
 main_events = EMRSparkOperator(
     task_id="main_events",
     job_name="Main Events View",
@@ -124,6 +155,20 @@ main_events = EMRSparkOperator(
         "to": "{{ ds_nodash }}",
         "bucket": "{{ task.__class__.private_output_bucket }}"}),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
+    dag=dag)
+
+main_events_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="main_events_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="events",
+        dataset_version="v1",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="main_events_bigquery_load",
     dag=dag)
 
 addon_aggregates = EMRSparkOperator(
@@ -141,6 +186,21 @@ addon_aggregates = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     dag=dag)
 
+addon_aggregates_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="addon_aggregates_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="addons/agg",
+        dataset_version="v2",
+        gke_cluster_name="bq-load-gke-1",
+        p2b_table_alias="addons_aggregates_v2",
+        ),
+    task_id="addon_aggregates_bigquery_load",
+    dag=dag)
+
 main_summary_experiments = EMRSparkOperator(
     task_id="main_summary_experiments",
     job_name="Experiments Main Summary View",
@@ -153,6 +213,23 @@ main_summary_experiments = EMRSparkOperator(
         "to": "{{ ds_nodash }}",
         "bucket": "{{ task.__class__.private_output_bucket }}"}),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
+    dag=dag)
+
+main_summary_experiments_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="main_summary_experiments_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="experiments",
+        dataset_version="v1",
+        objects_prefix='experiments/v1',
+        spark_gs_dataset_location='gs://moz-fx-data-derived-datasets-parquet-tmp/experiments/v1/*/submission_date_s3={{ds_nodash}}',
+        gke_cluster_name="bq-load-gke-1",
+        reprocess=True,
+        ),
+    task_id="main_summary_experiments_bigquery_load",
     dag=dag)
 
 experiments_aggregates_import = EMRSparkOperator(
@@ -185,6 +262,22 @@ search_dashboard = EMRSparkOperator(
     output_visibility="private",
     dag=dag)
 
+search_dashboard_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="search_dashboard_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="harter/searchdb",
+        dataset_version="v4",
+        bigquery_dataset="search",
+        gke_cluster_name="bq-load-gke-1",
+        p2b_table_alias="search_aggregates_v4",
+        ),
+    task_id="search_dashboard_bigquery_load",
+    dag=dag)
+
 search_clients_daily = EMRSparkOperator(
     task_id="search_clients_daily",
     job_name="Search Clients Daily",
@@ -201,6 +294,22 @@ search_clients_daily = EMRSparkOperator(
     }),
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     output_visibility="private",
+    dag=dag)
+
+search_clients_daily_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="search_clients_daily_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="search_clients_daily",
+        dataset_version="v4",
+        bigquery_dataset="search",
+        gke_cluster_name="bq-load-gke-1",
+        reprocess=True,
+        ),
+    task_id="search_clients_daily_bigquery_load",
     dag=dag)
 
 clients_daily = EMRSparkOperator(
@@ -237,6 +346,41 @@ clients_daily_v6 = EMRSparkOperator(
 
 register_status(clients_daily_v6, "Clients Daily", "A view of main pings with one row per client per day.")
 
+clients_daily_v6_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="clients_daily_v6_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="clients_daily",
+        dataset_version="v6",
+        gke_cluster_name="bq-load-gke-1",
+        reprocess=True,
+        ),
+    task_id="clients_daily_v6_bigquery_load",
+    dag=dag)
+
+clients_last_seen = BigQueryOperator(
+    task_id='clients_last_seen',
+    bql='sql/clients_last_seen_v1.sql',
+    destination_dataset_table='telemetry.clients_last_seen_v1${{ds_nodash}}',
+    write_disposition='WRITE_TRUNCATE',
+    use_legacy_sql=False,
+    bigquery_conn_id="google_cloud_derived_datasets",
+    dag=dag,
+)
+
+exact_mau_by_dimensions = BigQueryOperator(
+    task_id='exact_mau_by_dimensions',
+    bql='sql/firefox_desktop_exact_mau28_by_dimensions_v1.sql',
+    destination_dataset_table='telemetry.firefox_desktop_exact_mau28_by_dimensions_v1${{ds_nodash}}',
+    write_disposition='WRITE_TRUNCATE',
+    use_legacy_sql=False,
+    bigquery_conn_id="google_cloud_derived_datasets",
+    dag=dag,
+)
+
 retention = EMRSparkOperator(
     task_id="retention",
     job_name="1-Day Firefox Retention",
@@ -254,6 +398,22 @@ retention = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/retention.sh",
     dag=dag)
 
+retention_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="retention_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="retention",
+        dataset_version="v1",
+        gke_cluster_name="bq-load-gke-1",
+        date_submission_col="start_date",
+        ),
+    task_id="retention_bigquery_load",
+    dag=dag)
+
+
 client_count_daily_view = EMRSparkOperator(
     task_id="client_count_daily_view",
     job_name="Client Count Daily View",
@@ -263,6 +423,22 @@ client_count_daily_view = EMRSparkOperator(
     instance_count=10,
     env={"date": "{{ ds_nodash }}", "bucket": "{{ task.__class__.private_output_bucket }}"},
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/client_count_daily_view.sh",
+    dag=dag)
+
+client_count_daily_view_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="client_count_daily_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="client_count_daily",
+        dataset_version="v2",
+        gke_cluster_name="bq-load-gke-1",
+        date_submission_col="submission_date",
+        reprocess=True,
+        ),
+    task_id="client_count_daily_bigquery_load",
     dag=dag)
 
 main_summary_glue = EMRSparkOperator(
@@ -377,19 +553,26 @@ taar_collaborative_recommender = EMRSparkOperator(
 
 
 main_summary_schema.set_upstream(main_summary)
+main_summary_bigquery_load.set_upstream(main_summary)
 
 engagement_ratio.set_upstream(main_summary)
 
 addons.set_upstream(main_summary)
+addons_bigquery_load.set_upstream(addons)
 addon_aggregates.set_upstream(addons)
+addon_aggregates_bigquery_load.set_upstream(addon_aggregates)
 
 main_events.set_upstream(main_summary)
+main_events_bigquery_load.set_upstream(main_events)
 
 main_summary_experiments.set_upstream(main_summary)
+main_summary_experiments_bigquery_load.set_upstream(main_summary_experiments)
 
 experiments_aggregates_import.set_upstream(main_summary_experiments)
 search_dashboard.set_upstream(main_summary)
+search_dashboard_bigquery_load.set_upstream(search_dashboard)
 search_clients_daily.set_upstream(main_summary)
+search_clients_daily_bigquery_load.set_upstream(search_clients_daily)
 
 taar_dynamo.set_upstream(main_summary)
 taar_similarity.set_upstream(clients_daily_v6)
@@ -397,11 +580,16 @@ taar_similarity.set_upstream(clients_daily_v6)
 clients_daily.set_upstream(main_summary)
 clients_daily_v6.set_upstream(main_summary)
 desktop_active_dau.set_upstream(clients_daily_v6)
+clients_daily_v6_bigquery_load.set_upstream(clients_daily_v6)
+clients_last_seen.set_upstream(clients_daily_v6)
+exact_mau_by_dimensions.set_upstream(clients_last_seen)
 
 retention.set_upstream(main_summary)
+retention_bigquery_load.set_upstream(retention)
 
 client_count_daily_view.set_upstream(main_summary)
 desktop_dau.set_upstream(client_count_daily_view)
+client_count_daily_view_bigquery_load.set_upstream(client_count_daily_view)
 
 main_summary_glue.set_upstream(main_summary)
 

--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -1,6 +1,8 @@
 from airflow import DAG
+from airflow.operators.subdag_operator import SubDagOperator
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
+from utils.gcp import load_to_bigquery
 from utils.status import register_status
 
 default_args = {
@@ -34,3 +36,20 @@ register_status(
     crash_report_parquet.job_name,
     "Convert processed crash reports into parquet for analysis",
 )
+
+crash_report_parquet_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="crash_report_parquet_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="socorro_crash",
+        dataset_version="v2",
+        date_submission_col="crash_date",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="crash_report_parquet_bigquery_load",
+    dag=dag)
+
+crash_report_parquet >> crash_report_parquet_bigquery_load

--- a/dags/sql/clients_last_seen_v1.sql
+++ b/dags/sql/clients_last_seen_v1.sql
@@ -1,0 +1,46 @@
+WITH _current AS (
+  SELECT
+    submission_date_s3 AS last_seen_date,
+    * EXCEPT (submission_date_s3),
+    0 AS days_since_seen,
+    -- For measuring Active MAU, where this is the days since this
+    -- client_id was an Active User as defined by
+    -- https://docs.telemetry.mozilla.org/cookbooks/active_dau.html
+    IF(scalar_parent_browser_engagement_total_uri_count_sum >= 5,
+      0,
+      NULL) AS days_since_visited_5_uri
+  FROM
+    telemetry.clients_daily_v6
+  WHERE
+    submission_date_s3 = DATE '{{ds}}'
+), _previous AS (
+  SELECT
+    * EXCEPT (submission_date,
+      generated_time) REPLACE(
+      -- omit values outside 28 day window
+      IF(days_since_visited_5_uri < 27,
+        days_since_visited_5_uri,
+        NULL) AS days_since_visited_5_uri)
+  FROM
+    telemetry.clients_last_seen_v1
+  WHERE
+    submission_date = DATE_SUB(DATE '{{ds}}', INTERVAL 1 DAY)
+    AND days_since_seen < 27
+)
+SELECT
+  DATE '{{ds}}' AS submission_date,
+  CURRENT_DATETIME() AS generated_time,
+  IF(_current.client_id IS NOT NULL,
+    _current,
+    _previous).* EXCEPT (days_since_seen,
+    days_since_visited_5_uri),
+  COALESCE(_current.days_since_seen,
+    _previous.days_since_seen + 1) AS days_since_seen,
+  COALESCE(_current.days_since_visited_5_uri,
+    _previous.days_since_visited_5_uri + 1) AS days_since_visited_5_uri
+FROM
+  _current
+FULL JOIN
+  _previous
+USING
+  (client_id)

--- a/dags/sql/firefox_accounts_exact_mau28_raw_v1.sql
+++ b/dags/sql/firefox_accounts_exact_mau28_raw_v1.sql
@@ -1,0 +1,64 @@
+WITH
+  -- We have a one-time backfill of FxA data extracted from Amplitude that
+  -- runs through EOD 2019-03-27.
+  backfill AS (
+    SELECT
+      *
+    FROM
+      static.fxa_amplitude_export_users_last_seen
+    WHERE
+      submission_date < DATE '2019-03-28'
+  ),
+  -- "Live" FxA data gets to BigQuery via a Stackdriver pipeline that had its
+  -- first stable day on 2019-03-01, so first valid day for MAU is 2019-03-28.
+  live AS (
+    SELECT
+      *
+    FROM
+      telemetry.fxa_users_last_seen_v1
+    WHERE
+      submission_date >= DATE '2019-03-28'
+  ),
+  unioned AS (
+    SELECT * FROM backfill
+    UNION ALL
+    SELECT * FROM live
+  ),
+  inactive_days AS (
+    SELECT
+      *,
+      DATE_DIFF(submission_date, date_last_seen, DAY) AS _inactive_days,
+      DATE_DIFF(submission_date, date_last_seen_in_tier1_country, DAY) AS _inactive_days_tier1
+    FROM
+      unioned
+  )
+
+SELECT
+  submission_date,
+  CURRENT_DATETIME() AS generated_time,
+  COUNTIF(_inactive_days < 28) AS mau,
+  COUNTIF(_inactive_days < 7) AS wau,
+  COUNTIF(_inactive_days < 1) AS dau,
+  -- We are generally using an "exclusive dimensions" methodology where only
+  -- the last country observed for a user is considered for determining whether
+  -- they contribute to tier 1 MAU, but we also include an "inclusive" tier 1
+  -- mau calculation that we have previously been using for KPI calculations on
+  -- FxA data; we assign a single country per user per day and include a user
+  -- in this calculation if they were assigned a tier 1 country in any of the
+  -- 28 days of the MAU window.
+  COUNTIF(_inactive_days_tier1 < 28) AS mau_tier1_inclusive,
+  -- We hash user_ids into 20 buckets to aid in computing
+  -- confidence intervals for mau/wau/dau sums; the particular hash
+  -- function and number of buckets is subject to change in the future.
+  MOD(ABS(FARM_FINGERPRINT(user_id)), 20) AS id_bucket,
+  country
+FROM
+  inactive_days
+WHERE
+  -- First data is on 2017-10-01, so we start 28 days later for first complete MAU value.
+  submission_date >= DATE '2017-10-28'
+  AND submission_date = DATE '{{ds}}'
+GROUP BY
+  submission_date,
+  id_bucket,
+  country

--- a/dags/sql/firefox_desktop_exact_mau28_by_dimensions_v1.sql
+++ b/dags/sql/firefox_desktop_exact_mau28_by_dimensions_v1.sql
@@ -1,0 +1,37 @@
+SELECT
+  submission_date,
+  COUNTIF(days_since_seen < 28) AS mau,
+  COUNTIF(days_since_seen < 7) AS wau,
+  COUNTIF(days_since_seen < 1) AS dau,
+  -- Active MAU counts all Active Users on any day in the last 28 days not just
+  -- the most recent day making COUNTIF(_days_since_seen < 28 AND visited_5_uri)
+  -- incorrect. Instead we track days_since_visited_5_uri and use that.
+  -- https://docs.telemetry.mozilla.org/cookbooks/active_dau.html
+  COUNTIF(days_since_visited_5_uri < 28) AS visited_5_uri_mau,
+  COUNTIF(days_since_visited_5_uri < 7) AS visited_5_uri_wau,
+  COUNTIF(days_since_visited_5_uri < 1) AS visited_5_uri_dau,
+  -- We hash client_ids into 20 buckets to aid in computing
+  -- confidence intervals for mau/wau/dau sums; the particular hash
+  -- function and number of buckets is subject to change in the future.
+  MOD(ABS(FARM_FINGERPRINT(client_id)), 20) AS id_bucket,
+  -- requested fields from bug 1525689
+  attribution.source,
+  attribution.medium,
+  attribution.campaign,
+  attribution.content,
+  country,
+  distribution_id
+FROM
+  telemetry.clients_last_seen_v1
+WHERE
+  client_id IS NOT NULL
+  AND submission_date = DATE '{{ds}}'
+GROUP BY
+  submission_date,
+  id_bucket,
+  source,
+  medium,
+  campaign,
+  content,
+  country,
+  distribution_id

--- a/dags/sql/fxa_auth_bounce_events_v1.sql
+++ b/dags/sql/fxa_auth_bounce_events_v1.sql
@@ -1,0 +1,14 @@
+SELECT
+  * REPLACE ( (
+    SELECT
+      AS STRUCT jsonPayload.* REPLACE( (
+        SELECT
+          AS STRUCT jsonPayload.fields.* EXCEPT (device_id,
+            user_id),
+          TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id) AS fields )) AS jsonPayload )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_bounces_{{ds_nodash}}`
+WHERE
+  jsonPayload.type = 'amplitudeEvent'
+  AND jsonPayload.fields.event_type IS NOT NULL
+  AND jsonPayload.fields.user_id IS NOT NULL

--- a/dags/sql/fxa_auth_events_v1.sql
+++ b/dags/sql/fxa_auth_events_v1.sql
@@ -1,0 +1,14 @@
+SELECT
+  * REPLACE ( (
+    SELECT
+      AS STRUCT jsonPayload.* REPLACE( (
+        SELECT
+          AS STRUCT jsonPayload.fields.* EXCEPT (device_id,
+            user_id),
+          TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id) AS fields )) AS jsonPayload )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_{{ds_nodash}}`
+WHERE
+  jsonPayload.type = 'amplitudeEvent'
+  AND jsonPayload.fields.event_type IS NOT NULL
+  AND jsonPayload.fields.user_id IS NOT NULL

--- a/dags/sql/fxa_content_events_v1.sql
+++ b/dags/sql/fxa_content_events_v1.sql
@@ -1,0 +1,14 @@
+SELECT
+  * REPLACE ( (
+    SELECT
+      AS STRUCT jsonPayload.* REPLACE( (
+        SELECT
+          AS STRUCT jsonPayload.fields.* EXCEPT (device_id,
+            user_id),
+          TO_HEX(SHA256(jsonPayload.fields.user_id)) AS user_id) AS fields )) AS jsonPayload )
+FROM
+  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_content_{{ds_nodash}}`
+WHERE
+  jsonPayload.type = 'amplitudeEvent'
+  AND jsonPayload.fields.event_type IS NOT NULL
+  AND jsonPayload.fields.user_id IS NOT NULL

--- a/dags/sql/fxa_users_daily_v1.sql
+++ b/dags/sql/fxa_users_daily_v1.sql
@@ -1,0 +1,77 @@
+CREATE TEMP FUNCTION udf_mode_last(x ANY TYPE) AS ((
+  SELECT
+    val
+  FROM (
+    SELECT
+      val,
+      COUNT(val) AS n,
+      MAX(offset) AS max_offset
+    FROM
+      UNNEST(x) AS val
+    WITH OFFSET AS offset
+    GROUP BY
+      val
+    ORDER BY
+      n DESC,
+      max_offset DESC
+  )
+  LIMIT 1
+));
+
+-- This UDF is only applicable in the context of this query;
+-- telemetry data accepts countries as two-digit codes, but FxA
+-- data includes long-form country names. The logic here is specific
+-- to the FxA data.
+CREATE TEMP FUNCTION udf_contains_tier1_country(x ANY TYPE) AS (
+  EXISTS(
+    SELECT
+      country
+    FROM
+      UNNEST(x) AS country
+    WHERE country IN (
+      'United States',
+      'France',
+      'Germany',
+      'United Kingdom',
+      'Canada'))
+);
+
+WITH
+  windowed AS (
+  SELECT
+    DATE '{{ds}}' AS submission_date,
+    CURRENT_DATETIME() AS generated_time,
+    user_id,
+    ROW_NUMBER() OVER w1_unframed AS _n,
+    udf_mode_last(ARRAY_AGG(country) OVER w1) AS country,
+    udf_contains_tier1_country(ARRAY_AGG(country) OVER w1) AS seen_in_tier1_country
+  FROM
+    telemetry.fxa_all_events_v1
+  WHERE
+    user_id IS NOT NULL
+    AND event_type NOT IN (
+      'fxa_email - bounced', 'fxa_email - click', 'fxa_email - sent',
+      'fxa_reg - password_blocked','fxa_reg - password_common', 'fxa_reg - password_enrolled',
+      'fxa_reg - password_missing','fxa_sms - sent', 'mktg - email_click',
+      'mktg - email_open','mktg - email_sent','sync - repair_success',
+      'sync - repair_triggered')
+    AND EXTRACT(DATE FROM submission_timestamp) = DATE '{{ds}}'
+  WINDOW
+    w1 AS (
+      PARTITION BY
+      user_id
+    ORDER BY
+      submission_timestamp DESC
+    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING),
+    -- We must provide a modified window for ROW_NUMBER which cannot accept a frame clause.
+    w1_unframed AS (
+    PARTITION BY
+      user_id
+    ORDER BY
+      submission_timestamp DESC) )
+SELECT
+  * EXCEPT (_n)
+FROM
+  windowed
+WHERE
+  _n = 1

--- a/dags/sql/fxa_users_last_seen_v1.sql
+++ b/dags/sql/fxa_users_last_seen_v1.sql
@@ -1,0 +1,50 @@
+WITH
+  current_sample AS (
+  SELECT
+    -- Record the last day on which we received any FxA event at all from this user.
+    DATE '{{ds}}' AS date_last_seen,
+    -- Record the last day on which the user was in a "Tier 1" country;
+    -- this allows a variant of country-segmented MAU where we can still count
+    -- a user that appeared in one of the target countries in the previous
+    -- 28 days even if the most recent "country" value is not in this set.
+    IF(seen_in_tier1_country,
+      DATE '{{ds}}',
+      NULL) AS date_last_seen_in_tier1_country,
+    * EXCEPT (submission_date,
+      generated_time,
+      seen_in_tier1_country)
+  FROM
+    telemetry.fxa_users_daily_v1
+  WHERE
+    submission_date = DATE '{{ds}}' ),
+  previous AS (
+  SELECT
+    * EXCEPT (submission_date,
+      generated_time)
+      -- We use REPLACE to null out any last_seen observations older than 28 days;
+      -- this ensures data never bleeds in from outside the target 28 day window.
+      REPLACE (IF(date_last_seen_in_tier1_country > DATE_SUB(DATE '{{ds}}', INTERVAL 28 DAY),
+          date_last_seen_in_tier1_country,
+          NULL) AS date_last_seen_in_tier1_country)
+  FROM
+    telemetry.fxa_users_last_seen_v1
+  WHERE
+    submission_date = DATE_SUB(DATE '{{ds}}', INTERVAL 1 DAY)
+    AND date_last_seen > DATE_SUB(DATE '{{ds}}', INTERVAL 28 DAY) )
+SELECT
+  DATE '{{ds}}' AS submission_date,
+  CURRENT_DATETIME() AS generated_time,
+  COALESCE(current_sample.date_last_seen,
+    previous.date_last_seen) AS date_last_seen,
+  COALESCE(current_sample.date_last_seen_in_tier1_country,
+    previous.date_last_seen_in_tier1_country) AS date_last_seen_in_tier1_country,
+  IF(current_sample.user_id IS NOT NULL,
+    current_sample,
+    previous).* EXCEPT (date_last_seen,
+    date_last_seen_in_tier1_country)
+FROM
+  current_sample
+FULL JOIN
+  previous
+USING
+  (user_id)

--- a/dags/sync_view.py
+++ b/dags/sync_view.py
@@ -1,7 +1,9 @@
 from airflow import DAG
+from airflow.operators.subdag_operator import SubDagOperator
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
 from utils.mozetl import mozetl_envvar
+from utils.gcp import load_to_bigquery
 from utils.tbv import tbv_envvar
 
 
@@ -30,6 +32,20 @@ sync_view = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
     dag=dag)
 
+sync_view_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="sync_view_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="sync_summary",
+        dataset_version="v2",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="sync_view_bigquery_load",
+    dag=dag)
+
 sync_events_view = EMRSparkOperator(
     task_id="sync_events_view",
     job_name="Sync Events View",
@@ -43,6 +59,20 @@ sync_events_view = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
     dag=dag)
 
+sync_events_view_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="sync_events_view_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="sync_events",
+        dataset_version="v1",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="sync_events_view_bigquery_load",
+    dag=dag)
+
 sync_flat_view = EMRSparkOperator(
     task_id="sync_flat_view",
     job_name="Flattened Sync Pings View",
@@ -53,6 +83,20 @@ sync_flat_view = EMRSparkOperator(
         "to": "{{ ds_nodash }}",
         "bucket": "{{ task.__class__.private_output_bucket }}"}),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
+    dag=dag)
+
+sync_flat_view_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="sync_flat_view_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="sync_flat_summary",
+        dataset_version="v1",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="sync_flat_view_bigquery_load",
     dag=dag)
 
 sync_bookmark_validation = EMRSparkOperator(
@@ -70,3 +114,9 @@ sync_bookmark_validation = EMRSparkOperator(
 
 
 sync_bookmark_validation.set_upstream(sync_view)
+
+sync_view_bigquery_load.set_upstream(sync_view)
+
+sync_events_view_bigquery_load.set_upstream(sync_events_view)
+
+sync_flat_view_bigquery_load.set_upstream(sync_flat_view)

--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -1,0 +1,253 @@
+from airflow import models
+from airflow.utils import trigger_rule
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.subdag_operator import SubDagOperator
+
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.operators.dataproc_operator import DataprocClusterCreateOperator, DataprocClusterDeleteOperator, DataProcSparkOperator # noqa
+from operators.gcp_container_operator import GKEPodOperator
+from airflow.contrib.operators.s3_to_gcs_transfer_operator import S3ToGoogleCloudStorageTransferOperator # noqa
+
+
+def load_to_bigquery(parent_dag_name=None,
+                     default_args=None,
+                     dataset_s3_bucket=None,
+                     aws_conn_id=None,
+                     dataset=None,
+                     dataset_version=None,
+                     gke_cluster_name=None,
+                     date_submission_col='submission_date_s3',
+                     ds_type='ds_nodash',
+                     dag_name='load_to_bigquery',
+                     gke_location='us-central1-a',
+                     gke_namespace='default',
+                     docker_image='docker.io/mozilla/parquet2bigquery:20190415', # noqa
+                     reprocess=False,
+                     p2b_concurrency='10',
+                     p2b_table_alias=None,
+                     objects_prefix=None,
+                     spark_gs_dataset_location=None,
+                     bigquery_dataset='telemetry',
+                     dataset_gcs_bucket='moz-fx-data-derived-datasets-parquet',
+                     gcp_conn_id='google_cloud_derived_datasets'):
+
+    """ Load Parquet data into BigQuery. Used with SubDagOperator.
+
+    We use S3ToGoogleCloudStorageTransferOperator to create a GCS Transfer
+    Service job to transfer the AWS S3 parquet data into a GCS Bucket.
+    Once that is completed we launch a Kubernates pod on a existing GKE
+    cluster using the GKEPodOperator.
+
+    :param str parent_dag_name:            parent dag name
+    :param dict default_args:              dag configuration
+    :param str dataset_s3_bucket:          source S3 Bucket
+    :param str dataset_gcs_bucket:         destination GCS Bucket
+    :param str aws_conn_id:                airflow connection id for S3 access
+    :param str gcp_conn_id:                airflow connection id for GCP access
+    :param str dataset:                    dataset name
+    :param str dataset_version:            dataset version
+    :param str date_submission_col:        dataset date submission column
+    :param str ds_type:                    dataset format (ds or ds_nodash)
+    :param str gke_location:               GKE cluster zone
+    :param str gke_namespace:              GKE cluster namespace
+    :param str docker_image:               docker image to use for GKE pod operations # noqa
+    :param str bigquery_dataset:           bigquery load destination dataset
+    :param str p2b_concurrency:            number of processes for parquet2bigquery load
+    :param str p2b_table_alias:            override p2b table name with alias
+    :param bool reprocess:                 enable dataset reprocessing defaults to False
+    :param str objects_prefix:             custom objects_prefix to override defaults
+    :param str spark_gs_dataset_location:  custom spark dataset load location to override defaults
+
+    :return airflow.models.DAG
+    """
+
+    connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
+
+    _dag_name = '{}.{}'.format(parent_dag_name, dag_name)
+
+    if objects_prefix:
+        _objects_prefix = objects_prefix
+    else:
+        _objects_prefix = '{}/{}/{}={{{{{}}}}}'.format(dataset,
+                                                       dataset_version,
+                                                       date_submission_col,
+                                                       ds_type)
+    gcs_buckets = {
+        'transfer': dataset_gcs_bucket,
+        'load': dataset_gcs_bucket,
+    }
+
+    gcstj_object_conditions = {
+        'includePrefixes':  _objects_prefix
+    }
+
+    gcstj_transfer_options = {
+        'deleteObjectsUniqueInSink': True
+    }
+
+    gke_args = [
+        '-R',
+        '-d', bigquery_dataset,
+        '-c', p2b_concurrency,
+        '-b', gcs_buckets['load'],
+        ]
+
+    if p2b_table_alias:
+        gke_args += ['-a', p2b_table_alias]
+
+    if reprocess:
+        reprocess_objects_prefix = _objects_prefix.replace('_nodash', '')
+        gcs_buckets['transfer'] += '-tmp'
+        gke_args += ['-p', reprocess_objects_prefix]
+
+    else:
+        gke_args += ['-p', _objects_prefix]
+
+    with models.DAG(_dag_name, default_args=default_args) as dag:
+        s3_to_gcs = S3ToGoogleCloudStorageTransferOperator(
+            task_id='s3_to_gcs',
+            s3_bucket=dataset_s3_bucket,
+            gcs_bucket=gcs_buckets['transfer'],
+            description=_objects_prefix,
+            aws_conn_id=aws_conn_id,
+            gcp_conn_id=gcp_conn_id,
+            project_id=connection.project_id,
+            object_conditions=gcstj_object_conditions,
+            transfer_options=gcstj_transfer_options
+            )
+
+        reprocess = SubDagOperator(
+            subdag=reprocess_parquet(
+                _dag_name,
+                default_args,
+                reprocess,
+                gcp_conn_id,
+                gcs_buckets,
+                _objects_prefix,
+                date_submission_col,
+                dataset,
+                dataset_version,
+                gs_dataset_location=spark_gs_dataset_location),
+            task_id='reprocess_parquet')
+
+        bulk_load = GKEPodOperator(
+            task_id='bigquery_load',
+            gcp_conn_id=gcp_conn_id,
+            project_id=connection.project_id,
+            location=gke_location,
+            cluster_name=gke_cluster_name,
+            name=_dag_name.replace('_', '-'),
+            namespace=gke_namespace,
+            image=docker_image,
+            arguments=gke_args,
+            )
+
+        s3_to_gcs >> reprocess >> bulk_load
+
+        return dag
+
+
+def reprocess_parquet(parent_dag_name,
+                      default_args,
+                      reprocess,
+                      gcp_conn_id,
+                      gcs_buckets,
+                      objects_prefix,
+                      date_submission_col,
+                      dataset,
+                      dataset_version,
+                      gs_dataset_location=None,
+                      dataproc_zone='us-central1-a',
+                      dag_name='reprocess_parquet',
+                      num_preemptible_workers=10):
+
+    """ Reprocess Parquet datasets to conform with BigQuery Parquet loader.
+
+    This function should be invoked as part of `load_to_bigquery`.
+
+    https://github.com/mozilla-services/spark-parquet-to-bigquery/blob/master/src/main/scala/com/mozilla/dataops/spark/TransformParquet.scala ## noqa
+
+    :param str parent_dag_name:            parent dag name
+    :param dict default_args:              dag configuration
+    :param str gcp_conn_id:                airflow connection id for GCP access
+    :param dict gcp_buckets:               source and dest gcp buckets for reprocess
+    :param str dataset:                    dataset name
+    :param str dataset_version:            dataset version
+    :param str object_prefix               objects location
+    :param str date_submission_col:        dataset date submission column
+    :param str dataproc_zone:              GCP zone to launch dataproc clusters
+    :param str dag_name:                   name of dag
+    :param int num_preemptible_workers:    number of dataproc cluster workers to provision
+    :param bool reprocess:                 enable dataset reprocessing. defaults to False
+    :param str gs_dataset_location:        override source location, defaults to None
+
+    :return airflow.models.DAG
+    """
+
+    JAR = [
+        'gs://moz-fx-data-derived-datasets-parquet-tmp/jars/spark-parquet-to-bigquery-assembly-1.0.jar' # noqa
+    ]
+
+    if gs_dataset_location:
+        _gs_dataset_location = gs_dataset_location
+    else:
+        _gs_dataset_location = 'gs://{}/{}'.format(gcs_buckets['transfer'],
+                                                   objects_prefix)
+
+    cluster_name = '{}-{}'.format(dataset.replace('_', '-'),
+                                  dataset_version) + '-{{ ds_nodash }}'
+
+    connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
+
+    spark_args = [
+        '--files', _gs_dataset_location,
+        '--submission-date-col', date_submission_col,
+        '--gcp-project-id', connection.project_id,
+        '--gcs-bucket', 'gs://{}'.format(gcs_buckets['load']),
+    ]
+
+    _dag_name = '%s.%s' % (parent_dag_name, dag_name)
+
+    with models.DAG(
+            _dag_name,
+            default_args=default_args) as dag:
+
+        if reprocess:
+            create_dataproc_cluster = DataprocClusterCreateOperator(
+                task_id='create_dataproc_cluster',
+                cluster_name=cluster_name,
+                gcp_conn_id=gcp_conn_id,
+                project_id=connection.project_id,
+                num_workers=2,
+                image_version='1.3',
+                storage_bucket=gcs_buckets['transfer'],
+                zone=dataproc_zone,
+                master_machine_type='n1-standard-8',
+                worker_machine_type='n1-standard-8',
+                num_preemptible_workers=num_preemptible_workers,
+                metadata={
+                    'gcs-connector-version': '1.9.6',
+                    'bigquery-connector-version': '0.13.6'
+                    })
+
+            run_dataproc_spark = DataProcSparkOperator(
+                task_id='run_dataproc_spark',
+                cluster_name=cluster_name,
+                dataproc_spark_jars=JAR,
+                main_class='com.mozilla.dataops.spark.TransformParquet',
+                arguments=spark_args,
+                gcp_conn_id=gcp_conn_id)
+
+            delete_dataproc_cluster = DataprocClusterDeleteOperator(
+                task_id='delete_dataproc_cluster',
+                cluster_name=cluster_name,
+                gcp_conn_id=gcp_conn_id,
+                project_id=connection.project_id,
+                trigger_rule=trigger_rule.TriggerRule.ALL_DONE)
+
+            create_dataproc_cluster >> run_dataproc_spark >> delete_dataproc_cluster # noqa
+
+        else:
+            DummyOperator(task_id='no_reprocess')
+
+        return dag


### PR DESCRIPTION
Now that https://github.com/mozilla/telemetry-airflow/pull/467 https://github.com/mozilla/telemetry-airflow/pull/469 we can revert https://github.com/mozilla/telemetry-airflow/pull/468.

I've merged down the dag task commits and broke out the actual subdag into it's own commit to make it easier.

