### PR TITLE
Use py2 compatible pandas

### DIFF
--- a/jobs/fx_usage_report.sh
+++ b/jobs/fx_usage_report.sh
@@ -5,7 +5,7 @@ if [[ -z "$bucket" || -z "$date" || -z "$deploy_environment" ]]; then
 fi
 
 pip install py4j --upgrade
-pip install pandas --upgrade
+pip install pandas==0.24 --upgrade
 
 git clone https://www.github.com/mozilla/Fx_Usage_Report.git
 cd Fx_Usage_Report


### PR DESCRIPTION
Reference: https://pandas.pydata.org/pandas-docs/stable/install.html#plan-for-dropping-python-2-7