### PR TITLE
Bug 1583947: Add initial attitudes daily dag

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -121,6 +121,9 @@ init_variables() {
     airflow variables -s "LEANPLUM_FIREFOX_PREVIEW_CLIENT_KEY" "firefox-preview-client-key"
     airflow variables -s "LEANPLUM_FIREFOX_IOS_RELEASE_APP_ID" "firefox-ios-app-id"
     airflow variables -s "LEANPLUM_FIREFOX_IOS_RELEASE_CLIENT_KEY" "firefox-ios-client-key"
+    airflow variables -s "surveygizmo_daily_attitudes_survey_id" "12345"
+    airflow variables -s "surveygizmo_api_token" "tokentokentoken"
+    airflow variables -s "surveygizmo_api_secret" "tapsekret"
 }
 
 [ $# -lt 1 ] && usage

--- a/dags/attitudes_daily.py
+++ b/dags/attitudes_daily.py
@@ -38,6 +38,4 @@ with models.DAG(
             "--destination_table",
             "moz-fx-data-shared-prod.telemetry_derived.survey_gizmo_daily_attitudes"
         ],
-        docker_image="mozilla/bigquery-etl:latest",
-        owner="ssuh@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"])
+        docker_image="mozilla/bigquery-etl:latest")

--- a/dags/attitudes_daily.py
+++ b/dags/attitudes_daily.py
@@ -1,0 +1,43 @@
+import datetime
+
+from airflow import models
+from airflow.models import Variable
+from utils.gcp import gke_command
+
+default_args = {
+    "owner": "ssuh@mozilla.com",
+    "start_date": datetime.datetime(2019, 12, 16),
+    "email": ["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"],
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "depends_on_past": False,
+    # If a task fails, retry it once after waiting at least 5 minutes
+    "retries": 1,
+    "retry_delay": datetime.timedelta(minutes=30),
+}
+
+dag_name = "attitudes_daily"
+
+with models.DAG(
+        dag_name,
+        schedule_interval="0 1 * * *",
+        default_args=default_args) as dag:
+    surveygizmo_attitudes_daily_import = gke_command(
+        task_id="surveygizmo_attitudes_daily_import",
+        command=[
+            "python",
+            "templates/telemetry_derived/surveygizmo_daily_attitudes/import_responses.py",
+            "--date",
+            "{{ ds }}",
+            "--survey_id",
+            Variable.get("surveygizmo_daily_attitudes_survey_id"),
+            "--sg_api_token",
+            Variable.get("surveygizmo_api_token"),
+            "--sg_api_secret",
+            Variable.get("surveygizmo_api_secret"),
+            "--destination_table",
+            "moz-fx-data-shared-prod.telemetry_derived.survey_gizmo_daily_attitudes"
+        ],
+        docker_image="mozilla/bigquery-etl:latest",
+        owner="ssuh@mozilla.com",
+        email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"])


### PR DESCRIPTION
I've already added these variables to the prod Airflow instance so this should be good to go – the dag will get filled out with a few more steps when those queries are ready