### PR TITLE
Allow field addition in fxa load jobs

### DIFF
--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -29,6 +29,7 @@ with models.DAG(
         destination_dataset_table='telemetry.fxa_auth_events_v1${{ds_nodash}}',
         write_disposition='WRITE_TRUNCATE',
         use_legacy_sql=False,
+        schema_update_options=['ALLOW_FIELD_ADDITION'],
         bigquery_conn_id="google_cloud_derived_datasets",
     )
 
@@ -38,6 +39,7 @@ with models.DAG(
         destination_dataset_table='telemetry.fxa_auth_bounce_events_v1${{ds_nodash}}', ## noqa
         write_disposition='WRITE_TRUNCATE',
         use_legacy_sql=False,
+        schema_update_options=['ALLOW_FIELD_ADDITION'],
         bigquery_conn_id="google_cloud_derived_datasets",
     )
 
@@ -47,6 +49,7 @@ with models.DAG(
         destination_dataset_table='telemetry.fxa_content_events_v1${{ds_nodash}}', ## noqa
         write_disposition='WRITE_TRUNCATE',
         use_legacy_sql=False,
+        schema_update_options=['ALLOW_FIELD_ADDITION'],
         bigquery_conn_id="google_cloud_derived_datasets",
     )
 


### PR DESCRIPTION
There was a [failure this morning](https://workflow.telemetry.mozilla.org/log?execution_date=2019-04-25T10%3A00%3A00%2B00%3A00&task_id=fxa_auth_events&dag_id=fxa_events):

> Invalid schema update. Cannot add fields (field: jsonPayload.fields.flowid)

The source table in the fxa project had a field added. Allowing field addition
as part of the job should make us robust to future schema changes on the fxa
side.