### PR TITLE
Add execution_delta to wait for copy_deduplicate

### DIFF
--- a/dags/direct2parquet_bigquery_load.py
+++ b/dags/direct2parquet_bigquery_load.py
@@ -115,6 +115,7 @@ with DAG(
         task_id="wait_for_copy_deduplicate",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
+        execution_delta=timedelta(hours=1),
         dag=dag,
     )
 


### PR DESCRIPTION
Currently, these wait tasks aren't completing. I believe it's due to the 1 hour
difference between the DAG schedules.

See https://github.com/mozilla/telemetry-airflow/pull/595#discussion_r322336248