### PR TITLE
Features/gcp taar amodump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 *undo-tree~
 *.un~
 venv
+
+logs
+unittests.cfg
+.config

--- a/bin/run
+++ b/bin/run
@@ -48,10 +48,6 @@ init_connections() {
         --conn_type google_cloud_platform
 
     airflow connections --add \
-        --conn_id google_cloud_derived_datasets \
-        --conn_type google_cloud_platform
-
-    airflow connections --add \
         --conn_id amplitude_s3_conn \
         --conn_type s3
 }

--- a/dags/taar_amodump.py
+++ b/dags/taar_amodump.py
@@ -108,8 +108,8 @@ taar_lite = SubDagOperator(
         default_args=default_args,
         cluster_name=taarlite_cluster_name,
         job_name="TAAR_Lite_GUID_GUID",
-        # python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_lite_guidguid.py",
-        python_driver_code="gs://temp-hwoo-removemelater/taar_lite_guidguid.py",
+        python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_lite_guidguid.py",
+        # python_driver_code="gs://temp-hwoo-removemelater/taar_lite_guidguid.py",
         num_workers=8,
         py_args=[
             "--date",

--- a/dags/taar_amodump.py
+++ b/dags/taar_amodump.py
@@ -1,83 +1,128 @@
-from airflow import DAG
 from datetime import datetime, timedelta
 
-from operators.emr_spark_operator import EMRSparkOperator
+from airflow import DAG
+from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.operators.subdag_operator import SubDagOperator
 
-from utils.mozetl import mozetl_envvar
+from operators.gcp_container_operator import GKEPodOperator  # noqa
+from utils.dataproc import moz_dataproc_pyspark_runner
+
+gke_cluster_name = "bq-load-gke-1"
+
+taarlite_cluster_name = "dataproc-taarlite-guidguid"
+
+# Defined in Airflow's UI -> Admin -> Connections
+gcp_conn_id = "google_cloud_derived_datasets"
+connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
+
+# Dataproc connection to GCP
+gcpdataproc_conn_id = "google_cloud_airflow_dataproc"
+
+
+aws_conn_id = "airflow_taar_rw_s3"
+aws_access_key, aws_secret_key, session = AwsHook(aws_conn_id).get_credentials()
 
 default_args = {
-    'owner': 'amiyaguchi@mozilla.com',
-    'depends_on_past': False,
-    'start_date': datetime(2018, 11, 26),
-    'email': ['telemetry-alerts@mozilla.com', 'amiyaguchi@mozilla.com'],
-    'email_on_failure': True,
-    'email_on_retry': True,
-    'retries': 3,
-    'retry_delay': timedelta(minutes=30),
+    "owner": "vng@mozilla.com",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 10, 7),
+    "email": ["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com"],
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 3,
+    "retry_delay": timedelta(minutes=30),
 }
 
-dag = DAG('taar_amodump', default_args=default_args, schedule_interval='@daily')
+dag = DAG("taar_amodump", default_args=default_args, schedule_interval="@daily")
 
-amodump = EMRSparkOperator(
+amodump = GKEPodOperator(
     task_id="taar_amodump",
-    job_name="Dump AMO JSON blobs with oldest creation date",
-    execution_timeout=timedelta(hours=1),
-    instance_count=1,
+    gcp_conn_id=gcp_conn_id,
+    project_id=connection.project_id,
+    location="us-central1-a",
+    cluster_name=gke_cluster_name,
+    name="taar-amodump",
+    namespace="default",
+    # This uses a circleci built docker image from github.com/mozilla/taar_gcp_etl
+    image="gcr.io/moz-fx-data-airflow-prod-88e0/taar_gcp_etl:0.1",
     owner="vng@mozilla.com",
-    email=["mlopatka@mozilla.com", "vng@mozilla.com"],
-    env=mozetl_envvar("taar_amodump",
-                      {"date": "{{ ds_nodash }}"},
-                      {'MOZETL_SUBMISSION_METHOD': 'python'}),
-    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
-    output_visibility="private",
-    dag=dag
+    email=["mlopatka@mozilla.com", "vng@mozilla.com", "hwoo@mozilla.com"],
+    arguments=["-m", "taar_etl.taar_amodump", "--date", "{{ ds_nodash }}"],
+    env_vars={
+        "AWS_ACCESS_KEY_ID": aws_access_key,
+        "AWS_SECRET_ACCESS_KEY": aws_secret_key,
+    },
+    dag=dag,
 )
 
-amowhitelist = EMRSparkOperator(
+amowhitelist = GKEPodOperator(
     task_id="taar_amowhitelist",
-    job_name="Generate an algorithmically defined set of whitelisted addons for TAAR",
-    execution_timeout=timedelta(hours=1),
-    instance_count=1,
+    gcp_conn_id=gcp_conn_id,
+    project_id=connection.project_id,
+    location="us-central1-a",
+    cluster_name=gke_cluster_name,
+    name="taar-amowhitelist",
+    namespace="default",
+    # This uses a circleci built docker image from github.com/mozilla/taar_gcp_etl
+    image="gcr.io/moz-fx-data-airflow-prod-88e0/taar_gcp_etl:0.1",
     owner="vng@mozilla.com",
-    email=["mlopatka@mozilla.com", "vng@mozilla.com"],
-    env=mozetl_envvar("taar_amowhitelist",
-                      {},
-                      {'MOZETL_SUBMISSION_METHOD': 'spark'}),
-    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
-    output_visibility="private",
-    dag=dag
+    email=["mlopatka@mozilla.com", "vng@mozilla.com", "hwoo@mozilla.com"],
+    # We are extracting addons from the AMO server's APIs which don't
+    # support date based queries, so no date parameter is required
+    # here.
+    arguments=["-m", "taar_etl.taar_amowhitelist"],
+    env_vars={
+        "AWS_ACCESS_KEY_ID": aws_access_key,
+        "AWS_SECRET_ACCESS_KEY": aws_secret_key,
+    },
+    dag=dag,
 )
 
-editorial_whitelist = EMRSparkOperator(
+editorial_whitelist = GKEPodOperator(
     task_id="taar_update_whitelist",
-    job_name="Generate a JSON blob from editorial reviewed addons for TAAR",
-    execution_timeout=timedelta(hours=1),
-    instance_count=1,
+    gcp_conn_id=gcp_conn_id,
+    project_id=connection.project_id,
+    location="us-central1-a",
+    cluster_name=gke_cluster_name,
+    name="taar-update-whitelist",
+    namespace="default",
+    # This uses a circleci built docker image from github.com/mozilla/taar_gcp_etl
+    image="gcr.io/moz-fx-data-airflow-prod-88e0/taar_gcp_etl:0.1",
     owner="vng@mozilla.com",
-    email=["mlopatka@mozilla.com", "vng@mozilla.com"],
-    env=mozetl_envvar("taar_update_whitelist",
-                      {"date": "{{ ds_nodash }}"},
-                      {'MOZETL_SUBMISSION_METHOD': 'spark'}),
-    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
-    output_visibility="private",
-    dag=dag
+    email=["mlopatka@mozilla.com", "vng@mozilla.com", "hwoo@mozilla.com"],
+    arguments=["-m", "taar_etl.taar_update_whitelist", "--date", "{{ ds_nodash }}"],
+    env_vars={
+        "AWS_ACCESS_KEY_ID": aws_access_key,
+        "AWS_SECRET_ACCESS_KEY": aws_secret_key,
+    },
+    dag=dag,
 )
 
-taar_lite = EMRSparkOperator(
+
+taar_lite = SubDagOperator(
     task_id="taar_lite",
-    job_name="Generate GUID coinstallation JSON for TAAR",
-    instance_count=5,
-    execution_timeout=timedelta(hours=4),
-    owner="mlopatka@mozilla.com",
-    email=["mlopatka@mozilla.com", "vng@mozilla.com"],
-    env=mozetl_envvar("taar_lite",
-                      {"date": "{{ ds_nodash }}"},
-                      {'MOZETL_SUBMISSION_METHOD': 'spark'}),
-    uri="https://raw.githubusercontent.com/mozilla/python_mozetl/master/bin/mozetl-submit.sh",
-    output_visibility="private",
-    dag=dag
+    subdag=moz_dataproc_pyspark_runner(
+        parent_dag_name="taar_amodump",
+        dag_name="taar_lite",
+        default_args=default_args,
+        cluster_name=taarlite_cluster_name,
+        job_name="TAAR_Lite_GUID_GUID",
+        python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_lite_guidguid.py",
+        num_workers=8,
+        py_args=[
+            "--date",
+            "{{ ds_nodash }}",
+            "--aws_access_key_id",
+            aws_access_key,
+            "--aws_secret_access_key",
+            aws_secret_key,
+        ],
+        aws_conn_id=aws_conn_id,
+        gcp_conn_id=gcpdataproc_conn_id,
+    ),
+    dag=dag,
 )
-
 # Set a dependency on amodump from amowhitelist
 amowhitelist.set_upstream(amodump)
 

--- a/dags/taar_amodump.py
+++ b/dags/taar_amodump.py
@@ -108,7 +108,8 @@ taar_lite = SubDagOperator(
         default_args=default_args,
         cluster_name=taarlite_cluster_name,
         job_name="TAAR_Lite_GUID_GUID",
-        python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_lite_guidguid.py",
+        # python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_lite_guidguid.py",
+        python_driver_code="gs://temp-hwoo-removemelater/taar_lite_guidguid.py",
         num_workers=8,
         py_args=[
             "--date",

--- a/jobs/taar_lite_guidguid.py
+++ b/jobs/taar_lite_guidguid.py
@@ -1,0 +1,350 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This ETL job computes the co-installation occurrence of white-listed
+Firefox webextensions for a sample of the longitudinal telemetry dataset.
+"""
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.types import StructType, StructField, StringType, LongType
+import click
+import contextlib
+import datetime as dt
+import json
+import logging
+import os
+import os.path
+import tempfile
+
+import boto3
+from botocore.exceptions import ClientError
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+AMO_DUMP_BUCKET = "telemetry-parquet"
+AMO_DUMP_KEY = "telemetry-ml/addon_recommender/addons_database.json"
+
+AMO_WHITELIST_KEY = "telemetry-ml/addon_recommender/whitelist_addons_database.json"
+
+OUTPUT_BUCKET = "telemetry-parquet"
+OUTPUT_PREFIX = "taar/lite/"
+OUTPUT_BASE_FILENAME = "guid_coinstallation"
+
+MAIN_SUMMARY_PATH = "s3://telemetry-parquet/main_summary/v4/"
+ONE_WEEK_AGO = (dt.datetime.now() - dt.timedelta(days=7)).strftime("%Y%m%d")
+
+
+def aws_env_credentials():
+    """
+    Load the AWS credentials from the enviroment
+    """
+    result = {
+        "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", None),
+        "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY", None),
+    }
+    logging.info("Loading AWS credentials from enviroment: {}".format(str(result)))
+    return result
+
+
+def is_valid_addon(broadcast_amo_whitelist, guid, addon):
+    """ Filter individual addons out to exclude, system addons,
+    legacy addons, disabled addons, sideloaded addons.
+    """
+    return not (
+        addon.is_system
+        or addon.app_disabled
+        or addon.type != "extension"
+        or addon.user_disabled
+        or addon.foreign_install
+        or
+        # make sure the amo_whitelist has been broadcast to worker nodes.
+        guid not in broadcast_amo_whitelist.value
+        or
+        # Make sure that the Pioneer addon is explicitly
+        # excluded
+        guid == "pioneer-opt-in@mozilla.org"
+    )
+
+
+def get_addons_per_client(broadcast_amo_whitelist, users_df):
+    """ Extracts a DataFrame that contains one row
+    for each client along with the list of active add-on GUIDs.
+    """
+
+    # Create an add-ons dataset un-nesting the add-on map from each
+    # user to a list of add-on GUIDs. Also filter undesired add-ons.
+    rdd_list = users_df.rdd.map(
+        lambda p: (
+            p["client_id"],
+            [
+                addon_data.addon_id
+                for addon_data in p["active_addons"]
+                if is_valid_addon(
+                    broadcast_amo_whitelist, addon_data.addon_id, addon_data
+                )
+            ],
+        )
+    )
+    filtered_rdd = rdd_list.filter(lambda p: len(p[1]) > 1)
+    df = filtered_rdd.toDF(["client_id", "addon_ids"])
+    return df
+
+
+def get_initial_sample(spark, thedate):
+    """ Takes an initial sample from the longitudinal dataset
+    (randomly sampled from main summary). Coarse filtering on:
+    - number of installed addons (greater than 1)
+    - corrupt and generally wierd telemetry entries
+    - isolating release channel
+    - column selection
+    """
+    # Could scale this up to grab more than what is in
+    # longitudinal and see how long it takes to run.
+    s3_url = "s3a://telemetry-parquet/clients_daily/v6/submission_date_s3={}".format(
+        thedate
+    )
+    logging.info("Loading data from : {}".format(s3_url))
+    df = (
+        spark.read.parquet(s3_url)
+        .where("active_addons IS NOT null")
+        .where("size(active_addons) > 1")
+        .where("channel = 'release'")
+        .where("normalized_channel = 'release'")
+        .where("app_name = 'Firefox'")
+        .selectExpr("client_id", "active_addons")
+    )
+    logging.info("Initial dataframe loaded!")
+    return df
+
+
+def extract_telemetry(spark, thedate):
+    """ load some training data from telemetry given a sparkContext
+    """
+    sc = spark.sparkContext
+
+    # Define the set of feature names to be used in the donor computations.
+
+    client_features_frame = get_initial_sample(spark, thedate)
+
+    amo_white_list = load_amo_external_whitelist()
+    logging.info("AMO White list loaded")
+
+    broadcast_amo_whitelist = sc.broadcast(amo_white_list)
+    logging.info("Broadcast AMO whitelist success")
+
+    addons_info_frame = get_addons_per_client(
+        broadcast_amo_whitelist, client_features_frame
+    )
+    logging.info("Filtered for valid addons only.")
+
+    taar_training = (
+        addons_info_frame.join(client_features_frame, "client_id", "inner")
+        .drop("active_addons")
+        .selectExpr("addon_ids as installed_addons")
+    )
+    logging.info("JOIN completed on TAAR training data")
+
+    return taar_training
+
+
+def key_all(a):
+    """
+    Return (for each Row) a two column set of Rows that contains each individual
+    installed addon (the key_addon) as the first column and an array of guids of
+    all *other* addons that were seen co-installed with the key_addon. Excluding
+    the key_addon from the second column to avoid inflated counts in later aggregation.
+    """
+    return [(i, [b for b in a if b is not i]) for i in a]
+
+
+def transform(longitudinal_addons):
+    # Only for logging, not used, but may be interesting for later analysis.
+    guid_set_unique = (
+        longitudinal_addons.withColumn(
+            "exploded", F.explode(longitudinal_addons.installed_addons)
+        )
+        .select("exploded")  # noqa: E501 - long lines
+        .rdd.flatMap(lambda x: x)
+        .distinct()
+        .collect()
+    )
+    logging.info(
+        "Number of unique guids co-installed in sample: " + str(len(guid_set_unique))
+    )
+
+    restructured = longitudinal_addons.rdd.flatMap(
+        lambda x: key_all(x.installed_addons)
+    ).toDF(["key_addon", "coinstalled_addons"])
+
+    # Explode the list of co-installs and count pair occurrences.
+    addon_co_installations = (
+        restructured.select(
+            "key_addon", F.explode("coinstalled_addons").alias("coinstalled_addon")
+        )  # noqa: E501 - long lines
+        .groupBy("key_addon", "coinstalled_addon")
+        .count()
+    )
+
+    # Collect the set of coinstalled_addon, count pairs for each key_addon.
+    combine_and_map_cols = F.udf(
+        lambda x, y: (x, y),
+        StructType([StructField("id", StringType()), StructField("n", LongType())]),
+    )
+
+    # Spark functions are sometimes long and unwieldy. Tough luck.
+    # Ignore E128 and E501 long line errors
+    addon_co_installations_collapsed = (
+        addon_co_installations.select(  # noqa: E128
+            "key_addon",
+            combine_and_map_cols("coinstalled_addon", "count").alias(  # noqa: E501
+                "id_n"
+            ),
+        )
+        .groupby("key_addon")
+        .agg(F.collect_list("id_n").alias("coinstallation_counts"))
+    )
+    logging.info(addon_co_installations_collapsed.printSchema())
+    logging.info("Collecting final result of co-installations.")
+
+    return addon_co_installations_collapsed
+
+
+def load_s3(result_df, date, prefix, bucket):
+    result_list = result_df.collect()
+    result_json = {}
+
+    for row in result_list:
+        key_addon = row.key_addon
+        coinstalls = row.coinstallation_counts
+        value_json = {}
+        for _id, n in coinstalls:
+            value_json[_id] = n
+        result_json[key_addon] = value_json
+
+    store_json_to_s3(
+        json.dumps(result_json, indent=2), OUTPUT_BASE_FILENAME, date, prefix, bucket
+    )
+
+
+def store_json_to_s3(json_data, base_filename, date, prefix, bucket):
+    """Saves the JSON data to a local file and then uploads it to S3.
+
+    Two copies of the file will get uploaded: one with as "<base_filename>.json"
+    and the other as "<base_filename><YYYYMMDD>.json" for backup purposes.
+
+    :param json_data: A string with the JSON content to write.
+    :param base_filename: A string with the base name of the file to use for saving
+        locally and uploading to S3.
+    :param date: A date string in the "YYYYMMDD" format.
+    :param prefix: The S3 prefix.
+    :param bucket: The S3 bucket name.
+    """
+
+    tempdir = tempfile.mkdtemp()
+
+    with selfdestructing_path(tempdir):
+        JSON_FILENAME = "{}.json".format(base_filename)
+        FULL_FILENAME = os.path.join(tempdir, JSON_FILENAME)
+        with open(FULL_FILENAME, "w+") as json_file:
+            json_file.write(json_data)
+
+        archived_file_copy = "{}{}.json".format(base_filename, date)
+
+        # Store a copy of the current JSON with datestamp.
+        write_to_s3(FULL_FILENAME, archived_file_copy, prefix, bucket)
+        write_to_s3(FULL_FILENAME, JSON_FILENAME, prefix, bucket)
+
+
+def write_to_s3(source_file_name, s3_dest_file_name, s3_prefix, bucket):
+    """Store the new json file containing current top addons per locale to S3.
+
+    :param source_file_name: The name of the local source file.
+    :param s3_dest_file_name: The name of the destination file on S3.
+    :param s3_prefix: The S3 prefix in the bucket.
+    :param bucket: The S3 bucket.
+    """
+    client = boto3.client(
+        service_name="s3", region_name="us-west-2", **aws_env_credentials()
+    )
+    transfer = boto3.s3.transfer.S3Transfer(client)
+
+    # Update the state in the analysis bucket.
+    key_path = s3_prefix + s3_dest_file_name
+    transfer.upload_file(source_file_name, bucket, key_path)
+
+
+def load_amo_external_whitelist():
+    """ Download and parse the AMO add-on whitelist.
+
+    :raises RuntimeError: the AMO whitelist file cannot be downloaded or contains
+                          no valid add-ons.
+    """
+    final_whitelist = []
+    amo_dump = {}
+    try:
+        # Load the most current AMO dump JSON resource.
+        s3 = boto3.client(service_name="s3", **aws_env_credentials())
+        s3_contents = s3.get_object(Bucket=AMO_DUMP_BUCKET, Key=AMO_WHITELIST_KEY)
+        amo_dump = json.loads(s3_contents["Body"].read().decode("utf-8"))
+    except ClientError:
+        logger.exception(
+            "Failed to download from S3",
+            extra=dict(
+                bucket=AMO_DUMP_BUCKET, key=AMO_DUMP_KEY, **aws_env_credentials()
+            ),
+        )
+
+    # If the load fails, we will have an empty whitelist, this may be problematic.
+    for key, value in list(amo_dump.items()):
+        addon_files = value.get("current_version", {}).get("files", {})
+        # If any of the addon files are web_extensions compatible, it can be recommended.
+        if any([f.get("is_webextension", False) for f in addon_files]):
+            final_whitelist.append(value["guid"])
+
+    if len(final_whitelist) == 0:
+        raise RuntimeError("Empty AMO whitelist detected")
+
+    return final_whitelist
+
+
+@contextlib.contextmanager
+def selfdestructing_path(dirname):
+    import shutil
+
+    yield dirname
+    shutil.rmtree(dirname)
+
+
+@click.command()
+@click.option("--date", required=True)
+@click.option("--aws_access_key_id", required=True)
+@click.option("--aws_secret_access_key", required=True)
+@click.option("--date", required=True)
+@click.option("--bucket", default=OUTPUT_BUCKET)
+@click.option("--prefix", default=OUTPUT_PREFIX)
+def main(date, aws_access_key_id, aws_secret_access_key, bucket, prefix):
+    thedate = date
+
+    # Clobber the AWS access credentials
+    os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id
+    os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key
+
+    logging.info("Starting taarlite-guidguid")
+    logging.info("Acquiring spark session")
+    spark = SparkSession.builder.appName("taar_lite").getOrCreate()
+
+    logging.info("Loading telemetry sample.")
+
+    longitudinal_addons = extract_telemetry(spark, thedate)
+    result_df = transform(longitudinal_addons)
+    load_s3(result_df, thedate, prefix, bucket)
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/jobs/taar_lite_guidguid.py
+++ b/jobs/taar_lite_guidguid.py
@@ -116,6 +116,7 @@ def get_initial_sample(spark, thedate):
         .where("normalized_channel = 'release'")
         .where("app_name = 'Firefox'")
         .selectExpr("client_id", "active_addons")
+        .sample(False, 0.05)
     )
     logging.info("Initial dataframe loaded!")
     return df


### PR DESCRIPTION
These are patches to port the taar_amodump DAG to use GCP.

The first few jobs do not require Spark:

  * taar_amodump
  * taar_amo_whitelist
  * taar_update_whitelist

The last job requires PySpark:

  * taar_lite 

Of note - 3 Airflow connections:

GCP connections: `google_cloud_derived_datasets_3` and `google_cloud_airflow_dataproc`.

AWS connection: `airflow_taar_rw_s3`

This PR requires a patch to https://github.com/mozilla/taar_gcp_etl/ so that the taar_lite_guidguid.py script is pushed into a GCS bucket on a tagged build.