### PR TITLE
Bug 1593149 - Fix broken DAGs in local Airflow environment

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -39,6 +39,19 @@ print(json.dumps(extra))
 END
 }
 
+aws_default_extras() {
+python - <<END
+import json
+
+extra = {
+    "aws_access_key_id": "dummy_access_key_id",
+    "aws_secret_access_key": "dummy_secret_access_key",
+}
+
+print(json.dumps(extra))
+END
+}
+
 init_connections() {
     # set dummy credentials
     export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-dummy_access_key_id}
@@ -52,34 +65,38 @@ init_connections() {
         --conn_host https://dbc-caf9527b-e073.cloud.databricks.com \
         --conn_extra "{\"token\":\"${DB_TOKEN}\"}"
 
-    airflow connections --add \
-        --conn_id google_cloud_prio_admin \
+    gcp_conn=(
+      "google_cloud_airflow_dataproc"
+      "google_cloud_derived_datasets"
+      "google_cloud_prio_a"
+      "google_cloud_prio_admin"
+      "google_cloud_prio_b"
+    )
+    for conn_id in "${gcp_conn[@]}"; do
+        airflow connections --delete --conn_id "${conn_id}"
+        airflow connections --add \
+        --conn_id "${conn_id}" \
         --conn_type google_cloud_platform \
         --conn_extra "$(gcp_default_extras)"
+    done
 
-    airflow connections --add \
-        --conn_id google_cloud_prio_a \
-        --conn_type google_cloud_platform \
-        --conn_extra "$(gcp_default_extras)"
-
-    airflow connections --add \
-        --conn_id google_cloud_prio_b \
-        --conn_type google_cloud_platform \
-        --conn_extra "$(gcp_default_extras)"
-
-    airflow connections --add \
-        --conn_id amplitude_s3_conn \
-        --conn_type s3
-
-    airflow connections --add \
-        --conn_id google_cloud_derived_datasets \
-        --conn_type google_cloud_platform \
-        --conn_extra "$(gcp_default_extras)"
-
-    airflow connections --add \
-        --conn_id google_cloud_airflow_dataproc \
-        --conn_type google_cloud_platform \
-        --conn_extra "$(gcp_default_extras)"
+    aws_conn=(
+      "airflow_taar_rw_s3"
+      "amplitude_s3_conn"
+      "aws_dev_iam_s3"
+      "aws_dev_socorro_telemetry_parquet_s3"
+      "aws_dev_telemetry_public_analysis_2_rw"
+      "aws_prod_fx_usage_report"
+      "aws_prod_probe_scraper"
+      "aws_socorro_readonly_s3"
+    )
+    for conn_id in "${aws_conn[@]}"; do
+        airflow connections --delete --conn_id "${conn_id}"
+        airflow connections --add \
+        --conn_id "${conn_id}" \
+        --conn_type s3 \
+        --conn_extra "$(aws_default_extras)"
+    done
 }
 
 init_variables() {

--- a/bin/run
+++ b/bin/run
@@ -26,7 +26,24 @@ wait_for() {
   done
 }
 
+gcp_default_extras() {
+python - <<END
+import json
+
+extra = {
+    "extra__google_cloud_platform__project": "dummy_project_id",
+    "extra__google_cloud_platform__keyfile_dict": json.dumps({})
+}
+
+print(json.dumps(extra))
+END
+}
+
 init_connections() {
+    # set dummy credentials
+    export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-dummy_access_key_id}
+    export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-dummy_secret_access_key}
+
     airflow connections --delete --conn_id databricks_default
 
     airflow connections --add \
