### PR TITLE
Update upstream for ssl_ratios

### DIFF
--- a/dags/ssl_ratios.py
+++ b/dags/ssl_ratios.py
@@ -19,9 +19,9 @@ default_args = {
 with DAG("ssl_ratios", default_args=default_args, schedule_interval="@daily") as dag:
     # most downstream dependency is search_clients_daily
     wait_for_main_summary = ExternalTaskSensor(
-        task_id="wait_for_main_summary",
+        task_id="wait_for_copy_deduplicate",
         external_dag_id="main_summary",
-        external_task_id="main_summary",
+        external_task_id="copy_deduplicate_main_ping",
         execution_delta=timedelta(hours=-1),
         dag=dag,
     )

--- a/dags/ssl_ratios.py
+++ b/dags/ssl_ratios.py
@@ -19,7 +19,7 @@ default_args = {
 with DAG("ssl_ratios", default_args=default_args, schedule_interval="@daily") as dag:
     # most downstream dependency is search_clients_daily
     wait_for_main_summary = ExternalTaskSensor(
-        task_id="wait_for_copy_deduplicate",
+        task_id="wait_for_copy_deduplicate_main_ping",
         external_dag_id="main_summary",
         external_task_id="copy_deduplicate_main_ping",
         execution_delta=timedelta(hours=-1),


### PR DESCRIPTION
now reads `main` (populated by copy_dedup) rather than `main_summary` as of https://github.com/mozilla/bigquery-etl/pull/502