### PR TITLE
Add missing bgbb_runner

### DIFF
--- a/jobs/bgbb_runner.py
+++ b/jobs/bgbb_runner.py
@@ -1,0 +1,3 @@
+from bgbb_airflow import cli
+
+cli.entry_point()


### PR DESCRIPTION
This was missing from #765. This runner is necessary for the job to start, and is referenced in https://github.com/mozilla/telemetry-airflow/blob/master/dags/bgbb.py#L94