### PR TITLE
Replace sample_id with type integer for bigquery experiments load

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -366,6 +366,7 @@ main_summary_experiments_bigquery_load = SubDagOperator(
         cluster_by=["experiment_id"],
         drop=["submission_date"],
         rename={"submission_date_s3": "submission_date"},
+        replace=["SAFE_CAST(sample_id AS INT64) AS sample_id"],
         ),
     task_id="main_summary_experiments_bigquery_load",
     dag=dag)


### PR DESCRIPTION
I believe as part of https://github.com/mozilla/telemetry-airflow/pull/559 the experiments bigquery table schema was modified which included a field type change for `sample_id` from `STRING` to `INT64` however we did not update the task to replace the field as part of the import which is causing the BigQuery data load to fail.

r?