### PR TITLE
Bug 1596242 - Migrate mobile_aggregate_view to GCP

### DIFF
--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -1,7 +1,12 @@
+import json
+import os
 from datetime import datetime, timedelta
 
 from airflow import DAG
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
+from airflow.operators.subdag_operator import SubDagOperator
+from utils.dataproc import copy_artifacts_dev, moz_dataproc_pyspark_runner
 from utils.mozetl import mozetl_envvar
 from utils.status import register_status
 
@@ -49,3 +54,80 @@ register_status(
     "Mobile Aggregates",
     "Aggregates of metrics sent through the mobile-events pings.",
 )
+
+
+subdag_args = default_args.copy()
+subdag_args["retries"] = 0
+
+task_id = "mobile_aggregate_view_dataproc"
+gcp_conn = GoogleCloudBaseHook("google_cloud_airflow_dataproc")
+keyfile = json.loads(gcp_conn.extras["extra__google_cloud_platform__keyfile_dict"])
+project_id = keyfile["project_id"]
+
+is_dev = os.environ.get("DEPLOY_ENVIRONMENT") == "dev"
+client_email = (
+    keyfile["client_email"]
+    if is_dev
+    else "dataproc-runner-prod@airflow-dataproc.iam.gserviceaccount.com"
+)
+artifact_bucket = (
+    "{}-dataproc-artifacts".format(project_id)
+    if is_dev
+    else "moz-fx-data-prod-airflow-dataproc-artifacts"
+)
+storage_bucket = (
+    "{}-dataproc-scratch".format(project_id)
+    if is_dev
+    else "moz-fx-data-prod-dataproc-scratch"
+)
+output_bucket = artifact_bucket if is_dev else "moz-fx-data-derived-datasets-parquet"
+
+
+mobile_aggregate_view_dataproc = SubDagOperator(
+    task_id=task_id,
+    dag=dag,
+    subdag=moz_dataproc_pyspark_runner(
+        parent_dag_name=dag.dag_id,
+        dag_name=task_id,
+        job_name="mobile_aggregates",
+        cluster_name="mobile-metrics-aggregates-{{ ds_nodash }}",
+        idle_delete_ttl="600",
+        num_workers=5,
+        worker_machine_type="n1-standard-8",
+        init_actions_uris=[
+            "gs://dataproc-initialization-actions/python/pip-install.sh"
+        ],
+        additional_properties={
+            "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest.jar"
+        },
+        additional_metadata={
+            "PIP_PACKAGES": "git+https://github.com/mozilla/python_mozaggregator.git"
+        },
+        python_driver_code="gs://{}/jobs/mozaggregator_runner.py".format(
+            artifact_bucket
+        ),
+        py_args=[
+            "mobile",
+            "--date",
+            "{{ ds_nodash }}",
+            "--output",
+            "gs://{}/mobile_metrics_aggregates/v3".format(output_bucket),
+            "--num-partitions",
+            str(5 * 32),
+            "--source",
+            "bigquery",
+            "--project-id",
+            "moz-fx-data-shared-prod",
+        ],
+        gcp_conn_id=gcp_conn.gcp_conn_id,
+        service_account=client_email,
+        artifact_bucket=artifact_bucket,
+        storage_bucket=storage_bucket,
+        default_args=subdag_args,
+    ),
+)
+
+# copy over artifacts if we're running in dev
+if is_dev:
+    copy_to_dev = copy_artifacts_dev(dag, project_id, artifact_bucket, storage_bucket)
+    copy_to_dev.set_downstream(mobile_aggregate_view_dataproc)


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1596242)

This has been tested locally. This should be safe to deploy since it is running parallel with the existing job. This will be used to validate whether the aggregates are correct relative to the moztelemetry version. 

Job output: https://console.cloud.google.com/dataproc/jobs/mobile_aggregates_0be053f4?organizationId=442341870013&project=amiyaguchi-dev&region=global

