### PR TITLE
Kombu 4.6.4 breaks CeleryExecutor.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests
 jsonschema
 Flask-OAuthlib
 pytz
+kombu==4.6.3


### PR DESCRIPTION
Pin the version of kombu to 4.6.3 for py2

See: https://issues.apache.org/jira/browse/AIRFLOW-5240