### PR TITLE
Add tasks for running simpleprophet forecasts

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -3,6 +3,7 @@ import datetime
 from airflow import models
 from airflow.executors import GetDefaultExecutor
 from airflow.operators.subdag_operator import SubDagOperator
+from utils.forecasting import simpleprophet_forecast
 from utils.gcp import (bigquery_etl_copy_deduplicate,
                        bigquery_etl_query,
                        gke_command,
@@ -182,7 +183,37 @@ with models.DAG(
         email=['telemetry-alerts@mozilla.com', 'mreid@mozilla.com'],
     )
 
-    # Mobile search
+    nondesktop_aggregate_tasks = [
+        firefox_nondesktop_exact_mau28,
+        smoot_usage_nondesktop_v2,
+        firefox_nondesktop_exact_mau28_by_client_count_dimensions,
+    ]
+
+    (copy_deduplicate_all >>
+     core_clients_daily >>
+     core_clients_last_seen >>
+     nondesktop_aggregate_tasks)
+
+    (copy_deduplicate_all >>
+     fenix_clients_daily >>
+     fenix_clients_last_seen >>
+     nondesktop_aggregate_tasks)
+
+    # Nondesktop forecasts.
+
+    simpleprophet_forecasts_mobile = simpleprophet_forecast(
+        task_id="simpleprophet_forecasts_mobile",
+        datasource="mobile",
+        project_id='moz-fx-data-shared-prod',
+        dataset_id='telemetry_derived',
+        table_id='simpleprophet_forecasts_mobile_v1',
+        owner="jklukas@mozilla.com",
+        email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+    )
+
+    firefox_nondesktop_exact_mau28 >> simpleprophet_forecasts_mobile
+
+    # Mobile search queries and dependency chain.
 
     mobile_search_clients_daily = bigquery_etl_query(
         task_id='mobile_search_clients_daily',
@@ -199,17 +230,6 @@ with models.DAG(
         destination_table='mobile_search_aggregates_v1',
         email=['telemetry-alerts@mozilla.com', 'bewu@mozilla.com'],
     )
-
-    (copy_deduplicate_all >>
-     core_clients_daily >>
-     core_clients_last_seen >>
-     [firefox_nondesktop_exact_mau28, smoot_usage_nondesktop_v2,
-      firefox_nondesktop_exact_mau28_by_client_count_dimensions])
-
-    (copy_deduplicate_all >>
-     fenix_clients_daily >>
-     fenix_clients_last_seen >>
-     [firefox_nondesktop_exact_mau28, smoot_usage_nondesktop_v2])
 
     (copy_deduplicate_all >>
      mobile_search_clients_daily >>

--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -1,6 +1,7 @@
 import datetime
 
 from airflow import models
+from utils.forecasting import simpleprophet_forecast
 from utils.gcp import bigquery_etl_query
 
 default_args = {
@@ -88,6 +89,17 @@ with models.DAG(
     )
 
     fxa_users_last_seen >> smoot_usage_fxa_v2
+
+    simpleprophet_forecasts_fxa = simpleprophet_forecast(
+        task_id="fxa_simpleprophet_forecasts",
+        datasource="fxa",
+        project_id='moz-fx-data-shared-prod',
+        dataset_id='telemetry_derived',
+        table_id='simpleprophet_forecasts_fxa_v1',
+        email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+    )
+
+    simpleprophet_forecasts_fxa << firefox_accounts_exact_mau28_raw
 
 
     # Per-user-per-service tables.

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -22,6 +22,7 @@ from utils.gcp import (
     load_to_bigquery,
     gke_command,
 )
+from utils.forecasting import simpleprophet_forecast
 
 taar_aws_conn_id = "airflow_taar_rw_s3"
 taar_aws_access_key, taar_aws_secret_key, session = AwsHook(taar_aws_conn_id).get_credentials()
@@ -415,6 +416,16 @@ smoot_usage_desktop_v2 = bigquery_etl_query(
     email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
     dag=dag)
 
+simpleprophet_forecasts_desktop = simpleprophet_forecast(
+    task_id="simpleprophet_forecasts_desktop",
+    datasource="desktop",
+    project_id='moz-fx-data-shared-prod',
+    dataset_id='telemetry_derived',
+    table_id='simpleprophet_forecasts_desktop_v1',
+    owner="jklukas@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+    dag=dag)
+
 devtools_panel_usage = bigquery_etl_query(
     task_id="devtools_panel_usage",
     destination_table="devtools_panel_usage_v1",
@@ -701,6 +712,7 @@ exact_mau_by_dimensions.set_upstream(clients_last_seen)
 exact_mau_by_dimensions_export.set_upstream(exact_mau_by_dimensions)
 exact_mau_by_client_count_dimensions.set_upstream(clients_last_seen)
 smoot_usage_desktop_v2.set_upstream(clients_last_seen)
+simpleprophet_forecasts_desktop.set_upstream(exact_mau_by_dimensions)
 devtools_panel_usage.set_upstream(clients_daily)
 
 main_summary_glue.set_upstream(main_summary_export)

--- a/dags/utils/forecasting.py
+++ b/dags/utils/forecasting.py
@@ -1,0 +1,55 @@
+from operators.gcp_container_operator import GKEPodOperator
+
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
+def simpleprophet_forecast(
+    task_id,
+    datasource,
+    project_id,
+    dataset_id,
+    table_id,
+    gcp_conn_id="google_cloud_derived_datasets",
+    gke_location="us-central1-a",
+    gke_cluster_name="bq-load-gke-1",
+    gke_namespace="default",
+    docker_image="gcr.io/moz-fx-data-forecasting/simpleprophet:latest",
+    image_pull_policy="Always",
+    **kwargs
+):
+    """Run all simpleprophet models for the given datasource and model date.
+
+    :param str task_id:              [Required] ID for the task
+    :param str datasource:           [Required] One of desktop, mobile, fxa
+    :param str project_id:           [Required] ID of project where target table lives
+    :param str dataset_id:           [Required] ID of dataset where target table lives
+    :param str table_id:             [Required] ID of target table
+
+    :param str gcp_conn_id:          Airflow connection id for GCP access
+    :param str gke_location:         GKE cluster location
+    :param str gke_cluster_name:     GKE cluster name
+    :param str gke_namespace:        GKE cluster namespace
+    :param str docker_image:         docker image to use
+    :param str image_pull_policy:    Kubernetes policy for when to pull
+                                     docker_image
+    :param Dict[str, Any] kwargs:    Additional keyword arguments for
+                                     GKEPodOperator
+
+    :return: GKEPodOperator
+    """
+    kwargs["name"] = kwargs.get("name", task_id.replace("_", "-"))
+    return GKEPodOperator(
+        task_id=task_id,
+        gcp_conn_id=gcp_conn_id,
+        project_id=GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id).project_id,
+        location=gke_location,
+        cluster_name=gke_cluster_name,
+        namespace=gke_namespace,
+        image=docker_image,
+        arguments=["{{ds}}"]
+        + ["--datasource=" + datasource]
+        + ["--project-id=" + project_id]
+        + ["--dataset-id=" + dataset_id]
+        + ["--table-id=" + table_id],
+        image_pull_policy=image_pull_policy,
+        **kwargs
+    )


### PR DESCRIPTION
Depends on https://github.com/mozilla/forecasting/pull/10

We aren't going to start relying on these "productionized" forecasts until beginning of 2020, so for now nothing depends on the forecast tasks and we leave the kpi_dashboard dag alone.