### PR TITLE
Remove references to metastore from TBV

### DIFF
--- a/dags/utils/tbv.py
+++ b/dags/utils/tbv.py
@@ -5,7 +5,7 @@ from utils.deploy import get_artifact_url
 
 
 def tbv_envvar(klass, options, dev_options={}, branch=None, tag=None, other={},
-               metastore_location=None, artifact_url=None):
+               artifact_url=None):
     """Set up environment variables for telemetry-batch-view jobs.
 
     The command line interface can read options from the environment. All
@@ -20,7 +20,6 @@ def tbv_envvar(klass, options, dev_options={}, branch=None, tag=None, other={},
     :branch string:     the branch to run the job from, incompatible with tag
     :tag string:        the tag to run the job from, incompatible with branch
     :other dict:        environment variables to pass through
-    :metastore_location string: Location of the data-set metastore
     :artifact_url string:       Location of pre-built binaries
 
     :returns: a dictionary that contains properly prefixed class and options
@@ -43,9 +42,6 @@ def tbv_envvar(klass, options, dev_options={}, branch=None, tag=None, other={},
         prefixed_options["TBV_CLASS"] = klass
     else:
         assert other.get("DO_SUBMIT", "True") == "False", "To submit there must be a class name"
-
-    if metastore_location is not None:
-        prefixed_options["METASTORE_LOCATION"] = metastore_location
 
     prefixed_options["ARTIFACT_URL"] = url
     prefixed_options.update(other)

--- a/jobs/telemetry_batch_view.py
+++ b/jobs/telemetry_batch_view.py
@@ -100,17 +100,6 @@ def submit_job():
     call_exit_errors(command)
 
 
-def update_metastore(location, hive_server):
-    p2h_cmd = ("parquet2hive", "-ulv=1", "--sql", location)
-    beeline_cmd = ("beeline", "-u", "jdbc:hive2://{}:10000".format(hive_server))
-    print("+ {}".format(" ".join(p2h_cmd)))
-    p2h = Popen(p2h_cmd, stdout=PIPE)
-    print("+ {}".format(" ".join(beeline_cmd)))
-    rc = call(beeline_cmd, stdin=p2h.stdout)
-    if rc > 0:
-        exit(rc)
-
-
 if environ.get("DO_RETRIEVE", "True") == "True":
     retrieve_jar()
 
@@ -119,6 +108,3 @@ if environ.get("DO_EVENTS_TO_AMPLITUDE_SETUP") == "True":
 
 if environ.get("DO_SUBMIT", "True") == "True":
     submit_job()
-
-if environ.get("METASTORE_LOCATION") != None:
-    update_metastore(environ.get("METASTORE_LOCATION"), environ.get("HIVE_SERVER"))


### PR DESCRIPTION
Since we're removing the parquet data tomorrow there's no need to keep updating the metastore.