### PR TITLE
Pin numpy version

### DIFF
--- a/jobs/fx_usage_report.sh
+++ b/jobs/fx_usage_report.sh
@@ -5,6 +5,7 @@ if [[ -z "$bucket" || -z "$date" || -z "$deploy_environment" ]]; then
 fi
 
 pip install py4j --upgrade
+pip install numpy==1.16.4
 pip install pandas==0.24 --upgrade
 
 git clone https://www.github.com/mozilla/Fx_Usage_Report.git


### PR DESCRIPTION
Pandas requires numpy>=1.12, so it tries to install numpy 1.17, which is Python 3 only. numpy 1.16.* supports Python 2, and is the latest one to do so.