### PR TITLE
 Bug 1592737 - Remove depends_on_past condition

### DIFF
--- a/dags/prio/processor.py
+++ b/dags/prio/processor.py
@@ -48,7 +48,7 @@ from prio import dataproc, kubernetes
 
 DEFAULT_ARGS = {
     "owner": "amiyaguchi@mozilla.com",
-    "depends_on_past": True,
+    "depends_on_past": False,
     "start_date": datetime(2019, 8, 22),
     "email": [
         "amiyaguchi@mozilla.com",
@@ -92,6 +92,8 @@ BUCKET_SHARED_B = "moz-fx-prio-{}-b-shared".format(ENVIRONMENT)
 BUCKET_DATA_ADMIN = "moz-fx-data-{}-prio-data".format(ENVIRONMENT)
 BUCKET_BOOTSTRAP_ADMIN = "moz-fx-data-{}-prio-bootstrap".format(ENVIRONMENT)
 
+# https://airflow.apache.org/faq.html#how-can-my-airflow-dag-run-faster
+# max_active_runs controls the number of DagRuns at a given time.
 dag = DAG(dag_id="prio_processor", max_active_runs=1, default_args=DEFAULT_ARGS)
 
 


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1592737)

The prio_processor dag is currently blocked on 2019-10-25 because of an issue with large rows in `payload_bytes_decoded`. The dag was originally set with a `depends_on_past` condition because multiple dags would run at the same time. The job is currently stateful because it reuses fixed kubernetes clusters and storage bucket between runs for intermediate results.

If the Airflow FAQ is accurate, and the observation on the local run of 2019-10-28 and 2019-10-29 holds in production, then this should probably do the right thing and run a single date at a time. 