### PR TITLE
Dataproc operator fix

### DIFF
--- a/dags/operators/moz_dataproc_operator.py
+++ b/dags/operators/moz_dataproc_operator.py
@@ -283,7 +283,10 @@ class DataprocClusterCreateOperator(DataprocOperationBaseOperator):
 
         # Fetch current nested dict and add nested keys
         cluster_config_new = cluster_data['config']
-        cluster_config_new.update({'softwareConfig' : {'optionalComponents': self.optional_components }})
+
+        software_config_new = cluster_config_new['softwareConfig']
+        software_config_new.update({'optionalComponents': self.optional_components })
+        cluster_config_new.update({'softwareConfig': software_config_new})
 
         if self.install_component_gateway:
             cluster_config_new.update({'endpointConfig' : {'enableHttpPortAccess' : True}})

--- a/dags/update_orphaning_dashboard_etl.py
+++ b/dags/update_orphaning_dashboard_etl.py
@@ -17,7 +17,7 @@ default_args = {
     "owner": "akomar@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 10, 12),
-    "email": ["telemetry-alerts@mozilla.com", "rstrong@mozilla.com", "akomar@mozilla.com"],
+    "email": ["akomar@mozilla.com"], # TODO: add "telemetry-alerts@mozilla.com", "rstrong@mozilla.com" when this is stable
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,


### PR DESCRIPTION
This fixes a bug in DataprocClusterCreateOperator resulting in `image_version` property being cleared during nested dictionary update.

I also silenced email notifications from update orphaning job until everything is stable.