```
mobile_aggregates_0be053f4

Start time
    Nov 15, 2019, 3:31:28 PM
Elapsed time
    35 min 8 sec
Status

Line wrapping
Equivalent command line

WARNING: python_moztelemetry will stop working *VERY SOON* (if it hasn't stopped working already)
Please see this post to fx-data-dev for more information: https://mail.mozilla.org/pipermail/fx-data-dev/2019-November/000291.html
19/11/15 23:31:35 INFO org.spark_project.jetty.util.log: Logging initialized @4111ms
19/11/15 23:31:35 INFO org.spark_project.jetty.server.Server: jetty-9.3.z-SNAPSHOT, build timestamp: unknown, git hash: unknown
19/11/15 23:31:35 INFO org.spark_project.jetty.server.Server: Started @4194ms
19/11/15 23:31:35 INFO org.spark_project.jetty.server.AbstractConnector: Started ServerConnector@308ee4bb{HTTP/1.1,[http/1.1]}{0.0.0.0:4040}
19/11/15 23:31:36 WARN org.apache.spark.scheduler.FairSchedulableBuilder: Fair Scheduler configuration file not found so jobs will be scheduled in FIFO order. To use fair scheduling, configure pools in fairscheduler.xml or set spark.scheduler.allocation.file to a file that contains the configuration.
19/11/15 23:31:36 INFO org.apache.hadoop.yarn.client.RMProxy: Connecting to ResourceManager at mobile-metrics-aggregates-20191114-m/10.138.0.102:8032
19/11/15 23:31:36 INFO org.apache.hadoop.yarn.client.AHSProxy: Connecting to Application History server at mobile-metrics-aggregates-20191114-m/10.138.0.102:10200
19/11/15 23:31:38 INFO org.apache.hadoop.yarn.client.api.impl.YarnClientImpl: Submitted application application_1573859760696_0002
Running job for 20191114
19/11/15 23:31:48 INFO com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation: Created read session for table 'moz-fx-data-shared-prod.payload_bytes_decoded.telemetry_telemetry__mobile_metrics_v1': projects/amiyaguchi-dev/locations/us/sessions/CAISCDNGZy1BSXdhGgJpbhoCaXIaAml3GgJqYxoCamQaAmpxGgJqchoCbmEaAm9qGgJvcw
19/11/15 23:31:48 INFO com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation: Requested 5970 partitions, but only received 17 from the BigQuery Storage API for session projects/amiyaguchi-dev/locations/us/sessions/CAISCDNGZy1BSXdhGgJpbhoCaXIaAml3GgJqYxoCamQaAmpxGgJqchoCbmEaAm9qGgJvcw. Notice that the number of streams in actual may be lower than the requested number, depending on the amount parallelism that is reasonable for the table and the maximum amount of parallelism allowed by the system.
/opt/conda/default/lib/python3.6/socket.py:657: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 37726), raddr=('127.0.0.1', 38021)>
  self._sock = None
19/11/16 00:06:32 INFO org.spark_project.jetty.server.AbstractConnector: Stopped Spark@308ee4bb{HTTP/1.1,[http/1.1]}{0.0.0.0:4040}

Job output is complete
```

```
% gsutil ls -alh gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/
       0 B  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/#1573862791320743  metageneration=1
  4.65 MiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00000-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791754695  metageneration=1
  5.26 MiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00001-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791674461  metageneration=1
  3.77 MiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00002-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791795254  metageneration=1
 12.91 MiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00003-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791814505  metageneration=1
  2.35 MiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00004-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791663661  metageneration=1
638.48 KiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00005-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791683563  metageneration=1
663.84 KiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00006-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791723061  metageneration=1
  2.05 MiB  2019-11-16T00:06:31Z  gs://amiyaguchi-dev-dataproc-artifacts/mobile_metrics_aggregates/v3/submission_date=20191114/part-00007-f066e8c8-49b2-45d3-a66f-9be4897ff5b6.c000.snappy.parquet#1573862791691610  metageneration=1
TOTAL: 9 objects, 33829582 bytes (32.26 MiB)
```