### PR TITLE
Use default executor for parquet export subdags

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -2,6 +2,7 @@ from airflow import DAG
 from datetime import datetime, timedelta
 from operators.emr_spark_operator import EMRSparkOperator
 from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.executors import GetDefaultExecutor
 from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
 from airflow.operators.subdag_operator import SubDagOperator
 from operators.email_schema_change_operator import EmailSchemaChangeOperator
@@ -86,6 +87,7 @@ sql_main_summary_export = SubDagOperator(
         default_args=default_args,
         num_workers=40),
     task_id="sql_main_summary_export",
+    executor=GetDefaultExecutor(),
     dag=dag)
 
 main_summary = MozDatabricksSubmitRunOperator(
@@ -383,6 +385,7 @@ clients_daily_export = SubDagOperator(
         default_args=default_args,
         num_preemptible_workers=10),
     task_id="clients_daily_export",
+    executor=GetDefaultExecutor(),
     dag=dag)
 
 clients_daily_v6 = EMRSparkOperator(
@@ -448,6 +451,7 @@ clients_last_seen_export = SubDagOperator(
         default_args=default_args,
         num_preemptible_workers=10),
     task_id="clients_last_seen_export",
+    executor=GetDefaultExecutor(),
     dag=dag)
 
 exact_mau_by_dimensions = bigquery_etl_query(
@@ -466,6 +470,7 @@ exact_mau_by_dimensions_export = SubDagOperator(
         dag_name="exact_mau_by_dimensions_export",
         default_args=default_args),
     task_id="exact_mau_by_dimensions_export",
+    executor=GetDefaultExecutor(),
     dag=dag)
 
 smoot_usage_desktop_v2 = bigquery_etl_query(


### PR DESCRIPTION
[the default subdag executor was changed in airflow 1.10](
https://github.com/apache/airflow/blob/v1-10-stable/UPDATING.md#default-executor-for-subdagoperator-is-changed-to-sequentialexecutor) so that subdags are limited to one executor. 

The reason they did this was because it was possible for a subdag to consume all the executors such that top level dags couldn't run.

The reason we should allow these subdags to run in parallel is that the main summary parquet export subdag can save about 20 minutes by running `avro_delete` and `gcs_to_s3` in parallel, and these subdags only have a max of two tasks that would be running in parallel.