### PR TITLE
Add task to load sync_bmk_total_per_day to BigQuery

### DIFF
--- a/dags/sync_view.py
+++ b/dags/sync_view.py
@@ -115,6 +115,23 @@ sync_bookmark_validation = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
     dag=dag)
 
+sync_bookmark_validation_total_per_day_bigquery_load = SubDagOperator(
+    subdag=load_to_bigquery(
+        parent_dag_name=dag.dag_id,
+        dag_name="sync_bookmark_validation_total_per_day_bigquery_load",
+        default_args=default_args,
+        dataset_s3_bucket="telemetry-parquet",
+        aws_conn_id="aws_dev_iam_s3",
+        p2b_table_alias="sync_bmk_total_per_day_v1",
+        dataset="sync/bmk_total_per_day",
+        dataset_version="v1",
+        date_submission_col="start_date",
+        gke_cluster_name="bq-load-gke-1",
+        bigquery_dataset="telemetry_derived",
+        ),
+    task_id="sync_bookmark_validation_total_per_day_bigquery_load",
+    dag=dag)
+
 
 sync_bookmark_validation.set_upstream(sync_view)
 
@@ -123,3 +140,5 @@ sync_view_bigquery_load.set_upstream(sync_view)
 sync_events_view_bigquery_load.set_upstream(sync_events_view)
 
 sync_flat_view_bigquery_load.set_upstream(sync_flat_view)
+
+sync_bookmark_validation_total_per_day_bigquery_load.set_upstream(sync_bookmark_validation)


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1578581.

Backfill performed and available in `moz-fx-data-derivied-datasets.telemetry_derived.sync_bmk_total_per_day_v1`