### PR TITLE
Bug 1574490 - Migrate mobile products to generic Amplitude ingestion

### DIFF
--- a/dags/bq_events_to_amplitude.py
+++ b/dags/bq_events_to_amplitude.py
@@ -7,7 +7,7 @@ from utils.amplitude import export_to_amplitude
 default_args = {
     'owner': 'frank@mozilla.com',
     'start_date': datetime.datetime(2019, 6, 27),
-    'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com'],
+    'email': ['telemetry-alerts@mozilla.com', 'frank@mozilla.com', 'akomar@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
     'retries': 2,
@@ -21,15 +21,75 @@ with models.DAG(
         dag_name,
         default_args=default_args) as dag:
 
-    task_id = 'fenix_amplitude_export'
+    fenix_task_id = 'fenix_amplitude_export'
     SubDagOperator(
         subdag=export_to_amplitude(
-            dag_name=task_id,
+            dag_name=fenix_task_id,
             parent_dag_name=dag_name,
             default_args=default_args,
             dataset='telemetry',
             table_or_view='fenix_events_v1',
             s3_prefix='fenix',
         ),
-        task_id=task_id
+        task_id=fenix_task_id
+    )
+
+    fennec_ios_task_id = 'fennec_ios_amplitude_export'
+    fennec_ios_args = default_args.copy()
+    fennec_ios_args["start_date"] = datetime.datetime(2019, 12, 2)
+    SubDagOperator(
+        subdag=export_to_amplitude(
+            dag_name=fennec_ios_task_id,
+            parent_dag_name=dag_name,
+            default_args=fennec_ios_args,
+            dataset='telemetry',
+            table_or_view='fennec_ios_events_v1',
+            s3_prefix='fennec_ios',
+        ),
+        task_id=fennec_ios_task_id
+    )
+
+    focus_android_task_id = 'focus_android_amplitude_export'
+    focus_args = default_args.copy()
+    focus_args["start_date"] = datetime.datetime(2019, 12, 2)
+    SubDagOperator(
+        subdag=export_to_amplitude(
+            dag_name=focus_android_task_id,
+            parent_dag_name=dag_name,
+            default_args=focus_args,
+            dataset='telemetry',
+            table_or_view='focus_android_events_v1',
+            s3_prefix='focus_android',
+        ),
+        task_id=focus_android_task_id
+    )
+
+    rocket_android_task_id = 'rocket_android_amplitude_export'
+    rocket_args = default_args.copy()
+    rocket_args["start_date"] = datetime.datetime(2019, 12, 2)
+    SubDagOperator(
+        subdag=export_to_amplitude(
+            dag_name=rocket_android_task_id,
+            parent_dag_name=dag_name,
+            default_args=rocket_args,
+            dataset='telemetry',
+            table_or_view='rocket_android_events_v1',
+            s3_prefix='rocket_android',
+        ),
+        task_id=rocket_android_task_id
+    )
+
+    fire_tv_task_id = 'fire_tv_amplitude_export'
+    fire_tv_args = default_args.copy()
+    fire_tv_args["start_date"] = datetime.datetime(2019, 12, 2)
+    SubDagOperator(
+        subdag=export_to_amplitude(
+            dag_name=fire_tv_task_id,
+            parent_dag_name=dag_name,
+            default_args=fire_tv_args,
+            dataset='telemetry',
+            table_or_view='fire_tv_events_v1',
+            s3_prefix='fire_tv',
+        ),
+        task_id=fire_tv_task_id
     )

--- a/dags/events_to_amplitude.py
+++ b/dags/events_to_amplitude.py
@@ -6,12 +6,8 @@ from utils.tbv import tbv_envvar
 from utils.deploy import get_artifact_url
 from utils.status import register_status
 
-FOCUS_ANDROID_INSTANCES = 10
 DEVTOOLS_INSTANCES = 10
 DEVTOOLS_PRERELEASE_INSTANCES = 20
-ROCKET_ANDROID_INSTANCES = 5
-FENNEC_IOS_INSTANCES = 10
-FIRE_TV_INSTANCES = 10
 VCPUS_PER_INSTANCE = 16
 
 environment = "{{ task.__class__.deploy_environment }}"
@@ -45,21 +41,6 @@ default_args = {
 dag = DAG('events_to_amplitude', default_args=default_args, schedule_interval='0 1 * * *')
 
 
-focus_events_to_amplitude = EMRSparkOperator(
-    task_id="focus_android_events_to_amplitude",
-    job_name="Focus Android Events to Amplitude",
-    execution_timeout=timedelta(hours=8),
-    instance_count=FOCUS_ANDROID_INSTANCES,
-    env={
-        "date": "{{ ds_nodash }}",
-        "max_requests": FOCUS_ANDROID_INSTANCES * VCPUS_PER_INSTANCE,
-        "key_file": key_file("focus_android"),
-        "artifact": get_artifact_url(slug, branch="master"),
-        "config_filename": "focus_android_events_schemas.json",
-    },
-    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
-    dag=dag)
-
 devtools_prerelease_events_to_amplitude = EMRSparkOperator(
     task_id="devtools_prerelease_events_to_amplitude",
     job_name="DevTools Prerelease Events to Amplitude",
@@ -77,43 +58,6 @@ devtools_prerelease_events_to_amplitude = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
     dag=dag)
 
-rocket_android_events_to_amplitude = EMRSparkOperator(
-    owner='nechen@mozilla.com',
-    task_id="rocket_android_events_to_amplitude",
-    job_name="Rocket Android Events to Amplitude",
-    execution_timeout=timedelta(hours=8),
-    instance_count=ROCKET_ANDROID_INSTANCES,
-    email=['frank@mozilla.com', 'nechen@mozilla.com'],
-    env={
-        "date": "{{ ds_nodash }}",
-        "max_requests": ROCKET_ANDROID_INSTANCES * VCPUS_PER_INSTANCE,
-        "key_file": key_file("rocket_android"),
-        "artifact": get_artifact_url(slug, branch="master"),
-        "config_filename": "rocket_android_events_schemas.json",
-    },
-    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
-    dag=dag
-)
-
-fennec_ios_events_to_amplitude = EMRSparkOperator(
-    task_id="fennec_ios_events_to_amplitude",
-    job_name="Fennec iOS Events to Amplitude",
-    execution_timeout=timedelta(hours=8),
-    instance_count=FENNEC_IOS_INSTANCES,
-    email=['akomar@mozilla.com', 'telemetry-alerts@mozilla.com'],
-    env={
-        "date": "{{ ds_nodash }}",
-        "max_requests": FENNEC_IOS_INSTANCES * VCPUS_PER_INSTANCE,
-        "key_file": key_file("fennec_ios"),
-        "artifact": get_artifact_url(slug, branch="master"),
-        "config_filename": "fennec_ios_events_schemas.json",
-    },
-    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
-    dag=dag
-)
-
-register_status(fennec_ios_events_to_amplitude, "Firefox-iOS Amplitude events",
-                "Daily job sending Firefox iOS events to Amplitude.")
 
 devtools_release_events_to_amplitude = EMRSparkOperator(
     task_id="devtools_release_events_to_amplitude",
@@ -144,21 +88,3 @@ devtools_release_events_to_amplitude = EMRSparkOperator(
     uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/telemetry_batch_view.py",
     start_date=datetime(2018, 12, 4),
     dag=dag)
-
-fire_tv_events_to_amplitude = EMRSparkOperator(
-    owner='frank@mozilla.com',
-    task_id="fire_tv_events_to_amplitude",
-    job_name="Fire TV Events to Amplitude",
-    execution_timeout=timedelta(hours=8),
-    instance_count=FIRE_TV_INSTANCES,
-    email=['frank@mozilla.com'],
-    env={
-        "date": "{{ ds_nodash }}",
-        "max_requests": FIRE_TV_INSTANCES * VCPUS_PER_INSTANCE,
-        "key_file": key_file("fire_tv"),
-        "artifact": get_artifact_url(slug, branch="master"),
-        "config_filename": "fire_tv_events_schemas.json",
-    },
-    uri="https://raw.githubusercontent.com/mozilla/telemetry-airflow/master/jobs/events_to_amplitude.sh",
-    dag=dag
-)


### PR DESCRIPTION
~This is the next step after https://github.com/mozilla/telemetry-airflow/pull/759~

This moves mobile products' views to generic Amplitude ingestion.