### PR TITLE
Delete pod from GKE after completion

### DIFF
--- a/dags/adi_dim_backfill.py
+++ b/dags/adi_dim_backfill.py
@@ -61,6 +61,7 @@ load_bq_to_tmp_tbl = GKEPodOperator(
     name='bq-load-tmp-tbl',
     namespace='default',
     image='google/cloud-sdk:242.0.0-alpine',
+    is_delete_operator_pod=True,
     arguments=load_args,
     dag=blp_dag
 )
@@ -74,6 +75,7 @@ select_insert_into_final_table = GKEPodOperator(
     name='bq-query-insert-final-tbl',
     namespace='default',
     image='google/cloud-sdk:242.0.0-alpine',
+    is_delete_operator_pod=True,
     arguments=insert_args,
     dag=blp_dag
 )

--- a/dags/mango_log_processing.py
+++ b/dags/mango_log_processing.py
@@ -201,6 +201,7 @@ load_blpadi_to_bq = GKEPodOperator(
     namespace='default',
     image='google/cloud-sdk:242.0.0-alpine',
     arguments=bq_args,
+    is_delete_operator_pod=True,
     dag=blp_dag
 )
 

--- a/dags/prio/kubernetes.py
+++ b/dags/prio/kubernetes.py
@@ -97,6 +97,7 @@ def container_subdag(
             arguments=arguments,
             env_vars=env_vars,
             dag=dag,
+            is_delete_operator_pod=True,
             **shared_config
         )
 

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -45,6 +45,7 @@ with DAG('probe_scraper',
         namespace='default',
         image='mozilla/mozilla-schema-generator:latest',
         image_pull_policy='Always',
+        is_delete_operator_pod=True,
         env_vars={
             "MPS_SSH_KEY_BASE64": "{{ var.value.mozilla_pipeline_schemas_secret_git_sshkey_b64 }}",
             "MPS_REPO_URL": "git@github.com:mozilla-services/mozilla-pipeline-schemas.git",

--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -14,7 +14,7 @@ from utils.dataproc import moz_dataproc_pyspark_runner
 
 """
 Originally, this job read json (non-ndjson) from aws prod at:
-s3://crashstats-telemetry-crashes-prod-us-west-2/v1/crash_report 
+s3://crashstats-telemetry-crashes-prod-us-west-2/v1/crash_report
 and wrote the data to parquet format in aws dev at:
 s3://telemetry-parquet/socorro_crash/v2
 
@@ -61,7 +61,7 @@ write_aws_conn_id='aws_dev_socorro_telemetry_parquet_s3'
 aws_access_key, aws_secret_key, session = AwsHook(write_aws_conn_id).get_credentials()
 
 # We use an application-specific gcs bucket since the copy operator can't set the destination
-# bucket prefix, and unfortunately socorro data in s3 has prefix version/dataset instead 
+# bucket prefix, and unfortunately socorro data in s3 has prefix version/dataset instead
 # of having the dataset name come first
 gcs_data_bucket = 'moz-fx-data-prod-socorro-data'
 
@@ -143,6 +143,7 @@ gcs_to_s3 = GKEPodOperator(
         "AWS_ACCESS_KEY_ID": aws_access_key,
         "AWS_SECRET_ACCESS_KEY": aws_secret_key
     },
+    is_delete_operator_pod=True,
     dag=dag,
 )
 
@@ -181,6 +182,7 @@ bq_load = GKEPodOperator(
     namespace='default',
     image=docker_image,
     arguments=gke_args,
+    is_delete_operator_pod=True,
     dag=dag,
 )
 

--- a/dags/taar_amodump.py
+++ b/dags/taar_amodump.py
@@ -50,6 +50,7 @@ amodump = GKEPodOperator(
         "AWS_SECRET_ACCESS_KEY": taar_aws_secret_key,
     },
     dag=dag,
+    is_delete_operator_pod=True,
 )
 
 amowhitelist = GKEPodOperator(
@@ -73,6 +74,7 @@ amowhitelist = GKEPodOperator(
         "AWS_SECRET_ACCESS_KEY": taar_aws_secret_key,
     },
     dag=dag,
+    is_delete_operator_pod=True,
 )
 
 editorial_whitelist = GKEPodOperator(
@@ -93,6 +95,7 @@ editorial_whitelist = GKEPodOperator(
         "AWS_SECRET_ACCESS_KEY": taar_aws_secret_key,
     },
     dag=dag,
+    is_delete_operator_pod=True,
 )
 
 

--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -180,6 +180,7 @@ def load_to_bigquery(parent_dag_name=None,
             name=_dag_name.replace('_', '-'),
             namespace=gke_namespace,
             image=docker_image,
+            is_delete_operator_pod=True,
             arguments=gke_args,
             )
 
@@ -449,6 +450,7 @@ def bigquery_etl_query(
         + list(arguments)
         + [sql_file_path],
         image_pull_policy=image_pull_policy,
+        is_delete_operator_pod=True,
         **kwargs
     )
 
@@ -518,6 +520,7 @@ def bigquery_etl_copy_deduplicate(
         + (["--slices={}".format(slices)] if slices is not None else [])
         + table_qualifiers,
         image_pull_policy=image_pull_policy,
+        is_delete_operator_pod=True,
         **kwargs
     )
 
@@ -584,5 +587,6 @@ def gke_command(
             if value is not None
         },
         image_pull_policy=image_pull_policy,
+        is_delete_operator_pod=True,
         **kwargs
     )

--- a/dags/utils/leanplum.py
+++ b/dags/utils/leanplum.py
@@ -75,4 +75,5 @@ def export(
         image=docker_image,
         image_pull_policy=image_pull_policy,
         arguments=args,
+        is_delete_operator_pod=True,
         **kwargs)


### PR DESCRIPTION
When attempting to run some GKEPodOperator tasks I noticed that the tasks were timing out and were not scheduled on `bq-load-gke-1`. It looks like there is a 1K deployment limit on GKE and once I cleaned up old pod deployments the new deployments worked. I can't find documentation around the actual limit but I think going forward we should just clean them up since logs are already available in Airflow. I've manually cleaned up old pod deployments for now.

Enabling `is_delete_operator_pod` will delete the pod when when the pod reaches its final state, or the execution is interrupted.

r?