### PR TITLE
Cleans out old GKE pods

### DIFF
--- a/dags/clean_pods.py
+++ b/dags/clean_pods.py
@@ -1,0 +1,50 @@
+from airflow import DAG
+from datetime import timedelta, datetime
+from operators.gcp_container_operator import GKEPodOperator
+
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
+default_args = {
+    'owner': 'hwoo@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2019, 12, 26),
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+dag = DAG("clean-pods", default_args=default_args, schedule_interval="@weekly")
+
+gcp_conn_id = "google_cloud_derived_datasets"
+connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
+
+gke_location="us-central1-a"
+gke_cluster_name="bq-load-gke-1"
+
+# Built from cloudops-infra repo, projects/airflow/pod-clean
+# TODO - which project should host the image built? they both work
+#docker_image='gcr.io/moz-fx-dataops-images-global/airflow-pod-clean:latest'
+docker_image='gcr.io/moz-fx-data-airflow-prod-88e0/airflow-pod-clean:latest'
+
+docker_args = [
+    '--project', 'moz-fx-data-derived-datasets',
+    '--gke-cluster', gke_cluster_name,
+    '--region', gke_location,
+    '--retention-days', '14',
+    '--dry-run', 'False'
+]
+
+clean_pods = GKEPodOperator(
+    task_id="clean-pods",
+    gcp_conn_id=gcp_conn_id,
+    project_id=connection.project_id,
+    location=gke_location,
+    cluster_name=gke_cluster_name,
+    name='clean-pods',
+    namespace='default',
+    image=docker_image,
+    arguments=docker_args,
+    email=['hwoo@mozilla.com'],
+    dag=dag)
+

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -63,7 +63,6 @@ with DAG('probe_scraper',
         # Give additional time since we will likely always scale up when running this job
         startup_timeout_seconds=360,
         image=probe_scraper_image,
-        is_delete_operator_pod=True,
         arguments=probe_scraper_args,
         email=['telemetry-client-dev@mozilla.com', 'aplacitelli@mozilla.com', 'frank@mozilla.com', 'hwoo@mozilla.com'],
         env_vars={
@@ -82,7 +81,6 @@ with DAG('probe_scraper',
         name='schema-generator-1',
         namespace='default',
         image='mozilla/mozilla-schema-generator:latest',
-        is_delete_operator_pod=True,
         image_pull_policy='Always',
         env_vars={
             "MPS_SSH_KEY_BASE64": "{{ var.value.mozilla_pipeline_schemas_secret_git_sshkey_b64 }}",


### PR DESCRIPTION
Gke has a pod limit of 1k. Old finished GKEPodOperator runs count towards this limit and must be cleaned

related https://github.com/mozilla-services/cloudops-infra/pull/1720