### PR TITLE
Set entrypoint in mozilla/python_mozaggregator image to bash

### DIFF
--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -107,6 +107,7 @@ mobile_aggregate_view_dataproc = SubDagOperator(
 if EXPORT_TO_AVRO:
     gke_command(
         task_id="export_mobile_metrics_avro",
+        cmds=["bash"],
         command=[
             "bin/export-avro.sh",
             "moz-fx-data-shared-prod",
@@ -122,6 +123,7 @@ if EXPORT_TO_AVRO:
 
     gke_command(
         task_id="export_saved_session_avro",
+        cmds=["bash"],
         command=[
             "bin/export-avro.sh",
             "moz-fx-data-shared-prod",


### PR DESCRIPTION
The job currently fails with the the following error:

```
[2020-01-02 20:56:42,515] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,514] {pod_launcher.py:181} INFO - Event with job id export-mobile-metrics-avro-37e155bc Failed
[2020-01-02 20:56:42,596] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,595] {pod_launcher.py:104} INFO -   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load
[2020-01-02 20:56:42,596] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,596] {pod_launcher.py:104} INFO -     return self.load_wsgiapp()
[2020-01-02 20:56:42,598] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,598] {pod_launcher.py:104} INFO -   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
[2020-01-02 20:56:42,598] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,598] {pod_launcher.py:104} INFO -     return util.import_app(self.app_uri)
[2020-01-02 20:56:42,600] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,600] {pod_launcher.py:104} INFO -   File "/usr/local/lib/python3.7/site-packages/gunicorn/util.py", line 350, in import_app
[2020-01-02 20:56:42,601] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,601] {pod_launcher.py:104} INFO -     __import__(module)
[2020-01-02 20:56:42,602] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,602] {pod_launcher.py:104} INFO - ModuleNotFoundError: No module named 'bin/export-avro'
[2020-01-02 20:56:42,603] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,603] {pod_launcher.py:104} INFO - [2020-01-02 20:56:41 +0000] [10] [INFO] Worker exiting (pid: 10)
[2020-01-02 20:56:42,604] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,604] {pod_launcher.py:104} INFO - [2020-01-02 20:56:41 +0000] [1] [INFO] Shutting down: Master
[2020-01-02 20:56:42,605] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,605] {pod_launcher.py:104} INFO - [2020-01-02 20:56:41 +0000] [1] [INFO] Reason: Worker failed to boot.
[2020-01-02 20:56:42,682] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,682] {pod_launcher.py:121} INFO - Event: export-mobile-metrics-avro-37e155bc had an event of type Failed
[2020-01-02 20:56:42,683] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,683] {pod_launcher.py:181} INFO - Event with job id export-mobile-metrics-avro-37e155bc Failed
[2020-01-02 20:56:42,726] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,725] {pod_launcher.py:121} INFO - Event: export-mobile-metrics-avro-37e155bc had an event of type Failed
[2020-01-02 20:56:42,726] {logging_mixin.py:95} INFO - [2020-01-02 20:56:42,726] {pod_launcher.py:181} INFO - Event with job id export-mobile-metrics-avro-37e155bc Failed
```

In https://github.com/mozilla/python_mozaggregator/pull/206, the `--entrypoint bash` option is added to override the default gunicorn entrypoint. This is necessary here, too.

Reference for the `cmds` kubernetes keyword argument: https://airflow.readthedocs.io/en/stable/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html#airflow.contrib.operators.kubernetes_pod_operator.KubernetesPodOperator