### PR TITLE
Remove smoot_usage_v1 queries

### DIFF
--- a/dags/direct2parquet_bigquery_load.py
+++ b/dags/direct2parquet_bigquery_load.py
@@ -152,15 +152,6 @@ with DAG(
     core_clients_last_seen >> firefox_nondesktop_exact_mau28_raw
     fenix_clients_last_seen >> firefox_nondesktop_exact_mau28_raw
 
-    smoot_usage_nondesktop_raw = bigquery_etl_query(
-        task_id='smoot_usage_nondesktop_raw',
-        destination_table='smoot_usage_nondesktop_raw_v1',
-        dataset_id='telemetry',
-    )
-
-    core_clients_last_seen >> smoot_usage_nondesktop_raw
-    fenix_clients_last_seen >> smoot_usage_nondesktop_raw
-
     smoot_usage_nondesktop_v2 = bigquery_etl_query(
         task_id='smoot_usage_nondesktop_v2',
         destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_nondesktop_v2',

--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -80,14 +80,6 @@ with models.DAG(
 
     fxa_users_last_seen >> firefox_accounts_exact_mau28_raw
 
-    smoot_usage_fxa_raw = bigquery_etl_query(
-        task_id='smoot_usage_fxa_raw',
-        destination_table='smoot_usage_fxa_raw_v1',
-        dataset_id='telemetry',
-    )
-
-    fxa_users_last_seen >> smoot_usage_fxa_raw
-
     smoot_usage_fxa_v2 = bigquery_etl_query(
         task_id='smoot_usage_fxa_v2',
         destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_fxa_v2',

--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -29,12 +29,6 @@ with models.DAG(
         date_partition_parameter=None,
     )
 
-    smoot_usage_all_mtr = bigquery_etl_query(
-        destination_table='smoot_usage_all_mtr_v1',
-        dataset_id='telemetry',
-        date_partition_parameter=None,
-    )
-
     smoot_usage_new_profiles_v2 = bigquery_etl_query(
         task_id='smoot_usage_new_profiles_v2',
         destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_new_profiles_v2',

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -562,14 +562,6 @@ exact_mau_by_dimensions_export = SubDagOperator(
     task_id="exact_mau_by_dimensions_export",
     dag=dag)
 
-smoot_usage_desktop_raw = bigquery_etl_query(
-    task_id='smoot_usage_desktop_raw',
-    destination_table='smoot_usage_desktop_raw_v1',
-    dataset_id='telemetry',
-    owner="jklukas@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
-    dag=dag)
-
 smoot_usage_desktop_v2 = bigquery_etl_query(
     task_id='smoot_usage_desktop_v2',
     destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_desktop_v2',
@@ -809,7 +801,6 @@ clients_last_seen.set_upstream(clients_daily_v6_bigquery_load)
 clients_last_seen_export.set_upstream(clients_last_seen)
 exact_mau_by_dimensions.set_upstream(clients_last_seen)
 exact_mau_by_dimensions_export.set_upstream(exact_mau_by_dimensions)
-smoot_usage_desktop_raw.set_upstream(clients_last_seen)
 smoot_usage_desktop_v2.set_upstream(clients_last_seen)
 
 main_summary_glue.set_upstream(main_summary)


### PR DESCRIPTION
GUD now uses the v2 tables and the v1 tables are no longer needed.