### PR TITLE
Bug 1566623 - Remove start_date parameter from the taar_weekly DAG

### DIFF
--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -43,7 +43,6 @@ taar_ensemble = MozDatabricksSubmitRunOperator(
     spot_bid_price_percent=100,
     max_instance_count=60,
     enable_autoscale=True,
-    start_date='20190527',
     pypi_libs=['mozilla-taar3==0.4.5', 'mozilla-srgutil==0.1.10', 'python-decouple==3.1'],
     env=mozetl_envvar(
         "taar_ensemble",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1566623)

The start_date parameter in the taar_ensemble job is set incorrectly as a string, causing it to fail on scheduled triggers.

@crankycoder I don't think this parameter is necessary since there is already a default start_date for the DAG. 

