### PR TITLE
Use Databricks w autoscaling for experiments dataset

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -200,11 +200,15 @@ addon_aggregates_bigquery_load = SubDagOperator(
     task_id="addon_aggregates_bigquery_load",
     dag=dag)
 
-main_summary_experiments = EMRSparkOperator(
+main_summary_experiments = MozDatabricksSubmitRunOperator(
     task_id="main_summary_experiments",
     job_name="Experiments Main Summary View",
     execution_timeout=timedelta(hours=10),
-    instance_count=10,
+    instance_count=5,
+    max_instance_count=40,
+    enable_autoscale=True,
+    instance_type="i3.2xlarge",
+    spot_bid_price_percent=50,
     owner="ssuh@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "ssuh@mozilla.com", "robhudson@mozilla.com"],
     env=tbv_envvar("com.mozilla.telemetry.views.ExperimentSummaryView", {


### PR DESCRIPTION
Moves the experiments job to databricks, which, with spot instances, autoscaling, and faster machines for the same price, seems like it'd be a net win while also fixing issues with highly variable volume in experiments.

Dev seems pretty broken right now so I wasn't able to test this entirely :/ Experiments are already currently broken anyway, though, so I feel like even though it's a Friday and I'm generally not for this, it might be worth it to merge this in today if you get a chance to review this before EOD