### PR TITLE
Add version string to bgbb paths

### DIFF
--- a/dags/bgbb.py
+++ b/dags/bgbb.py
@@ -44,7 +44,7 @@ bgbb_fit = MozDatabricksSubmitRunOperator(
             "sample-fraction": "1.0",
             "penalizer-coef": "0.01",
             "bucket": "{{ task.__class__.private_output_bucket }}",
-            "prefix": "bgbb/params",
+            "prefix": "bgbb/params/v1",
         },
         dev_options={"model-win": "30"},
         other={

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -582,9 +582,9 @@ bgbb_pred = MozDatabricksSubmitRunOperator(
             "model-win": "120",
             "sample-ids": "[]",
             "param-bucket": "{{ task.__class__.private_output_bucket }}",
-            "param-prefix": "bgbb/params",
+            "param-prefix": "bgbb/params/v1",
             "pred-bucket": "{{ task.__class__.private_output_bucket }}",
-            "pred-prefix": "bgbb/active_profiles",
+            "pred-prefix": "bgbb/active_profiles/v1",
         },
         dev_options={
             "model-win": "30",


### PR DESCRIPTION
This adds the v1 the path prefixes for discoverability.

```
$ aws s3 ls s3://telemetry-test-bucket/bgbb/ --recursive
...
2019-06-03 13:43:20     729214 bgbb/active_profiles/v1/submission_date_s3=2019-05-02/sample_id=1/part-00197-tid-6186755752760602289-685d6747-1c59-4bf7-896f-f7080ac7d077-5199.c000.snappy.parquet
2019-06-03 13:43:20     724770 bgbb/active_profiles/v1/submission_date_s3=2019-05-02/sample_id=1/part-00198-tid-6186755752760602289-685d6747-1c59-4bf7-896f-f7080ac7d077-5200.c000.snappy.parquet
2019-06-03 13:43:20     741741 bgbb/active_profiles/v1/submission_date_s3=2019-05-02/sample_id=1/part-00199-tid-6186755752760602289-685d6747-1c59-4bf7-896f-f7080ac7d077-5201.c000.snappy.parquet
2019-06-03 13:16:35          0 bgbb/params/v1/submission_date_s3=2019-05-01/_SUCCESS
2019-06-03 13:16:35        123 bgbb/params/v1/submission_date_s3=2019-05-01/_committed_5629314365652120244
2019-06-03 13:16:34          0 bgbb/params/v1/submission_date_s3=2019-05-01/_started_5629314365652120244
2019-06-03 13:16:34        991 bgbb/params/v1/submission_date_s3=2019-05-01/part-00000-tid-5629314365652120244-4d5d3057-71ff-4791-abb0-f835470c07c3-6216-c000.snappy.parquet
```

I'll either remove or move the existing data into the right paths after this PR is merged in.
