### PR TITLE
Schedule the exact_mau by client count dims queries

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -175,6 +175,13 @@ with models.DAG(
         email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
+    firefox_nondesktop_exact_mau28_by_client_count_dimensions = bigquery_etl_query(
+        task_id='firefox_nondesktop_exact_mau28_by_client_count_dimensions',
+        destination_table='firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1',
+        dataset_id='telemetry_derived',
+        email=['telemetry-alerts@mozilla.com', 'mreid@mozilla.com'],
+    )
+
     # Mobile search
 
     mobile_search_clients_daily = bigquery_etl_query(
@@ -196,7 +203,8 @@ with models.DAG(
     (copy_deduplicate_all >>
      core_clients_daily >>
      core_clients_last_seen >>
-     [firefox_nondesktop_exact_mau28, smoot_usage_nondesktop_v2])
+     [firefox_nondesktop_exact_mau28, smoot_usage_nondesktop_v2,
+      firefox_nondesktop_exact_mau28_by_client_count_dimensions])
 
     (copy_deduplicate_all >>
      fenix_clients_daily >>

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -398,6 +398,14 @@ exact_mau_by_dimensions_export = SubDagOperator(
     executor=GetDefaultExecutor(),
     dag=dag)
 
+exact_mau_by_client_count_dimensions = bigquery_etl_query(
+    task_id="exact_mau_by_client_count_dimensions",
+    destination_table="firefox_desktop_exact_mau28_by_client_count_dimensions_v1",
+    dataset_id="telemetry_derived",
+    owner="mreid@mozilla.com",
+    email=["telemetry-alerts@mozilla.com", "mreid@mozilla.com"],
+    dag=dag)
+
 smoot_usage_desktop_v2 = bigquery_etl_query(
     task_id='smoot_usage_desktop_v2',
     project_id='moz-fx-data-shared-prod',
@@ -691,6 +699,7 @@ clients_last_seen.set_upstream(clients_daily)
 clients_last_seen_export.set_upstream(clients_last_seen)
 exact_mau_by_dimensions.set_upstream(clients_last_seen)
 exact_mau_by_dimensions_export.set_upstream(exact_mau_by_dimensions)
+exact_mau_by_client_count_dimensions.set_upstream(clients_last_seen)
 smoot_usage_desktop_v2.set_upstream(clients_last_seen)
 devtools_panel_usage.set_upstream(clients_daily)
 


### PR DESCRIPTION
These are added as helpers for rewriting old queries that used
the HLL-based "client_count" datasets. Using this data makes
them faster and cheaper than using the "last_seen" tables
directly.