### PR TITLE
Bug 1564937 - Add dummy prio credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       # https://docs.databricks.com/api/latest/authentication.html#generate-a-token
       - "AIRFLOW_CONN_DATABRICKS_DEFAULT=databricks://:@dbc-caf9527b-e073.cloud.databricks.com:443?token=${DB_TOKEN}"
       - "AIRFLOW_CONN_GOOGLE_CLOUD_DERIVED_DATASETS=google_cloud_platform://:@:"
+      - "AIRFLOW_CONN_GOOGLE_CLOUD_PRIO_A=google_cloud_platform://:@:"
+      - "AIRFLOW_CONN_GOOGLE_CLOUD_PRIO_B=google_cloud_platform://:@:"
 
   web:
     extends:


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1564937)

This adds dummy credentials to prevent the broken dag message when running the airflow server locally.
