### PR TITLE
GCP port of taar-dynamo

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -1,7 +1,6 @@
 from airflow import DAG
 from datetime import datetime, timedelta
 from itertools import chain
-from operators.emr_spark_operator import EMRSparkOperator
 from airflow.contrib.hooks.aws_hook import AwsHook
 from airflow.executors import GetDefaultExecutor
 from airflow.operators.moz_databricks import MozDatabricksSubmitRunOperator
@@ -29,6 +28,7 @@ taar_aws_access_key, taar_aws_secret_key, session = AwsHook(taar_aws_conn_id).ge
 taarlite_cluster_name = "dataproc-taarlite-guidguid"
 taar_locale_cluster_name = "dataproc-taar-locale"
 taar_gcpdataproc_conn_id = "google_cloud_airflow_dataproc"
+taar_dynamo_cluster_name = "dataproc-taar-dynamo"
 
 default_args = {
     'owner': 'frank@mozilla.com',
@@ -567,7 +567,7 @@ addon_aggregates.set_upstream(copy_deduplicate_main_ping)
 main_summary_experiments.set_upstream(main_summary)
 main_summary_experiments.set_upstream(main_summary_experiments_get_experiment_list)
 
-taar_dynamo.set_upstream(main_summary_export)
+taar_dynamo_job.set_upstream(main_summary_export)
 taar_similarity.set_upstream(clients_daily_export)
 
 clients_last_seen.set_upstream(clients_daily)

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -311,8 +311,7 @@ taar_dynamo_job = SubDagOperator(
         worker_machine_type='n1-standard-32',
         cluster_name=taar_dynamo_cluster_name,
         job_name="TAAR_Dynamo",
-        #python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_dynamo.py",
-        python_driver_code="gs://temp-hwoo-removemelater/taar_dynamo.py",
+        python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_dynamo.py",
         num_workers=12,
         py_args=[
             "--date",

--- a/dags/utils/dataproc.py
+++ b/dags/utils/dataproc.py
@@ -367,7 +367,12 @@ def moz_dataproc_jar_runner(parent_dag_name=None,
                             jar_args=None,
                             job_name=None,
                             aws_conn_id=None,
-                            gcp_conn_id='google_cloud_airflow_dataproc'):
+                            gcp_conn_id='google_cloud_airflow_dataproc',
+                            master_disk_type='pd-standard',
+                            worker_disk_type='pd-standard',
+                            master_disk_size=1024,
+                            worker_disk_size=1024,
+                            ):
 
     """
     This will initially create a GCP Dataproc cluster with Anaconda/Jupyter/Component gateway.
@@ -433,7 +438,12 @@ def moz_dataproc_jar_runner(parent_dag_name=None,
                                      optional_components=optional_components,
                                      install_component_gateway=install_component_gateway,
                                      aws_conn_id=aws_conn_id,
-                                     gcp_conn_id=gcp_conn_id)
+                                     gcp_conn_id=gcp_conn_id,
+                                     master_disk_type=master_disk_type,
+                                     master_disk_size=master_disk_size,
+                                     worker_disk_type=worker_disk_type,
+                                     worker_disk_size=worker_disk_size,
+                                     )
 
     _dag_name = '{}.{}'.format(parent_dag_name, dag_name)
 
@@ -487,7 +497,12 @@ def moz_dataproc_scriptrunner(parent_dag_name=None,
                               arguments=None,
                               job_name=None,
                               aws_conn_id=None,
-                              gcp_conn_id='google_cloud_airflow_dataproc'):
+                              gcp_conn_id='google_cloud_airflow_dataproc',
+                              master_disk_type='pd-standard',
+                              worker_disk_type='pd-standard',
+                              master_disk_size=1024,
+                              worker_disk_size=1024,
+                              ):
 
     """
     This will initially create a GCP Dataproc cluster with Anaconda/Jupyter/Component gateway.
@@ -561,7 +576,12 @@ def moz_dataproc_scriptrunner(parent_dag_name=None,
                                      optional_components=optional_components,
                                      install_component_gateway=install_component_gateway,
                                      aws_conn_id=aws_conn_id,
-                                     gcp_conn_id=gcp_conn_id)
+                                     gcp_conn_id=gcp_conn_id,
+                                     master_disk_type=master_disk_type,
+                                     master_disk_size=master_disk_size,
+                                     worker_disk_type=worker_disk_type,
+                                     worker_disk_size=worker_disk_size,
+                                     )
 
     _dag_name = '{}.{}'.format(parent_dag_name, dag_name)
     environment = _format_envvar(env)

--- a/dags/utils/dataproc.py
+++ b/dags/utils/dataproc.py
@@ -44,10 +44,10 @@ class DataProcHelper:
                  gcp_conn_id='google_cloud_airflow_dataproc',
                  artifact_bucket='moz-fx-data-prod-airflow-dataproc-artifacts',
                  storage_bucket='moz-fx-data-prod-dataproc-scratch',
-                 master_disk_type='pd-standard',
-                 master_disk_size=1024,
-                 worker_disk_type='pd-standard',
-                 worker_disk_size=1024,
+                 master_disk_type=None,
+                 master_disk_size=None,
+                 worker_disk_type=None,
+                 worker_disk_size=None,
                 ):
 
         self.cluster_name = cluster_name
