### PR TITLE
Modify mango log processing dags to not use EMR

### DIFF
--- a/dags/mango_log_processing.py
+++ b/dags/mango_log_processing.py
@@ -1,20 +1,20 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from operators.emr_create_job_flow_operator import EmrCreateJobFlowOperator
+
 from operators.gcp_container_operator import GKEPodOperator
 
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.contrib.operators.s3_to_gcs_transfer_operator import S3ToGoogleCloudStorageTransferOperator # noqa
-from airflow.contrib.sensors.emr_job_flow_sensor import EmrJobFlowSensor
 
+from utils.dataproc import moz_dataproc_jar_runner
 from utils.status import register_status
 
 
 DEFAULT_ARGS = {
     'owner': 'jthomas@mozilla.com',
     'depends_on_past': False,
-    'start_date': datetime(2018, 11, 26),
+    'start_date': datetime(2019, 11, 7),
     'email': ['jthomas@mozilla.com', 'hwoo@mozilla.com', 'dataops+alerts@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
@@ -38,6 +38,78 @@ BLP_STEPS = [
         }
     }
 ]
+
+blp_dag = DAG(
+    'mango_log_processing_adi',
+    default_args=DEFAULT_ARGS,
+    dagrun_timeout=timedelta(hours=6),
+    schedule_interval='0 3 * * *'
+)
+
+aws_conn_id = 'aws_data_iam'
+emr_conn_id = 'emr_data_iam_mango'
+
+blp_logs = EmrCreateJobFlowOperator(
+    task_id='blp_create_job_flow',
+    job_flow_overrides={'Steps': BLP_STEPS},
+    aws_conn_id=aws_conn_id,
+    emr_conn_id=emr_conn_id,
+    dag=blp_dag
+)
+
+gcp_conn_id = "google_cloud_derived_datasets"
+connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
+
+gcstj_object_conditions = {
+    'includePrefixes':  'blpadi/{{ ds }}'
+}
+
+gcstj_transfer_options = {
+    'deleteObjectsUniqueInSink': True
+}
+
+bq_args = [
+    'bq',
+    '--location=US',
+    'load',
+    '--source_format=CSV',
+    '--skip_leading_rows=0',
+    '--replace',
+    "--field_delimiter=\001",
+    'blpadi.adi_dimensional_by_date${{ ds_nodash }}',
+    'gs://moz-fx-data-derived-datasets-blpadi/blpadi/{{ ds }}/*',
+]
+
+blp_aws_conn_id = 'aws_data_iam_blpadi'
+
+s3_to_gcs = S3ToGoogleCloudStorageTransferOperator(
+    task_id='s3_to_gcs',
+    s3_bucket='net-mozaws-data-us-west-2-data-analysis',
+    gcs_bucket='moz-fx-data-derived-datasets-blpadi',
+    description='blpadi copy from s3 to gcs',
+    aws_conn_id=blp_aws_conn_id,
+    gcp_conn_id=gcp_conn_id,
+    project_id=connection.project_id,
+    object_conditions=gcstj_object_conditions,
+    transfer_options=gcstj_transfer_options,
+    dag=blp_dag
+)
+
+load_blpadi_to_bq = GKEPodOperator(
+    task_id='bigquery_load',
+    gcp_conn_id=gcp_conn_id,
+    project_id=connection.project_id,
+    location='us-central1-a',
+    cluster_name='bq-load-gke-1',
+    name='load-blpadi-to-bq',
+    namespace='default',
+    image='google/cloud-sdk:242.0.0-alpine',
+    arguments=bq_args,
+    dag=blp_dag
+)
+
+blp_logs >> s3_to_gcs >> load_blpadi_to_bq
+
 
 AMO_STEPS = [
     {
@@ -70,6 +142,24 @@ AMO_STEPS = [
         }
     }
 ]
