### PR TITLE
Only allow one run of bq-amplitude export at a time

### DIFF
--- a/dags/bq_events_to_amplitude.py
+++ b/dags/bq_events_to_amplitude.py
@@ -12,7 +12,7 @@ default_args = {
     'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
-    'depends_on_past': False,
+    'depends_on_past': True,
     'retries': 2,
     'retry_delay': datetime.timedelta(minutes=10),
 }


### PR DESCRIPTION
Currently, the job overwrites a table to run; this
means if multiple run in parallel, they may export the
wrong data.