### PR TITLE
Bug: 1566623 The TAAR Ensemble airflow job points to an invalid filename

### DIFF
--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -51,7 +51,7 @@ taar_ensemble = MozDatabricksSubmitRunOperator(
             "date": "{{ ds_nodash }}",
         },
     ),
-    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-databricks.sh",
+    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-databricks.py",
     output_visibility="private",
 )
 


### PR DESCRIPTION
The TAAR similarity job points to an invalid databricks airflow runner.  The fileextension should be `.py`, not `.sh`