+
+amo_dag = DAG(
+    'mango_log_processing_amo',
+    default_args=DEFAULT_ARGS,
+    dagrun_timeout=timedelta(hours=6),
+    schedule_interval='0 3 * * *'
+)
+
+amo_logs = EmrCreateJobFlowOperator(
+    task_id='amo_create_job_flow',
+    job_flow_overrides={'Steps': AMO_STEPS},
+    aws_conn_id=aws_conn_id,
+    emr_conn_id=emr_conn_id,
+    dag=amo_dag
+)
+
+register_status(amo_logs, 'AMO Logs', 'Mango Processed AMO Logs')
+
 
 AMO_DEV_STAGE_STEPS = [
     {
@@ -130,113 +220,6 @@ AMO_DEV_STAGE_STEPS = [
     }
 ]
 
-blp_dag = DAG(
-    'mango_log_processing_adi',
-    default_args=DEFAULT_ARGS,
-    dagrun_timeout=timedelta(hours=6),
-    schedule_interval='0 3 * * *'
-)
-
-blp_logs = EmrCreateJobFlowOperator(
-    task_id='blp_create_job_flow',
-    job_flow_overrides={'Steps': BLP_STEPS},
-    aws_conn_id='aws_data_iam',
-    emr_conn_id='emr_data_iam_mango',
-    dag=blp_dag
-)
-
-blp_job_sensor = EmrJobFlowSensor(
-    task_id='blp_check_job_flow',
-    job_flow_id="{{ task_instance.xcom_pull('blp_create_job_flow', key='return_value') }}",
-    aws_conn_id='aws_data_iam',
-    dag=blp_dag,
-    on_retry_callback=lambda context: blp_dag.clear(
-        start_date=context['execution_date'],
-        end_date=context['execution_date']),
-)
-
-gcp_conn_id = "google_cloud_derived_datasets"
-connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
-
-gcstj_object_conditions = {
-    'includePrefixes':  'blpadi/{{ ds }}'
-}
-
-gcstj_transfer_options = {
-    'deleteObjectsUniqueInSink': True
-}
-
-bq_args = [
-    'bq',
-    '--location=US',
-    'load',
-    '--source_format=CSV',
-    '--skip_leading_rows=0',
-    '--replace',
-    "--field_delimiter=\001",
-    'blpadi.adi_dimensional_by_date${{ ds_nodash }}',
-    'gs://moz-fx-data-derived-datasets-blpadi/blpadi/{{ ds }}/*',
-]
-
-s3_to_gcs = S3ToGoogleCloudStorageTransferOperator(
-    task_id='s3_to_gcs',
-    s3_bucket='net-mozaws-data-us-west-2-data-analysis',
-    gcs_bucket='moz-fx-data-derived-datasets-blpadi',
-    description='blpadi copy from s3 to gcs',
-    aws_conn_id='aws_data_iam_blpadi',
-    gcp_conn_id=gcp_conn_id,
-    project_id=connection.project_id,
-    object_conditions=gcstj_object_conditions,
-    transfer_options=gcstj_transfer_options,
-    dag=blp_dag
-)
-
-load_blpadi_to_bq = GKEPodOperator(
-    task_id='bigquery_load',
-    gcp_conn_id=gcp_conn_id,
-    project_id=connection.project_id,
-    location='us-central1-a',
-    cluster_name='bq-load-gke-1',
-    name='load-blpadi-to-bq',
-    namespace='default',
-    image='google/cloud-sdk:242.0.0-alpine',
-    arguments=bq_args,
-    dag=blp_dag
-)
-
-blp_logs.set_downstream(blp_job_sensor)
-blp_job_sensor.set_downstream(s3_to_gcs)
-s3_to_gcs.set_downstream(load_blpadi_to_bq)
-
-amo_dag = DAG(
-    'mango_log_processing_amo',
-    default_args=DEFAULT_ARGS,
-    dagrun_timeout=timedelta(hours=6),
-    schedule_interval='0 3 * * *'
-)
-
-amo_logs = EmrCreateJobFlowOperator(
-    task_id='amo_create_job_flow',
-    job_flow_overrides={'Steps': AMO_STEPS},
-    aws_conn_id='aws_data_iam',
-    emr_conn_id='emr_data_iam_mango',
-    dag=amo_dag
-)
-
-register_status(amo_logs, 'AMO Logs', 'Mango Processed AMO Logs')
-
-amo_job_sensor = EmrJobFlowSensor(
-    task_id='amo_check_job_flow',
-    job_flow_id="{{ task_instance.xcom_pull('amo_create_job_flow', key='return_value') }}",
-    aws_conn_id='aws_data_iam',
-    dag=amo_dag,
-    on_retry_callback=lambda context: amo_dag.clear(
-        start_date=context['execution_date'],
-        end_date=context['execution_date']),
-)
-
-amo_logs.set_downstream(amo_job_sensor)
-
 # For AMO Dev and Stage Environments
 amo_dev_stage_dag = DAG(
     'mango_log_processing_amo_dev_stage',
@@ -248,19 +231,7 @@ amo_dev_stage_dag = DAG(
 amo_dev_stage_logs = EmrCreateJobFlowOperator(
     task_id='amo_dev_stage_create_job_flow',
     job_flow_overrides={'Steps': AMO_DEV_STAGE_STEPS},
-    aws_conn_id='aws_data_iam',
-    emr_conn_id='emr_data_iam_mango',
+    aws_conn_id=aws_conn_id,
+    emr_conn_id=emr_conn_id,
     dag=amo_dev_stage_dag
 )
-
-amo_dev_stage_job_sensor = EmrJobFlowSensor(
-    task_id='amo_dev_stage_check_job_flow',
-    job_flow_id="{{ task_instance.xcom_pull('amo_dev_stage_create_job_flow', key='return_value') }}",
-    aws_conn_id='aws_data_iam',
-    dag=amo_dev_stage_dag,
-    on_retry_callback=lambda context: amo_dev_stage_dag.clear(
-        start_date=context['execution_date'],
-        end_date=context['execution_date']),
-)
-
-amo_dev_stage_logs.set_downstream(amo_dev_stage_job_sensor)

--- a/jobs/mango_blocklist_processlogs.sh
+++ b/jobs/mango_blocklist_processlogs.sh
@@ -1,0 +1,6 @@
+if [[ -z "$bucket" || -z "$date" || -z "$domain" ]]; then
+    echo "Missing arguments!" 1>&2
+    exit 1
+fi
+
+/usr/local/bin/processlogs --domain $domain --bucket $bucket --date $date


### PR DESCRIPTION
Update: we will not migrate this airflow MR job off of EMR because 
1. the applications that produce the log data will continue to run in AWS. 
2. the raw data xfer costs will exceed the hadoop MR job costs. We will keep this dag running on EMR and ship the aggregated data to BQ

- [x] Use script-runner subdagop
- [ ] Write 3 bash entrypoint scripts to processlogs, using domain, bucket, date params. one for blocklist, amo, amo dev which sequentially run processlogs on one or more sets of params
- [ ] Write custom bootstrap script to install all deps on dataproc clusters, including installing processlogs (https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/data/ansible/scripts/mango/bootstrap_action#L44-L45)
- [ ] Configure hadoop configs on cluster create (https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/data/ansible/scripts/mango/emr_job_flow.json#L21)
- [x] Check AWS permissions from  and 'aws_data_iam'? Do we need to add more permissions now that this will run in GCP and will not have all the EMR node iam permissions?
--> This role has EMR*, EC2*, S3*, etc in aws data account and s3 access to:
                "arn:aws:s3:::net-mozaws-prod-kintoblocklist-blocklist-kbprod1",
                "arn:aws:s3:::amo-metrics-logs-prod",
                "arn:aws:s3:::amo-metrics-logs-stage",
                "arn:aws:s3:::amo-metrics-logs-dev",
                "arn:aws:s3:::net-mozaws-prod-ops-rpmrepo-geoip"

- [ ] Do we still want to read/write from S3 or move things to GCS
- [ ] Jason to help figure out some GeoIp requirements
- [ ] Test
- [x] Add any needed connection creds to wtmo and sops secrets