### PR TITLE
Manually install all pandas deps

### DIFF
--- a/jobs/fx_usage_report.sh
+++ b/jobs/fx_usage_report.sh
@@ -6,7 +6,9 @@ fi
 
 pip install py4j --upgrade
 pip install numpy==1.16.4
-pip install pandas==0.24 --upgrade
+pip install python-dateutil==2.5.0
+pip install pytz==2011k
+pip install --no-dependencies pandas==0.24
 
 git clone https://www.github.com/mozilla/Fx_Usage_Report.git
 cd Fx_Usage_Report


### PR DESCRIPTION
The previous iteration still ran into the bug. We now don't allow the pandas install to install anything but pandas.

```
Downloading 's3://telemetry-airflow/steps/airflow.sh' to '/mnt/var/lib/hadoop/steps/s-EYEFR58IMN5Q/.'
Collecting py4j
  Downloading https://files.pythonhosted.org/packages/04/de/2d314a921ef4c20b283e1de94e0780273678caac901564df06b948e4ba9b/py4j-0.10.8.1-py2.py3-none-any.whl (196kB)
Installing collected packages: py4j
  Found existing installation: py4j 0.10.7
    Uninstalling py4j-0.10.7:
      Successfully uninstalled py4j-0.10.7
Successfully installed py4j-0.10.8.1
Collecting numpy==1.16.4
  Downloading https://files.pythonhosted.org/packages/1f/c7/198496417c9c2f6226616cff7dedf2115a4f4d0276613bab842ec8ac1e23/numpy-1.16.4-cp27-cp27mu-manylinux1_x86_64.whl (17.0MB)
Installing collected packages: numpy
  Found existing installation: numpy 1.11.1
    Uninstalling numpy-1.11.1:
      Successfully uninstalled numpy-1.11.1
Successfully installed numpy-1.16.4
Collecting pandas==0.24
  Downloading https://files.pythonhosted.org/packages/78/8c/ab02f368a41b5d5a901b186cdc33832752f32c8eb3276ce1127e6f72466f/pandas-0.24.0-cp27-cp27mu-manylinux1_x86_64.whl (10.1MB)
Collecting pytz>=2011k (from pandas==0.24)
  Downloading https://files.pythonhosted.org/packages/87/76/46d697698a143e05f77bec5a526bf4e56a0be61d63425b68f4ba553b51f2/pytz-2019.2-py2.py3-none-any.whl (508kB)
Collecting numpy>=1.12.0 (from pandas==0.24)
  Downloading https://files.pythonhosted.org/packages/da/32/1b8f2bb5fb50e4db68543eb85ce37b9fa6660cd05b58bddfafafa7ed62da/numpy-1.17.0.zip (6.5MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/mnt/tmp/pip-build-rTXS7t/numpy/setup.py", line 31, in <module>
        raise RuntimeError("Python version >= 3.5 required.")
    RuntimeError: Python version >= 3.5 required.
```