@@ -37,15 +54,18 @@ init_connections() {
 
     airflow connections --add \
         --conn_id google_cloud_prio_admin \
-        --conn_type google_cloud_platform
+        --conn_type google_cloud_platform \
+        --conn_extra "$(gcp_default_extras)"
 
     airflow connections --add \
         --conn_id google_cloud_prio_a \
-        --conn_type google_cloud_platform
+        --conn_type google_cloud_platform \
+        --conn_extra "$(gcp_default_extras)"
 
     airflow connections --add \
         --conn_id google_cloud_prio_b \
-        --conn_type google_cloud_platform
+        --conn_type google_cloud_platform \
+        --conn_extra "$(gcp_default_extras)"
 
     airflow connections --add \
         --conn_id amplitude_s3_conn \
@@ -53,11 +73,13 @@ init_connections() {
 
     airflow connections --add \
         --conn_id google_cloud_derived_datasets \
-        --conn_type google_cloud_platform
+        --conn_type google_cloud_platform \
+        --conn_extra "$(gcp_default_extras)"
 
     airflow connections --add \
         --conn_id google_cloud_airflow_dataproc \
-        --conn_type google_cloud_platform
+        --conn_type google_cloud_platform \
+        --conn_extra "$(gcp_default_extras)"
 }
 
 init_variables() {

--- a/bin/run
+++ b/bin/run
@@ -32,7 +32,18 @@ import json
 
 extra = {
     "extra__google_cloud_platform__project": "dummy_project_id",
-    "extra__google_cloud_platform__keyfile_dict": json.dumps({})
+    "extra__google_cloud_platform__keyfile_dict": json.dumps({
+        "type": "service_account",
+        "project_id": "dummy-project",
+        "private_key_id": "d8b87911500d92da857b92ab74a9d53631e8904e",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEogIBAAKCAQEAjj1EQOX7o14lnDRJAyFZeXGNLywPuyf/vdDt6tI2v0cTgoOH\nEAaCL5OYyXnYnLYEfQIap5sU8DcVDgiidCQv3+PKyzXPV8YPe9E2ureMZJAu48Zn\nKPzoltvLFFqAIX8yzezb3Av+tnRY495iuqTpR1x4ZKXvgVPFtOotT1dseZhNbZ2x\nmg5mNVxxsV3pVPmaRLj8CjtJI2qU3EZ2AbxTON3k4k0Q+7Gy2bG5Ef5rKbTFsp5O\nFF7MGjX7A54H7keVCc0QkEWSx/bsaRkGsnDbrZG3Kn118xJOYY/+CREURNO1FNTA\nzlJgIxN4PAOAGRXEBeXcsCZKp3MYpU75cvF5/wIDAQABAoIBAFtXkMs0ZaKFxRVI\nplJySiko+IeAfiGsEBlvYDnaAPpYxHidylBKPbQbzpQjwSzx3nQAs+lKN+oDFWxL\nszduPahDemmBBsPRFwRmWAUT9f5mcRYoxPqXXy3xu7o4W+wm6RNAtffbZBj7IlJC\n75f4ay4+fbn0rZeZmm8Rq0M2WxzB8DDiO96N3JLhPYV/uR9TeQp4pn/lUYLKRO2i\nuMBmCLl6hjaV8/0Dox0KhNICox+BXKnIUlIrDV9NanmO5dAZJPOzSHH6aJ4ovdFo\nmLdqlBw50qGm9DaYHR3pbZo17kX/42yZogrcEJMNGHjJgZna+W54gVsP6Gs4ht3G\nO+O6A4ECgYEA2oASmeAVs65VdVpBpI6Ky1PW4wFV+zMxVykbgY++6ZTg8rjRfzps\nDsmoGTaI3b/lxeiakIu96bkSr3A7r1fVuKtwSzU5jSSkONe8mWiHt4VIX+x5GiY2\nP4CZCEi3v+bVzovmXcx9Wy62h+bBWsrkYav2CrXrOSB7Byz7XduQVmECgYEApqag\nrpY7Db2HuCK3yhp08AT7itDi9ck43Zes/YB2TqXtTYsDVWVNeYcXkSh1VrQytQZW\ncPXtfmBXogGSTnjXEmpCRf+z5Bsxu57Zole5ENiBTzEcpFJpQ/5UPH8PJzWA+dB4\ncAuvgRKxnTG8LRhkrbVM8t0WJi1v1nP6DyDA7F8CgYARC/bnjGUFDK/cJPuEFB7d\n+B+GvF7x5y+NRkbAF+/kF1ppdWPa0jsF+FOmC+wnqMYLZ7dPWaeqaWb8yvvNFUQ2\nUSHErFVeHqK1UJeFPHOCLOLVoQRdtud6ktTdoZa8YQ0DPUTuwnpxN7bD6YviQnwI\n5rqeYU0FuvP+PlMqImwjYQKBgG/fbgCls1D/CcwP6mdPKW8zORWwMpwjD/yZ5LRs\n937Gnq4ugvdhwQezK5vzmAmzgFLLxV2himQLEukbuvbY4jBnisPo6v9XTiSQd7Mm\nxoLLhMr/wiWBeU7+vde6yBZfMY0CaMd24MN6JCfNinCPbo66JcTnrAXG/MvvIU/k\ngf5rAoGAfFN3JUFRcGZsQ+2qqeghcnD38iXkhBE5WL/g5CMA+v/AXvS7L67HVcTa\nV2O/KlmS53RV5MPnNZsOCyWBtohLYc+8kTAwl+DUf2ZfbzLJty6mCPrlaRaqCZ9q\nXTu2Ea7bs7gbVmhj2xcD+OPBUkITy7+XWAqwqe6C4hhwiHTDIoI=\n-----END PRIVATE KEY-----\n",
+        "client_email": "test-account@dummy-project.iam.gserviceaccount.com",
+        "client_id": "19327456837",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test-account%40dummy-project.iam.gserviceaccount.com"
+    })
 }
 
 print(json.dumps(extra))


### PR DESCRIPTION
This fixes all of the broken DAGs in the local environment.

1. This adds dummy extra values for both GCP and AWS
2. This lists out all of the necessary GCP and AWS connection strings
3. This moves the mozetl runner generation from the operator initization to the operator execution

I ran the `system_check` DAG to verify that mozetl jobs still work (which currently only runs on Databricks).

https://dbc-caf9527b-e073.cloud.databricks.com/#setting/sparkui/1031-232337-gimpy15/driver-logs

```
Out[1]: '\n# This runner has been auto-generated from mozilla/telemetry-airflow/plugins/moz_databricks.py.\n# Any changes made to the runner file may be over-written on subsequent runs.\nfrom mozetl import cli\n\ntry:\n    cli.entry_point(auto_envvar_prefix="MOZETL")\nexcept SystemExit:\n    # avoid calling sys.exit() in databricks\n    # http://click.palletsprojects.com/en/7.x/api/?highlight=auto_envvar_prefix#click.BaseCommand.main\n    pass\n'
input_prefix: main_summary/v4
output_bucket: telemetry-test-bucket
local: True
submission_date_s3: 20191029
output_prefix: mozetl_system_check
input_bucket: telemetry-parquet
Python version: sys.version_info(major=3, minor=5, micro=2, releaselevel='final', serial=0)
Spark version: 2.3.1
Done!
```