### PR TITLE
Fix initialization of timeout param in bq_sensor

### DIFF
--- a/dags/operators/bq_sensor.py
+++ b/dags/operators/bq_sensor.py
@@ -53,7 +53,10 @@ class BigQuerySQLSensorOperator(BaseSensorOperator):
                  *args,
                  **kwargs):
 
-        super(BaseSensorOperator, self).__init__(timeout=timeout, *args, **kwargs)
+        super(BigQuerySQLSensorOperator, self).__init__(
+            timeout=timeout,
+            *args,
+            **kwargs)
         self.sql = sql
         self.bigquery_conn_id = bigquery_conn_id
         self.use_legacy_sql = use_legacy_sql


### PR DESCRIPTION
The current super(...) call goes one class too far in the hierarchy, so we
never initialize the timeout param in BaseSensorOperator.

Currently, these waiting tasks only work correctly if the target is ready the
first time it's checked. If it's not ready, an exception is thrown rather
than going into a loop for waiting.

In practice, we see the amplitude wait tasks fail twice and then usually succeed
on the third try, only because the query is finally ready by then.