@@ -124,6 +124,11 @@ class DataProcHelper:
             }
         metadata.update(self.additional_metadata)
 
+        disk_kwargs = {}
+        for key in ['master_disk_type', 'master_disk_size', 'worker_disk_type', 'worker_disk_size']:
+            if getattr(self, key, None) is not None:
+                disk_kwargs[key] = getattr(self, key)
+
         return DataprocClusterCreateOperator(
             task_id='create_dataproc_cluster',
             cluster_name=self.cluster_name,
@@ -145,11 +150,8 @@ class DataProcHelper:
             optional_components = self.optional_components,
             install_component_gateway = self.install_component_gateway,
             init_actions_uris=self.init_actions_uris,
-            master_disk_type=self.master_disk_type,
-            master_disk_size=self.master_disk_size,
-            worker_disk_type=self.worker_disk_type,
-            worker_disk_size=self.worker_disk_size,
             metadata=metadata,
+            **disk_kwargs,
         )
 
     def delete_cluster(self):
@@ -191,10 +193,10 @@ def moz_dataproc_pyspark_runner(parent_dag_name=None,
                                 gcp_conn_id='google_cloud_airflow_dataproc',
                                 artifact_bucket='moz-fx-data-prod-airflow-dataproc-artifacts',
                                 storage_bucket='moz-fx-data-prod-dataproc-scratch',
-                                master_disk_type='pd-standard',
-                                worker_disk_type='pd-standard',
-                                master_disk_size=1024,
-                                worker_disk_size=1024,
+                                master_disk_type=None,
+                                worker_disk_type=None,
+                                master_disk_size=None,
+                                worker_disk_size=None,
                             ):
 
     """

--- a/dags/utils/dataproc.py
+++ b/dags/utils/dataproc.py
@@ -45,10 +45,10 @@ class DataProcHelper:
                  gcp_conn_id='google_cloud_airflow_dataproc',
                  artifact_bucket='moz-fx-data-prod-airflow-dataproc-artifacts',
                  storage_bucket='moz-fx-data-prod-dataproc-scratch',
-                 master_disk_type=None,
-                 master_disk_size=None,
-                 worker_disk_type=None,
-                 worker_disk_size=None,
+                 master_disk_type='pd-standard',
+                 master_disk_size=1024,
+                 worker_disk_type='pd-standard',
+                 worker_disk_size=1024,
                 ):
 
         self.cluster_name = cluster_name
@@ -125,11 +125,6 @@ class DataProcHelper:
             }
         metadata.update(self.additional_metadata)
 
-        disk_kwargs = {}
-        for key in ['master_disk_type', 'master_disk_size', 'worker_disk_type', 'worker_disk_size']:
-            if getattr(self, key, None) is not None:
-                disk_kwargs[key] = getattr(self, key)
-
         return DataprocClusterCreateOperator(
             task_id='create_dataproc_cluster',
             cluster_name=self.cluster_name,
@@ -151,8 +146,11 @@ class DataProcHelper:
             optional_components = self.optional_components,
             install_component_gateway = self.install_component_gateway,
             init_actions_uris=self.init_actions_uris,
+            master_disk_type=self.master_disk_type,
+            master_disk_size=self.master_disk_size,
+            worker_disk_type=self.worker_disk_type,
+            worker_disk_size=self.worker_disk_size,
             metadata=metadata,
-            **disk_kwargs,
         )
 
     def delete_cluster(self):
@@ -194,10 +192,10 @@ def moz_dataproc_pyspark_runner(parent_dag_name=None,
                                 gcp_conn_id='google_cloud_airflow_dataproc',
                                 artifact_bucket='moz-fx-data-prod-airflow-dataproc-artifacts',
                                 storage_bucket='moz-fx-data-prod-dataproc-scratch',
-                                master_disk_type=None,
-                                worker_disk_type=None,
-                                master_disk_size=None,
-                                worker_disk_size=None,
+                                master_disk_type='pd-standard',
+                                worker_disk_type='pd-standard',
+                                master_disk_size=1024,
+                                worker_disk_size=1024,
                             ):
 
     """

