### PR TITLE
Add load_to_bigquery for first_shutdown_summary DAG

### DIFF
--- a/dags/first_shutdown_summary.py
+++ b/dags/first_shutdown_summary.py
@@ -1,6 +1,8 @@
 from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
+from airflow.operators.subdag_operator import SubDagOperator
+from utils.gcp import load_to_bigquery
 from utils.tbv import tbv_envvar
 
 default_args = {
@@ -33,3 +35,19 @@ first_shutdown_summary = EMRSparkOperator(
     }),
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
     dag=dag)
+
+first_shutdown_summary_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="first_shutdown_summary_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        dataset="first_shutdown_summary",
+        dataset_version="v4",
+        gke_cluster_name="bq-load-gke-1",
+        ),
+    task_id="first_shutdown_summary_bigquery_load",
+    dag=dag)
+
+first_shutdown_summary >> first_shutdown_summary_bigquery_load


### PR DESCRIPTION
I missed this in my PR (https://github.com/mozilla/telemetry-airflow/pull/470). r?