### PR TITLE
Bug: 1566623 - taar_ensemble job needs a start_date parameter

### DIFF
--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -51,6 +51,7 @@ taar_ensemble = MozDatabricksSubmitRunOperator(
         "python-decouple==3.1",
     ],
     env=mozetl_envvar("taar_ensemble", {"date": "{{ ds_nodash }}"}),
+    start_date=datetime(2019, 7, 14),
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-databricks.py",
     output_visibility="private",
 )


### PR DESCRIPTION
Oops.  We actually do need the start_date parameter in the taar_ensemble task.