--- a/dags/utils/dataproc.py
+++ b/dags/utils/dataproc.py
@@ -44,6 +44,10 @@ class DataProcHelper:
                  gcp_conn_id='google_cloud_airflow_dataproc',
                  artifact_bucket='moz-fx-data-prod-airflow-dataproc-artifacts',
                  storage_bucket='moz-fx-data-prod-dataproc-scratch',
+                 master_disk_type='pd-standard',
+                 master_disk_size=1024,
+                 worker_disk_type='pd-standard',
+                 worker_disk_size=1024,
                 ):
 
         self.cluster_name = cluster_name
@@ -61,6 +65,11 @@ class DataProcHelper:
         # The bucket with a default dataproc init script
         self.artifact_bucket = artifact_bucket
         self.storage_bucket = storage_bucket
+
+        self.master_disk_type = master_disk_type
+        self.master_disk_size = master_disk_size
+        self.worker_disk_type = worker_disk_type
+        self.worker_disk_size = worker_disk_size
 
         if init_actions_uris is None:
             self.init_actions_uris=['gs://{}/bootstrap/dataproc_init.sh'.format(self.artifact_bucket)]
@@ -136,6 +145,10 @@ class DataProcHelper:
             optional_components = self.optional_components,
             install_component_gateway = self.install_component_gateway,
             init_actions_uris=self.init_actions_uris,
+            master_disk_type=self.master_disk_type,
+            master_disk_size=self.master_disk_size,
+            worker_disk_type=self.worker_disk_type,
+            worker_disk_size=self.worker_disk_size,
             metadata=metadata,
         )
 
@@ -178,6 +191,10 @@ def moz_dataproc_pyspark_runner(parent_dag_name=None,
                                 gcp_conn_id='google_cloud_airflow_dataproc',
                                 artifact_bucket='moz-fx-data-prod-airflow-dataproc-artifacts',
                                 storage_bucket='moz-fx-data-prod-dataproc-scratch',
+                                master_disk_type='pd-standard',
+                                worker_disk_type='pd-standard',
+                                master_disk_size=1024,
+                                worker_disk_size=1024,
                             ):
 
     """
@@ -285,6 +302,10 @@ def moz_dataproc_pyspark_runner(parent_dag_name=None,
                                      gcp_conn_id=gcp_conn_id,
                                      artifact_bucket=artifact_bucket,
                                      storage_bucket=storage_bucket,
+                                     master_disk_type=master_disk_type,
+                                     master_disk_size=master_disk_size,
+                                     worker_disk_type=worker_disk_type,
+                                     worker_disk_size=worker_disk_size,
                                      )
 
     _dag_name = '{}.{}'.format(parent_dag_name, dag_name)

--- a/dags/utils/dataproc.py
+++ b/dags/utils/dataproc.py
@@ -17,6 +17,7 @@ Note: We are currently deployed on v1.10.2, and when we upgrade, the functionali
 for the DataProcPySparkOperator and DataProcSparkOperator will change.
 """
 
