### PR TITLE
Bug: fully qualify destination table with project name

### DIFF
--- a/dags/direct2parquet_bigquery_load.py
+++ b/dags/direct2parquet_bigquery_load.py
@@ -150,9 +150,8 @@ with DAG(
 
     smoot_usage_nondesktop_v2 = bigquery_etl_query(
         task_id='smoot_usage_nondesktop_v2',
-        destination_table='smoot_usage_nondesktop_v2',
+        destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_nondesktop_v2',
         dataset_id='telemetry_derived',
-        project_id='moz-fx-data-shared-prod',
     )
 
     core_clients_last_seen >> smoot_usage_nondesktop_v2

--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -82,9 +82,8 @@ with models.DAG(
 
     smoot_usage_fxa_v2 = bigquery_etl_query(
         task_id='smoot_usage_fxa_v2',
-        destination_table='smoot_usage_fxa_v2',
+        destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_fxa_v2',
         dataset_id='telemetry_derived',
-        project_id='moz-fx-data-shared-prod',
     )
 
     fxa_users_last_seen >> smoot_usage_fxa_v2

--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -36,7 +36,7 @@ with models.DAG(
     )
 
     smoot_usage_new_profiles_v2 = bigquery_etl_query(
-        destination_table='smoot_usage_new_profiles_v2',
+        task_id='smoot_usage_new_profiles_v2',
+        destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_new_profiles_v2',
         dataset_id='telemetry_derived',
-        project_id='moz-fx-data-shared-prod',
     )

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -462,9 +462,8 @@ smoot_usage_desktop_raw = bigquery_etl_query(
 
 smoot_usage_desktop_v2 = bigquery_etl_query(
     task_id='smoot_usage_desktop_v2',
-    destination_table='smoot_usage_desktop_v2',
+    destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_desktop_v2',
     dataset_id='telemetry_derived',
-    project_id='moz-fx-data-shared-prod',
     owner="jklukas@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     dag=dag)


### PR DESCRIPTION
https://github.com/mozilla/telemetry-airflow/pull/602 didn't work as expected
since the airflow user doesn't have permissions to create jobs in the
shared-prod project. This should allow the job to be in derived-datasets,
but write into shared-prod.