### PR TITLE
Run queries in shared-prod for destination tables in shared-prod

### DIFF
--- a/dags/direct2parquet_bigquery_load.py
+++ b/dags/direct2parquet_bigquery_load.py
@@ -121,8 +121,8 @@ with DAG(
 
     fenix_clients_daily = bigquery_etl_query(
         task_id='fenix_clients_daily',
-        destination_table='moz-fx-data-shared-prod:org_mozilla_fenix_derived.clients_daily_v1',
-        sql_file_path='sql/org_mozilla_fenix_derived/clients_daily_v1/query.sql',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='clients_daily_v1',
         dataset_id='org_mozilla_fenix_derived',
         start_date=datetime(2019, 9, 5),
     )
@@ -131,8 +131,8 @@ with DAG(
 
     fenix_clients_last_seen = bigquery_etl_query(
         task_id='fenix_clients_last_seen',
-        destination_table='moz-fx-data-shared-prod:org_mozilla_fenix_derived.clients_last_seen_v1',
-        sql_file_path='sql/org_mozilla_fenix_derived/clients_last_seen_v1/query.sql',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='clients_last_seen_v1',
         dataset_id='org_mozilla_fenix_derived',
         start_date=datetime(2019, 9, 5),
         depends_on_past=True,
@@ -154,8 +154,8 @@ with DAG(
 
     smoot_usage_nondesktop_v2 = bigquery_etl_query(
         task_id='smoot_usage_nondesktop_v2',
-        destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_nondesktop_v2',
-        sql_file_path='sql/telemetry_derived/smoot_usage_nondesktop_v2/query.sql',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='smoot_usage_nondesktop_v2',
         dataset_id='telemetry_derived',
     )
 

--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -9,7 +9,7 @@ default_args = {
     'email': ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
-    'depends_on_past': True,
+    'depends_on_past': False,
     # If a task fails, retry it once after waiting at least 5 minutes
     'retries': 1,
     'retry_delay': datetime.timedelta(minutes=10),
@@ -82,8 +82,8 @@ with models.DAG(
 
     smoot_usage_fxa_v2 = bigquery_etl_query(
         task_id='smoot_usage_fxa_v2',
-        destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_fxa_v2',
-        sql_file_path='sql/telemetry_derived/smoot_usage_fxa_v2/query.sql',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='smoot_usage_fxa_v2',
         dataset_id='telemetry_derived',
     )
 
@@ -94,8 +94,8 @@ with models.DAG(
 
     fxa_users_services_daily = bigquery_etl_query(
         task_id='fxa_users_services_daily',
-        destination_table='moz-fx-data-shared-prod:telemetry_derived.fxa_users_services_daily_v1',
-        sql_file_path='sql/telemetry_derived/fxa_users_services_daily_v1/query.sql',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='fxa_users_services_daily_v1',
         dataset_id='telemetry_derived',
     )
 
@@ -106,6 +106,7 @@ with models.DAG(
 
     fxa_users_services_first_seen = bigquery_etl_query(
         task_id='fxa_users_services_first_seen',
+        project_id='moz-fx-data-shared-prod',
         sql_file_path='sql/telemetry_derived/fxa_users_services_first_seen_v1/init.sql',
         dataset_id='telemetry_derived',
         # At least for now, we completely recreate this table every day;
@@ -124,8 +125,8 @@ with models.DAG(
 
     fxa_users_services_last_seen = bigquery_etl_query(
         task_id='fxa_users_services_last_seen',
-        destination_table='moz-fx-data-shared-prod:telemetry_derived.fxa_users_services_last_seen_v1',
-        sql_file_path='sql/telemetry_derived/fxa_users_services_last_seen_v1/query.sql',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='fxa_users_services_last_seen_v1',
         dataset_id='telemetry_derived',
         depends_on_past=True,
         start_date=datetime.datetime(2019, 10, 8),

--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -31,7 +31,7 @@ with models.DAG(
 
     smoot_usage_new_profiles_v2 = bigquery_etl_query(
         task_id='smoot_usage_new_profiles_v2',
-        destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_new_profiles_v2',
-        sql_file_path='sql/telemetry_derived/smoot_usage_new_profiles_v2/query.sql',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='smoot_usage_new_profiles_v2',
         dataset_id='telemetry_derived',
     )

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -575,8 +575,8 @@ exact_mau_by_dimensions_export = SubDagOperator(
 
 smoot_usage_desktop_v2 = bigquery_etl_query(
     task_id='smoot_usage_desktop_v2',
-    destination_table='moz-fx-data-shared-prod:telemetry_derived.smoot_usage_desktop_v2',
-    sql_file_path='sql/telemetry_derived/smoot_usage_desktop_v2/query.sql',
+    project_id='moz-fx-data-shared-prod',
+    destination_table='smoot_usage_desktop_v2',
     dataset_id='telemetry_derived',
     owner="jklukas@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],


### PR DESCRIPTION
This is now possible due to updates to permissions such that Airflow can
now run BQ jobs in shared-prod.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1582791

Thank you, @jasonthomas. This is going to avoid some significant hassles esp. for the GLAM queries that are coming up.