### PR TITLE
Migrate Fx usage report from emr to dataproc

### DIFF
--- a/dags/fx_usage_report.py
+++ b/dags/fx_usage_report.py
@@ -1,13 +1,18 @@
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
 from datetime import datetime, timedelta
-from operators.emr_spark_operator import EMRSparkOperator
+
+from airflow.operators.subdag_operator import SubDagOperator
+from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
 from utils.constants import DS_WEEKLY
+from utils.dataproc import moz_dataproc_scriptrunner
 
 default_args = {
     'owner': 'frank@mozilla.com',
     'depends_on_past': True,
-    'start_date': datetime(2018, 11, 25),
+    'start_date': datetime(2019, 9, 30),
     'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
@@ -17,6 +22,7 @@ default_args = {
 
 dag = DAG('fx_usage_report', default_args=default_args, schedule_interval='@weekly')
 
+
 wait_for_main_summary = ExternalTaskSensor(
     task_id='wait_for_main_summary',
     external_dag_id='main_summary',
@@ -24,17 +30,43 @@ wait_for_main_summary = ExternalTaskSensor(
     execution_delta=timedelta(days=-7, hours=-1), # main_summary waits one hour, execution date is beginning of the week
     dag=dag)
 
-usage_report = EMRSparkOperator(
+
+cluster_name = 'fx-usage-report-dataproc-cluster'
+gcp_conn_id = 'google_cloud_airflow_dataproc'
+
+# AWS credentials to read/write from output bucket
+aws_conn_id = 'aws_prod_fx_usage_report'
+aws_access_key, aws_secret_key, session = AwsHook(aws_conn_id).get_credentials()
+
+output_bucket = 'net-mozaws-prod-us-west-2-data-public'
+
+usage_report = SubDagOperator(
     task_id="fx_usage_report",
-    job_name="Fx Usage Report",
-    execution_timeout=timedelta(hours=4),
-    instance_count=10,
-    owner="frank@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "frank@mozilla.com", "shong@mozilla.com"],
-    env={"date": DS_WEEKLY,
-         "bucket": "net-mozaws-prod-us-west-2-data-public",
-         "deploy_environment": "{{ task.__class__.deploy_environment }}"},
-    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/fx_usage_report.sh",
-    dag=dag)
+    dag=dag,
+    subdag = moz_dataproc_scriptrunner(
+        parent_dag_name=dag.dag_id,
+        dag_name='fx_usage_report',
+        default_args=default_args,
+        cluster_name=cluster_name,
+        service_account='dataproc-runner-prod@airflow-dataproc.iam.gserviceaccount.com',
+        job_name="Fx_Usage_Report",
+        uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/fx_usage_report.sh",
+        env={"date": DS_WEEKLY,
+             "bucket": output_bucket,
+             "PYTHONPATH": "/usr/lib/spark/python/lib/pyspark.zip",
+             "deploy_environment": "{{ task.__class__.deploy_environment }}",
+             # These env variables are needed in addition to the s3a configs, since some code uses boto to list bucket objects
+             "AWS_ACCESS_KEY_ID": aws_access_key,
+             "AWS_SECRET_ACCESS_KEY": aws_secret_key
+        },
+        gcp_conn_id=gcp_conn_id,
+        # This should is used to set the s3a configs for read/write to s3 for non boto calls
+        aws_conn_id=aws_conn_id,
+        num_workers=9,
+        worker_machine_type='n1-standard-16',
+        image_version='1.3',
+        init_actions_uris=['gs://moz-fx-data-prod-airflow-dataproc-artifacts/bootstrap/fx_usage_init.sh'],
+    )
+)
 
 usage_report.set_upstream(wait_for_main_summary)

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -85,7 +85,7 @@ main_summary_dataproc = SubDagOperator(
             "--export-path=" + main_ping_bigquery_export_prefix,
         ],
         job_name="main_summary_view_{{ds_nodash}}",
-        artifact_bucket=None,
+        init_action_uris=[],
         gcp_conn_id="google_cloud_airflow_dataproc",
     ),
     task_id="main_summary_dataproc",

--- a/dataproc_bootstrap/fx_usage_init.sh
+++ b/dataproc_bootstrap/fx_usage_init.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -exo pipefail
+
+# Logs will be available on the dataproc nodes at /var/log/dataproc-initialization-script-X.log
+# or via the GCP Dataproc UI
+
+/opt/conda/default/bin/pip install --upgrade pip
+
+/opt/conda/default/bin/pip install arrow==0.10.0
+/opt/conda/default/bin/pip install boto3==1.9.199
+/opt/conda/default/bin/pip install click==6.7
+/opt/conda/default/bin/pip install click_datetime==0.2
+/opt/conda/default/bin/pip install --ignore-installed flake8==3.7.8
+/opt/conda/default/bin/pip install pyspark==2.2.2
+/opt/conda/default/bin/pip install pytest==4.6.4
+/opt/conda/default/bin/pip install scipy==1.0.0rc1
+
+/opt/conda/default/bin/pip install py4j --upgrade
+/opt/conda/default/bin/pip install numpy==1.16.4
+/opt/conda/default/bin/pip install python-dateutil==2.5.0
+/opt/conda/default/bin/pip install pytz==2011k
+/opt/conda/default/bin/pip install --no-dependencies pandas==0.24
+
+# This fixes the PythonAccumulatorV2 does not exist error
+export PYTHONPATH=/usr/lib/spark/python/lib/pyspark.zip

--- a/jobs/fx_usage_report.sh
+++ b/jobs/fx_usage_report.sh
@@ -16,5 +16,7 @@ cd Fx_Usage_Report
 python usage_report/usage_report.py \
     --date $date \
     --sample 10 \
+    --input-bucket 'moz-fx-data-derived-datasets-parquet' \
     --output-bucket $bucket \
-    --output-prefix "$deploy_environment/usage_report_data"
+    --output-prefix "$deploy_environment/usage_report_data" \
+    --spark-provider 'dataproc'


### PR DESCRIPTION
Notes:
This job originally read main_summary from s3://telemetry-parquet in the AWS Dev account and wrote data to s3://net-mozaws-prod-us-west-2-data-public in the AWS Prod account which is hosted by cloudfront.

This job now reads parquet data from GCS and still writes to the same location in s3.  When the spark/bigquery main summary access has been resolved, we can modify this job to read from bq.

Currently a few YAUs are slightly higher for dataproc on gcs parquet data. This is not a KPI so we will leave it at that.

TODO - 
- [x] Figure out why dataproc and emr results have slightly different results for YAU. The full parquet data (back to 2016-03-12 didn't exist in GCP yet. After adding all the data back, there are still 30 diffs in the result json (~15876 lines), which means < 15 YAU differences since they are paired with slight avg_intensity and avg_daily_usage(hours) diffs. I've noticed about 350-480 greater YAU in the dataproc runs, using GCS parquet data that we use to load into bq.
- [x] All todos in code - change start date, and maybe followup PR for CI of custom bootstrap script
- [x]  rebase with master after https://github.com/mozilla/telemetry-airflow/pull/618/files merges, and make sure to change main_summary.py where artifact_bucket=None to set init_action_urls = [] instead.
- [x] Add aws_prod_fx_usage_report connection to wtmo