### PR TITLE
Bug 1566623 - Fix the start_date parameter in the taar_weekly DAG

### DIFF
--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -24,11 +24,14 @@ taar_weekly = DAG(
 )
 
 wait_for_clients_daily = ExternalTaskSensor(
-    task_id='clients_daily',
-    external_dag_id='main_summary',
-    external_task_id='clients_daily',
-    execution_delta=timedelta(days=-7, hours=-1),  # main_summary waits one hour, execution date is beginning of the week
-    dag=taar_weekly)
+    task_id="clients_daily",
+    external_dag_id="main_summary",
+    external_task_id="clients_daily",
+    execution_delta=timedelta(
+        days=-7, hours=-1
+    ),  # main_summary waits one hour, execution date is beginning of the week
+    dag=taar_weekly,
+)
 
 
 taar_ensemble = MozDatabricksSubmitRunOperator(
@@ -43,13 +46,12 @@ taar_ensemble = MozDatabricksSubmitRunOperator(
     max_instance_count=60,
     enable_autoscale=True,
     start_date=datetime(2019, 7, 27),
-    pypi_libs=['mozilla-taar3==0.4.5', 'mozilla-srgutil==0.1.10', 'python-decouple==3.1'],
-    env=mozetl_envvar(
-        "taar_ensemble",
-        {
-            "date": "{{ ds_nodash }}",
-        },
-    ),
+    pypi_libs=[
+        "mozilla-taar3==0.4.5",
+        "mozilla-srgutil==0.1.10",
+        "python-decouple==3.1",
+    ],
+    env=mozetl_envvar("taar_ensemble", {"date": "{{ ds_nodash }}"}),
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-databricks.py",
     output_visibility="private",
 )

--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -10,7 +10,7 @@ from utils.mozetl import mozetl_envvar
 default_args_weekly = {
     "owner": "vng@mozilla.com",
     "depends_on_past": False,
-    "start_date": datetime(2019, 7, 27),
+    "start_date": datetime(2019, 7, 14),
     "email": ["telemetry-alerts@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
@@ -45,7 +45,6 @@ taar_ensemble = MozDatabricksSubmitRunOperator(
     spot_bid_price_percent=100,
     max_instance_count=60,
     enable_autoscale=True,
-    start_date=datetime(2019, 7, 27),
     pypi_libs=[
         "mozilla-taar3==0.4.5",
         "mozilla-srgutil==0.1.10",

--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -10,14 +10,13 @@ from utils.mozetl import mozetl_envvar
 default_args_weekly = {
     "owner": "vng@mozilla.com",
     "depends_on_past": False,
-    "start_date": datetime(2019, 5, 31),
+    "start_date": datetime(2019, 7, 27),
     "email": ["telemetry-alerts@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
     "retry_delay": timedelta(minutes=30),
 }
-
 
 
 taar_weekly = DAG(
@@ -28,7 +27,7 @@ wait_for_clients_daily = ExternalTaskSensor(
     task_id='clients_daily',
     external_dag_id='main_summary',
     external_task_id='clients_daily',
-    execution_delta=timedelta(days=-7, hours=-1), # main_summary waits one hour, execution date is beginning of the week
+    execution_delta=timedelta(days=-7, hours=-1),  # main_summary waits one hour, execution date is beginning of the week
     dag=taar_weekly)
 
 
@@ -43,7 +42,7 @@ taar_ensemble = MozDatabricksSubmitRunOperator(
     spot_bid_price_percent=100,
     max_instance_count=60,
     enable_autoscale=True,
-    start_date='20190527',
+    start_date=datetime(2019, 7, 27),
     pypi_libs=['mozilla-taar3==0.4.5', 'mozilla-srgutil==0.1.10', 'python-decouple==3.1'],
     env=mozetl_envvar(
         "taar_ensemble",


### PR DESCRIPTION
The start_date parameter has a bad default causing regularly scheduled runs to fail.  The changes the string to a datetime type for the taar ensemble run operator.