### PR TITLE
Fix ds_next to next_ds

### DIFF
--- a/dags/bgbb.py
+++ b/dags/bgbb.py
@@ -37,7 +37,7 @@ bgbb_fit = MozDatabricksSubmitRunOperator(
     env=mozetl_envvar(
         "bgbb_fit",
         {
-            "submission-date": "{{ ds_next }}",
+            "submission-date": "{{ next_ds }}",
             "model-win": "120",
             "start-params": "[0.387, 0.912, 0.102, 1.504]",
             "sample-ids": "[42]",


### PR DESCRIPTION
This fixes a typo I made in #437 that caused various failures last night. 

```
Airflow alert: <TaskInstance: bgbb_fit.bgbb_fit 2019-04-01T08:00:00+00:00 [up_for_retry]>
Airflow alert: <TaskInstance: main_summary.bgbb_pred 2019-05-16T01:00:00+00:00 [failed]>
```

Since the `bgbb_fit` job failed, there were no parameters for the `bgbb_pred` job. I could turn off the fit DAG, but the pred task is coupled to main_summary. Sorry about the extra noise. 