+
 class DataProcHelper:
     """
     This is a helper class for creating/deleting dataproc clusters.
@@ -271,6 +272,20 @@ def moz_dataproc_pyspark_runner(parent_dag_name=None,
     :param list optional_components:      List of optional components to install on cluster
                                           Defaults to ['ANACONDA'] for now since JUPYTER is broken.
     :param str install_component_gateway: Enable alpha feature component gateway.
+    :param master_disk_type:              Type of the boot disk for the master node
+                                            (default is ``pd-standard``).
+                                            Valid values: ``pd-ssd`` (Persistent Disk Solid State Drive) or
+                                            ``pd-standard`` (Persistent Disk Hard Disk Drive).
+    :type master_disk_type: str
+    :param master_disk_size:              Disk size for the master node
+    :type master_disk_size: int
+    :param worker_disk_type:              Type of the boot disk for the worker node
+                                            (default is ``pd-standard``).
+                                            Valid values: ``pd-ssd`` (Persistent Disk Solid State Drive) or
+                                            ``pd-standard`` (Persistent Disk Hard Disk Drive).
+    :type worker_disk_type: str
+    :param worker_disk_size:              Disk size for the worker node
+    :type worker_disk_size: int
 
     Pyspark related args:
     ---
@@ -450,6 +465,7 @@ def _format_envvar(env=None):
     # Use a default value if an environment dictionary isn't supplied
     return ' '.join(['{}={}'.format(k, v) for k, v in (env or {}).items()])
 
+
 def moz_dataproc_scriptrunner(parent_dag_name=None,
                               dag_name='run_script_on_dataproc',
                               default_args=None,
@@ -625,6 +641,7 @@ def copy_artifacts_dev(dag, project_id, artifact_bucket, storage_bucket):
         },
         dag=dag,
     )
+
 
 # parameters that can be used to reconfigure a dataproc job for dev testing
 DataprocParameters = namedtuple(

--- a/jobs/taar_dynamo.py
+++ b/jobs/taar_dynamo.py
@@ -1,0 +1,499 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+This module replicates the scala script over at
+
+https://github.com/mozilla/telemetry-batch-view/blob/1c544f65ad2852703883fe31a9fba38c39e75698/src/main/scala/com/mozilla/telemetry/views/HBaseAddonRecommenderView.scala
+
+This should be invoked with something like this:
+
+spark-submit \
+    --master=spark://ec2-52-32-39-246.us-west-2.compute.amazonaws.com taar_dynamo.py \
+    --date=20180218  \
+    --region=us-west-2  \
+    --table=taar_addon_data_20180206 \
+    --prod-iam-role=arn:aws:iam::361527076523:role/taar-write-dynamodb-from-dev
+
+"""
+
+from datetime import date
+from datetime import timedelta
+from datetime import datetime
+import hashlib
+import os
+from pprint import pprint
+from pyspark import SparkConf
+from pyspark.sql import SparkSession
+from pyspark.sql import Window
+from pyspark.sql.functions import desc, row_number
+import click
+import dateutil.parser
+import json
+import botocore
+import boto3
+from botocore.exceptions import ClientError
+from boto3.dynamodb.types import Binary as DynamoBinary
+import logging
+import time
+import zlib
+
+PATCH_DAYS = timedelta(days=2)
+
+# We use the os and threading modules to generate a spark worker
+# specific identity:w
+
+MAX_RECORDS = 200
+EMPTY_TUPLE = (0, 0, [], [])
+
+BOTO_CFG = botocore.config.Config(retries={"max_attempts": 16})
+
+
+def hash_telemetry_id(telemetry_id):
+    """
+        This hashing function is a reference implementation based on :
+            https://phabricator.services.mozilla.com/D8311
+
+    """
+    return hashlib.sha256(telemetry_id.encode("utf8")).hexdigest()
+
+
+def json_serial(obj):
+    """JSON serializer for objects not serializable by default json code"""
+
+    try:
+        if isinstance(obj, (datetime, date)):
+            return obj.isoformat()
+    except Exception:
+        # Some dates are invalid and won't serialize to
+        # ISO format if the year is < 1601.  Yes. This actually
+        # happens.  Force the date to epoch in this case
+        return date(1970, 1, 1).isoformat()
+    raise TypeError("Type %s not serializable" % type(obj))
+
+
+def filterDateAndClientID(row_jstr):
+    """
+    Filter out any rows where the client_id is None or where the
+    subsession_start_date is not a valid date
+    """
+    (row, jstr) = row_jstr
+    try:
+        assert row.client_id is not None
+        assert row.client_id != ""
+        some_date = dateutil.parser.parse(row.subsession_start_date)
+        if some_date.year < 1970:
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def list_transformer(row_jsonstr):
+    """
+    We need to merge two elements of the row data - namely the
+    client_id and the start_date into the main JSON blob.
+
+    This is then packaged into a 4-tuple of :
+
+    The first integer represents the number of records that have been
+    pushed into DynamoDB.
+
+    The second is the length of the JSON data list. This prevents us
+    from having to compute the length of the JSON list unnecessarily.
+
+    The third element of the tuple is the list of JSON data.
+
+    The fourth element is a list of invalid JSON blobs.  We maintain
+    this to be no more than 50 elements long.
+    """
+    (row, json_str) = row_jsonstr
+    client_id = row.client_id
+    start_date = dateutil.parser.parse(row.subsession_start_date)
+    start_date = start_date.date()
+    start_date = start_date.strftime("%Y%m%d")
+    jdata = json.loads(json_str)
+    jdata["client_id"] = client_id
+    jdata["start_date"] = start_date
+
+    # Filter out keys with an empty value
+    jdata = {key: value for key, value in list(jdata.items()) if value}
+
+    # We need to return a 4-tuple of values
+    # (numrec_dynamodb_pushed, json_list_length, json_list, error_json)
+
+    # These 4-tuples can be reduced in a map/reduce
+    return (0, 1, [jdata], [])
+
+
+def _write_batch(table, item_list, pause_time):
+    logging.info("Pausing for {} seconds".format(pause_time))
+    time.sleep(pause_time)
+    with table.batch_writer(overwrite_by_pkeys=["client_id"]) as batch:
+        for item in item_list:
+            batch.put_item(Item=item)
+
+
+class DynamoReducer(object):
+    def __init__(
+        self,
+        region_name=None,
+        table_name=None,
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+    ):
+
+        if region_name is None:
+            region_name = "us-west-2"
+
+        if table_name is None:
+            table_name = "taar_addon_data"
+
+        self._region_name = region_name
+        self._table_name = table_name
+
+        self._aws_access_key_id = aws_access_key_id
+        self._aws_secret_access_key = aws_secret_access_key
+
+    def hash_client_ids(self, data_tuple):
+        """
+        # Clobber the client_id by using sha256 hashes encoded as hex
+        # Based on the js code in Fx
+
+        """
+
+        for item in data_tuple[2]:
+            client_id = item["client_id"]
+            item["client_id"] = hash_telemetry_id(client_id)
+
+    def push_to_dynamo(self, data_tuple):  # noqa
+        """
+        This connects to DynamoDB and pushes records in `item_list` into
+        a table.
+
+        We accumulate a list of up to 50 elements long to allow debugging
+        of write errors.
+        """
+        # Transform the data into something that DynamoDB will always
+        # accept
+        # Set TTL to 60 days from now
+        ttl = int(time.time()) + 60 * 60 * 24 * 60
+
+        self.hash_client_ids(data_tuple)
+
+        item_list = [
+            {
+                "client_id": item["client_id"],
+                "TTL": ttl,
+                "json_payload": DynamoBinary(
+                    zlib.compress(json.dumps(item, default=json_serial).encode("utf8"))
+                ),
+            }
+            for item in data_tuple[2]
+        ]
+
+        # Clobber the enviroment variables for boto3 just prior to
+        # making the dynamodb connection
+        os.environ["AWS_ACCESS_KEY_ID"] = self._aws_access_key_id
+        os.environ["AWS_SECRET_ACCESS_KEY"] = self._aws_secret_access_key
+        # Obtain credentials from the singleton
+        conn = boto3.resource(
+            "dynamodb", region_name=self._region_name, config=BOTO_CFG
+        )
+
+        table = conn.Table(self._table_name)
+
+        retry_exceptions = (
+            "ProvisionedThroughputExceededException",
+            "ThrottlingException",
+        )
+
+        retries = 0
+        pause_time = 0
+        while True:
+            try:
+                _write_batch(table, item_list, pause_time)
+                logging.info(
+                    "Wrote {:d} items to dynamo batch mode.".format(len(item_list))
+                )
+            except ClientError as err:
+                if err.response["Error"]["Code"] not in retry_exceptions:
+                    raise
+                pause_time = 2 ** retries
+                logging.info("Back-off set to %d seconds", pause_time)
+                retries += 1
+
+        return []
+
+    def dynamo_reducer(self, list_a, list_b, force_write=False):
+        """
+        This function can be used to reduce tuples of the form in
+        `list_transformer`. Data is merged and when MAX_RECORDS
+        number of JSON blobs are merged, the list of JSON is batch written
+        into DynamoDB.
+        """
+        new_list = [
+            list_a[0] + list_b[0],
+            list_a[1] + list_b[1],
+            list_a[2] + list_b[2],
+            list_a[3] + list_b[3],
+        ]
+
+        if new_list[1] >= MAX_RECORDS or force_write:
+            error_blobs = self.push_to_dynamo(new_list)
+            if len(error_blobs) > 0:
+                # Gather up to maximum 50 error blobs
+                new_list[3].extend(error_blobs[: 50 - new_list[1]])
+                # Zero out the number of accumulated records
+                new_list[1] = 0
+                print("Captured {:d} errors".format(len(error_blobs)))
+            else:
+                # No errors during write process
+                # Update number of records written to dynamo
+                new_list[0] += new_list[1]
+                # Zero out the number of accumulated records
+                new_list[1] = 0
+                # Clear out the accumulated JSON records
+                new_list[2] = []
+
+        return tuple(new_list)
+
+
+def etl(
+    spark,
+    run_date,
+    region_name,
+    table_name,
+    sample_rate,
+    aws_access_key_id,
+    aws_secret_access_key,
+):
+    """
+    This function is responsible for extract, transform and load.
+
+    Data is extracted from Parquet files in Amazon S3.
+    Transforms and filters are applied to the data to create
+    3-tuples that are easily merged in a map-reduce fashion.
+
+    The 3-tuples are then loaded into DynamoDB using a map-reduce
+    operation in Spark.
+    """
+
+    rdd = extract_transform(spark, run_date, sample_rate)
+
+    result = load_rdd(
+        region_name, table_name, rdd, aws_access_key_id, aws_secret_access_key
+    )
+    return result
+
+
+def extract_transform(spark, run_date, sample_rate=0):
+    currentDate = run_date
+    currentDateString = currentDate.strftime("%Y%m%d")
+    print("Processing %s" % currentDateString)
+
+    # Get the data for the desired date out of parquet
+    template = "gs://moz-fx-data-derived-datasets-parquet/main_summary/v4/submission_date_s3=%s"
+    datasetForDate = spark.read.parquet(template % currentDateString)
+
+    if sample_rate is not None and sample_rate != 0:
+        print("Sample rate set to %0.9f" % sample_rate)
+        datasetForDate = datasetForDate.sample(False, sample_rate)
+    else:
+        print("No sampling on dataset")
+
+    print("Parquet data loaded")
+
+    # Get the most recent (client_id, subsession_start_date) tuple
+    # for each client since the main_summary might contain
+    # multiple rows per client. We will use it to filter out the
+    # full table with all the columns we require.
+
+    clientShortList = datasetForDate.select(
+        "client_id",
+        "subsession_start_date",
+        row_number()
+        .over(Window.partitionBy("client_id").orderBy(desc("subsession_start_date")))
+        .alias("clientid_rank"),
+    )
+    print("clientShortList selected")
+    clientShortList = clientShortList.where("clientid_rank == 1").drop("clientid_rank")
+    print("clientShortList selected")
+
+    select_fields = [
+        "client_id",
+        "subsession_start_date",
+        "subsession_length",
+        "city",
+        "locale",
+        "os",
+        "places_bookmarks_count",
+        "scalar_parent_browser_engagement_tab_open_event_count",
+        "scalar_parent_browser_engagement_total_uri_count",
+        "scalar_parent_browser_engagement_unique_domains_count",
+        "active_addons",
+        "disabled_addons_ids",
+    ]
+    dataSubset = datasetForDate.select(*select_fields)
+    print("datasetForDate select fields completed")
+
+    # Join the two tables: only the elements in both dataframes
+    # will make it through.
+    clientsData = dataSubset.join(
+        clientShortList, ["client_id", "subsession_start_date"]
+    )
+
+    print("clientsData join with client_id and subsession_start_date")
+
+    # Convert the DataFrame to JSON and get an RDD out of it.
+    subset = clientsData.select("client_id", "subsession_start_date")
+
+    print("clientsData select of client_id and subsession_start_date completed")
+
+    jsonDataRDD = clientsData.select(
+        "city",
+        "subsession_start_date",
+        "subsession_length",
+        "locale",
+        "os",
+        "places_bookmarks_count",
+        "scalar_parent_browser_engagement_tab_open_event_count",
+        "scalar_parent_browser_engagement_total_uri_count",
+        "scalar_parent_browser_engagement_unique_domains_count",
+        "active_addons",
+        "disabled_addons_ids",
+    ).toJSON()
+
+    print("jsonDataRDD selected")
+    rdd = subset.rdd.zip(jsonDataRDD)
+    print("subset rdd has been zipped")
+
+    # Filter out any records with invalid dates or client_id
+    filtered_rdd = rdd.filter(filterDateAndClientID)
+    print("rdd filtered by date and client_id")
+
+    # Transform the JSON elements into a 4-tuple as per docstring
+    merged_filtered_rdd = filtered_rdd.map(list_transformer)
+    print("rdd has been transformed into tuples")
+
+    return merged_filtered_rdd
+
+
+def load_rdd(region_name, table_name, rdd, aws_access_key_id, aws_secret_access_key):
+    # Apply a MapReduce operation to the RDD
+    # Note that we're passing around the AWS keys here
+    dynReducer = DynamoReducer(
+        region_name, table_name, aws_access_key_id, aws_secret_access_key
+    )
+
+    reduction_output = rdd.reduce(dynReducer.dynamo_reducer)
+    print("1st pass dynamo reduction completed")
+
+    # Apply the reducer one more time to force any lingering
+    # data to get pushed into DynamoDB.
+    final_reduction_output = dynReducer.dynamo_reducer(
+        reduction_output, EMPTY_TUPLE, force_write=True
+    )
+    return final_reduction_output
+
+
+def run_etljob(
+    spark,
+    run_date,
+    region_name,
+    table_name,
+    sample_rate,
+    aws_access_key_id,
+    aws_secret_access_key,
+):
+
+    reduction_output = etl(
+        spark,
+        run_date,
+        region_name,
+        table_name,
+        sample_rate,
+        aws_access_key_id,
+        aws_secret_access_key,
+    )
+    report_data = (reduction_output[0], reduction_output[1])
+    print("=" * 40)
+    print(
+        "%d records inserted to DynamoDB.\n%d records remaining in queue." % report_data
+    )
+    print("=" * 40)
+    return reduction_output
+
+
+class DynamoProxy:
+    """
+    This class tests to make sure we can read
+    """
+
+    def __init__(self, region, table):
+        self._conn = boto3.resource("dynamodb", region_name=region, config=BOTO_CFG)
+        self._table = self._conn.Table(table)
+
+    def scan_page(self):
+        response = self._table.scan()
+        for item in response["Items"]:
+            compressed_bytes = item["json_payload"].value
+            json_byte_data = zlib.decompress(compressed_bytes)
+            json_str_data = json_byte_data.decode("utf8")
+            yield json.loads(json_str_data)
+
+    def check_sentinel(self):
+        client_id = "write_sentinel"
+        response = self._table.get_item(Key={"client_id": client_id})
+        compressed_bytes = response["Item"]["json_payload"].value
+        json_byte_data = zlib.decompress(compressed_bytes)
+        json_str_data = json_byte_data.decode("utf8")
+        return json.loads(json_str_data)
+
+    def inject_record(self):
+        with self._table.batch_writer(overwrite_by_pkeys=["client_id"]) as batch:
+            item = {"update_time": datetime.datetime.now().isoformat()}
+            print("Writing: {}".format(item["update_time"]))
+            payload = zlib.compress(
+                json.dumps(item, default=json_serial).encode("utf8")
+            )
+            item = {"client_id": "write_sentinel", "json_payload": payload}
+            batch.put_item(Item=item)
+
+    def item_count(self):
+        print("Approximate row count: {:d}".format(self._table.item_count))
+
+
+@click.command()
+@click.option("--date", required=True)  # YYYYMMDD
+@click.option("--aws_access_key_id", required=True)
+@click.option("--aws_secret_access_key", required=True)
+@click.option("--region", default="us-west-2")
+@click.option("--table", default="taar_addon_data_20180206")
+@click.option("--sample-rate", default=0)
+def main(date, aws_access_key_id, aws_secret_access_key, region, table, sample_rate):
+
+    # Clobber the AWS access credentials
+    os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id
+    os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key
+
+    APP_NAME = "TaarDynamo"
+    conf = SparkConf().setAppName(APP_NAME)
+    spark = SparkSession.builder.config(conf=conf).getOrCreate()
+    date_obj = datetime.strptime(date, "%Y%m%d") - PATCH_DAYS
+
+    reduction_output = run_etljob(
+        spark,
+        date_obj,
+        region,
+        table,
+        sample_rate,
+        aws_access_key_id,
+        aws_secret_access_key,
+    )
+    pprint(reduction_output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* added options for master and worker disk type and size
* dataproc should really be operated with only pd-ssd disk types and >
  1TB drives.
* added explicit 10 retry configuration for boto3+dynamodb
* added custom exponential backoff around the batch write
  as boto3 does not seem to backoff quite enough