### PR TITLE
Bump mobile_metrics dataset to v3 with submission_date based partitioning

### DIFF
--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -32,8 +32,7 @@ mobile_aggregate_view = MozDatabricksSubmitRunOperator(
         "mobile",
         {
             "date": "{{ ds_nodash }}",
-            "channels": "nightly",
-            "output": "s3://{{ task.__class__.private_output_bucket }}/mobile_metrics_aggregates/v2",
+            "output": "s3://{{ task.__class__.private_output_bucket }}/mobile_metrics_aggregates/v3",
             "num-partitions": 5*32
         },
         other={


### PR DESCRIPTION
This is necessary to deploy https://github.com/mozilla/python_mozaggregator/pull/201. Having this partitioning scheme will make it easier to validate the data and keep it around.

For reference, the command line arguments are as follows:
https://github.com/mozilla/python_mozaggregator/blob/35bb1c0a0d1051e0662d6169eaa5d2387995e278/mozaggregator/cli.py#L125-L143