### PR TITLE
Export bq-based event_events_v1 to aws (and write to test bucket for …

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -1,7 +1,13 @@
 import datetime
 
 from airflow import models
-from utils.gcp import bigquery_etl_copy_deduplicate, bigquery_etl_query, gke_command, bigquery_xcom_query
+from airflow.executors import GetDefaultExecutor
+from airflow.operators.subdag_operator import SubDagOperator
+from utils.gcp import (bigquery_etl_copy_deduplicate,
+                       bigquery_etl_query,
+                       gke_command,
+                       bigquery_xcom_query,
+                       export_to_parquet)
 
 default_args = {
     "owner": "jklukas@mozilla.com",
@@ -43,7 +49,34 @@ with models.DAG(
         owner="ssuh@mozilla.com",
         email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"])
 
-    copy_deduplicate_all >> event_events
+    event_events_export = SubDagOperator(
+        subdag=export_to_parquet(
+            table="moz-fx-data-shared-prod:telemetry_derived.event_events_v1${{ds_nodash}}",
+            destination_table="events",
+            static_partitions=["submission_date_s3={{ds_nodash}}", "doc_type=event"],
+            arguments=[
+                "--drop='submission_date",
+                "--replace='UNIX_TIMESTAMP(timestamp) AS timestamp'",
+                "--replace='CAST(sample_id AS STRING) AS sample_id'",
+                "--replace='UNIX_TIMESTAMP(session_start_time) AS session_start_time'",
+                "--replace='MAP_FROM_ARRAYS(experiments.key, experiments.value.branch) AS experiments",
+                "--replace='MAP_FROM_ENTRIES(event_map_values) AS event_map_values",
+                "--bigint-columns",
+                "sample_id",
+                "event_timestamp",
+            ],
+            # Write into telemetry-test-bucket for a day so we can check schema compat between outputs
+            # before turning off the AWS-based event_events dag
+            s3_output_bucket="telemetry-test-bucket",
+            parent_dag_name=dag.dag_id,
+            dag_name="event_events_export",
+            default_args=default_args,
+            num_workers=10),
+        task_id="event_events_export",
+        executor=GetDefaultExecutor(),
+        dag=dag)
+
+    copy_deduplicate_all >> event_events >> event_events_export
 
     # Experiment enrollment aggregates chain (depends on events)
 

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -81,7 +81,7 @@ main_summary = bigquery_etl_query(
 main_summary_export = SubDagOperator(
     subdag=export_to_parquet(
         table="moz-fx-data-shared-prod:telemetry_derived.main_summary_v4${{ds_nodash}}",
-        static_partitions="submission_date_s3={{ds_nodash}}",
+        static_partitions=["submission_date_s3={{ds_nodash}}"],
         arguments=[
             "--partition-by=sample_id",
             "--replace='{{ds_nodash}}' AS submission_date",
@@ -148,7 +148,7 @@ addons = bigquery_etl_query(
 addons_export = SubDagOperator(
     subdag=export_to_parquet(
         table="moz-fx-data-derived-datasets:telemetry_derived.addons_v2${{ds_nodash}}",
-        static_partitions="submission_date_s3={{ds_nodash}}",
+        static_partitions=["submission_date_s3={{ds_nodash}}"],
         arguments=[
             "--partition-by=sample_id",
             "--drop=submission_date",
@@ -207,7 +207,7 @@ addon_aggregates_export = SubDagOperator(
     subdag=export_to_parquet(
         table="moz-fx-data-derived-datasets:telemetry_derived.addon_aggregates_v2${{ds_nodash}}",
         destination_table="addons/agg/v2",
-        static_partitions="submission_date_s3={{ds_nodash}}",
+        static_partitions=["submission_date_s3={{ds_nodash}}"],
         arguments=[
             "--partition-by=sample_id",
             "--drop=submission_date",
@@ -285,7 +285,7 @@ clients_daily = bigquery_etl_query(
 clients_daily_export = SubDagOperator(
     subdag=export_to_parquet(
         table="moz-fx-data-shared-prod:telemetry_derived.clients_daily_v6${{ds_nodash}}",
-        static_partitions="submission_date_s3={{ds_nodash}}",
+        static_partitions=["submission_date_s3={{ds_nodash}}"],
         arguments=[
             # restore legacy schema
             "--maps-from-entries",
@@ -348,7 +348,7 @@ clients_last_seen = bigquery_etl_query(
 clients_last_seen_export = SubDagOperator(
     subdag=export_to_parquet(
         table="moz-fx-data-shared-prod:telemetry_derived.clients_last_seen_v1${{ds_nodash}}",
-        static_partitions="submission_date={{ds}}",
+        static_partitions=["submission_date={{ds}}"],
         arguments=[
             "--select",
             "cast(log2(days_seen_bits & -days_seen_bits) as long) as days_since_seen",
@@ -387,7 +387,7 @@ exact_mau_by_dimensions = bigquery_etl_query(
 exact_mau_by_dimensions_export = SubDagOperator(
     subdag=export_to_parquet(
         table="telemetry.firefox_desktop_exact_mau28_by_dimensions_v1${{ds_nodash}}",
-        static_partitions="submission_date={{ds}}",
+        static_partitions=["submission_date={{ds}}"],
         parent_dag_name=dag.dag_id,
         dag_name="exact_mau_by_dimensions_export",
         default_args=default_args),

--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -356,7 +356,7 @@ def export_to_parquet(
     # separate version using "/" instead of "_"
     export_prefix = re.sub(r"_(v[0-9]+)$", r"/\1", destination_table) + "/"
     if static_partitions:
-        export_prefix += static_partitions + "/"
+        export_prefix += "/".join(static_partitions) + "/"
     avro_prefix = "avro/" + export_prefix
     avro_path = "gs://" + gcs_output_bucket + "/" + avro_prefix + "*.avro"
 
@@ -398,10 +398,10 @@ def export_to_parquet(
                     "avro-path": (not use_storage_api) and avro_path,
                     "destination": "gs://" + gcs_output_bucket,
                     "destination-table": destination_table,
-                    "static-partitions": static_partitions,
                 }.items()
                 if value
             ]
+            + ["--static-partitions=" + p for p in static_partitions]
             + arguments,
             gcp_conn_id=gcp_conn_id,
         )


### PR DESCRIPTION
…now)

Includes one minor change to the `export_to_parquet` function, which is to make `static_partitions` a list instead of a string so we can pass in multiple arguments (which the export_parquet script supports)

I was able to get the DAGs to load locally but haven't been able to run the actual task since gcp permissions are non-trivial to set up correctly locally, so I'm going to run at least one day of this as a test writing `telemetry-test-bucket`.