### PR TITLE
Increase error agg dag frequency to 3 hours

### DIFF
--- a/dags/error_aggregates.py
+++ b/dags/error_aggregates.py
@@ -18,7 +18,7 @@ dag_name = 'error_aggregates'
 
 with models.DAG(
         dag_name,
-        schedule_interval=datetime.timedelta(hours=8),
+        schedule_interval=datetime.timedelta(hours=3),
         default_args=default_args) as dag:
 
     error_aggregates = bigquery_etl_query(


### PR DESCRIPTION
More than one update per work day will make mission control more usable and monitorable.  Cost isn't an issue (~15 cents per query).