### PR TITLE
decrementing model window to 90 days

### DIFF
--- a/dags/bgbb.py
+++ b/dags/bgbb.py
@@ -38,7 +38,7 @@ bgbb_fit = MozDatabricksSubmitRunOperator(
         "bgbb_fit",
         {
             "submission-date": "{{ next_ds }}",
-            "model-win": "120",
+            "model-win": "90",
             "start-params": "[0.387, 0.912, 0.102, 1.504]",
             "sample-ids": "[42]",
             "sample-fraction": "1.0",


### PR DESCRIPTION
95% of MAU is covered by users seen in the past 90 days, so this should keep most of the signal while reducing job time and query run times.