### PR TITLE
Make clients_last_seen dependent on clients_daily_v6_bq_load

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -581,7 +581,7 @@ clients_daily.set_upstream(main_summary)
 clients_daily_v6.set_upstream(main_summary)
 desktop_active_dau.set_upstream(clients_daily_v6)
 clients_daily_v6_bigquery_load.set_upstream(clients_daily_v6)
-clients_last_seen.set_upstream(clients_daily_v6)
+clients_last_seen.set_upstream(clients_daily_v6_bigquery_load)
 exact_mau_by_dimensions.set_upstream(clients_last_seen)
 
 retention.set_upstream(main_summary)


### PR DESCRIPTION
In the current configuration, I think the clients_daily query
is going to end up missing new records for the day because it
runs immediately after the EMR job for clients_daily, not waiting
for the data to load to BQ.