### PR TITLE
Add Skyline dashboard stakeholder emails to KPI-relevant tasks

### DIFF
--- a/dags/direct2parquet_bigquery_load.py
+++ b/dags/direct2parquet_bigquery_load.py
@@ -95,6 +95,7 @@ with DAG(
         task_id='core_clients_daily',
         destination_table='core_clients_daily_v1',
         dataset_id='telemetry',
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
     )
 
     tasks['telemetry_core_parquet_bigquery_load'] >> core_clients_daily
@@ -104,6 +105,7 @@ with DAG(
         destination_table='core_clients_last_seen_raw_v1',
         dataset_id='telemetry',
         depends_on_past=True,
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
     )
 
     core_clients_daily >> core_clients_last_seen
@@ -125,6 +127,7 @@ with DAG(
         destination_table='clients_daily_v1',
         dataset_id='org_mozilla_fenix_derived',
         start_date=datetime(2019, 9, 5),
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
     )
 
     fenix_clients_daily << wait_for_copy_deduplicate
@@ -136,6 +139,7 @@ with DAG(
         dataset_id='org_mozilla_fenix_derived',
         start_date=datetime(2019, 9, 5),
         depends_on_past=True,
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
     )
 
     fenix_clients_daily >> fenix_clients_last_seen
@@ -147,6 +151,7 @@ with DAG(
         task_id='firefox_nondesktop_exact_mau28_raw',
         destination_table='firefox_nondesktop_exact_mau28_raw_v1',
         dataset_id='telemetry',
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
     )
 
     core_clients_last_seen >> firefox_nondesktop_exact_mau28_raw
@@ -157,6 +162,7 @@ with DAG(
         project_id='moz-fx-data-shared-prod',
         destination_table='smoot_usage_nondesktop_v2',
         dataset_id='telemetry_derived',
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
     core_clients_last_seen >> smoot_usage_nondesktop_v2

--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -6,7 +6,7 @@ from utils.gcp import bigquery_etl_query
 default_args = {
     'owner': 'jklukas@mozilla.com',
     'start_date': datetime.datetime(2019, 3, 1),
-    'email': ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
+    'email': ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
     'depends_on_past': False,

--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -27,6 +27,7 @@ with models.DAG(
         destination_table='firefox_kpi_dashboard_v1',
         dataset_id='telemetry',
         date_partition_parameter=None,
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com']
     )
 
     smoot_usage_new_profiles_v2 = bigquery_etl_query(

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -68,7 +68,7 @@ main_summary = bigquery_etl_query(
     sql_file_path="sql/telemetry_derived/main_summary_v4/",
     multipart=True,
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
     start_date=datetime(2019, 10, 25),
     dag=dag)
 
@@ -357,7 +357,7 @@ clients_daily = bigquery_etl_query(
     project_id="moz-fx-data-shared-prod",
     dataset_id="telemetry_derived",
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
     start_date=datetime(2019, 11, 5),
     dag=dag)
 
@@ -451,7 +451,7 @@ clients_last_seen = bigquery_etl_query(
     destination_table="clients_last_seen_v1",
     dataset_id="telemetry_derived",
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "jklukas@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "jklukas@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
     depends_on_past=True,
     start_date=datetime(2019, 4, 15),
     dag=dag)
@@ -481,7 +481,7 @@ exact_mau_by_dimensions = bigquery_etl_query(
     destination_table="firefox_desktop_exact_mau28_by_dimensions_v1",
     dataset_id="telemetry",
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
     dag=dag)
 
 exact_mau_by_dimensions_export = SubDagOperator(


### PR DESCRIPTION
At the request of Skyline dashboard stakeholders.

This seemed preferable to adding these folks to the `telemetry-alerts@mozilla.com` firehose.