### PR TITLE
Bugfix for clients_daily_export

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -382,7 +382,7 @@ clients_daily_export = SubDagOperator(
             "--replace",
             "STRING(sample_id) AS sample_id",
             "CAST(subsession_hours_sum AS DECIMAL(37,6)) AS subsession_hours_sum",
-            "TRANSFORM(active_addons, _ -> STRUCT(_.addon_id AS addon_id, _.blocklisted AS blocklisted, _.name AS name, _.user_disabled AS user_disabled, _.app_disabled AS app_disabled, _.version AS version, INT(_.scope) AS scope, _.type AS type, _.foreign_install AS foreign_install, _.has_binary_components AS has_binary_components, INT(_.install_day) AS install_day, INT(_.update_day) AS update_day, INT(_.signed_state) AS signed_state, _.is_system AS is_system, _.is_web_extension AS is_web_extension, _.multiprocess_compatible AS multiprocess_compatible) AS active_addons",
+            "TRANSFORM(active_addons, _ -> STRUCT(_.addon_id AS addon_id, _.blocklisted AS blocklisted, _.name AS name, _.user_disabled AS user_disabled, _.app_disabled AS app_disabled, _.version AS version, INT(_.scope) AS scope, _.type AS type, _.foreign_install AS foreign_install, _.has_binary_components AS has_binary_components, INT(_.install_day) AS install_day, INT(_.update_day) AS update_day, INT(_.signed_state) AS signed_state, _.is_system AS is_system, _.is_web_extension AS is_web_extension, _.multiprocess_compatible AS multiprocess_compatible)) AS active_addons",
             "TRANSFORM(scalar_parent_devtools_accessibility_select_accessible_for_node_sum, _ -> STRUCT(_.key AS key, INT(_.value) AS value)) AS scalar_parent_devtools_accessibility_select_accessible_for_node_sum",
             "INT(cpu_cores) AS cpu_cores",
             "INT(cpu_count) AS cpu_count",


### PR DESCRIPTION
There was a failure last night:

> org.apache.spark.sql.catalyst.parser.ParseException:
> extraneous input '<EOF>' expecting {')', ','}(line 1, pos 546)

And it points to the line starting "TRANSFORM(active_addons..."

Looks like we're just missing a closing paren. cc @relud 