### PR TITLE
Add remaining D2P datasets for historical import

### DIFF
--- a/dags/direct2parquet_bigquery_load.py
+++ b/dags/direct2parquet_bigquery_load.py
@@ -62,6 +62,21 @@ with DAG(
             'dataset_version': 'v1',
             'bigquery_dataset': 'telemetry',
             },
+        'coverage-coverage-parquet': {
+            'dataset_version': 'v1',
+            },
+        'firefox-launcher-process-launcher-process-failure-parquet': {
+            'dataset_version': 'v1',
+            },
+        'pocket-fire-tv-events-parquet': {
+            'dataset_version': 'v1',
+            },
+        'webpagetest-webpagetest-run-parquet': {
+            'dataset_version': 'v1',
+            },
+        'telemetry-ip-privacy-parquet': {
+            'dataset_version': 'v1',
+            },
     }
 
     tasks = {}


### PR DESCRIPTION
These are the remaining datasets outlined in the [import document](https://docs.google.com/document/d/1i578JFxXmCCxxURO5UeWkUchv3uq0MSweHlreh3P6BI/edit#heading=h.l9i8jik4xe4x). They are all very small.

We're not importing these for users to use but rather as the first step in the planned migration of the data into the `_stable` tables.