### PR TITLE
mobile_aggregates - Add parenthesis to ensure proper evaluation order

### DIFF
--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -87,14 +87,16 @@ mobile_aggregate_view_dataproc = SubDagOperator(
             "--num-partitions",
             str(5 * 32),
         ]
-        + ["--source", "bigquery", "--project-id", "moz-fx-data-shared-prod"]
-        if not EXPORT_TO_AVRO
-        else [
-            "--source",
-            "avro",
-            "--avro-prefix",
-            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/moz-fx-data-shared-prod",
-        ],
+        + (
+            ["--source", "bigquery", "--project-id", "moz-fx-data-shared-prod"]
+            if not EXPORT_TO_AVRO
+            else [
+                "--source",
+                "avro",
+                "--avro-prefix",
+                "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/moz-fx-data-shared-prod",
+            ]
+        ),
         gcp_conn_id=gcp_conn.gcp_conn_id,
         service_account=client_email,
         artifact_bucket=artifact_bucket,


### PR DESCRIPTION
```
Exception:
Google DataProc job has state: ERROR: Job failed with message [Error: no such option: --source]. Additional details can be found at 'https://console.cloud.google.com/dataproc/jobs/mobile_aggregates_d36ecb8e?project=airflow-dataproc®ion=global'.
```

Operations are evaluated left to right. I had intended this to be something like `[1] + [2] if False else [3] == [1,3]`, but instead I got `[3]`. 