### PR TITLE
Mobile aggregates - Fix "org.apache.spark.sql.AnalysisException: Failed to find data source: avro"

### DIFF
--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -70,7 +70,8 @@ mobile_aggregate_view_dataproc = SubDagOperator(
             "gs://dataproc-initialization-actions/python/pip-install.sh"
         ],
         additional_properties={
-            "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest.jar"
+            "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest.jar",
+            "spark:spark.jars.packages": "org.apache.spark:spark-avro_2.11:2.4.4",
         },
         additional_metadata={
             "PIP_PACKAGES": "git+https://github.com/mozilla/python_mozaggregator.git"


### PR DESCRIPTION
```
Running job for 20200102
Traceback (most recent call last):
  File "/usr/lib/spark/python/lib/pyspark.zip/pyspark/sql/utils.py", line 63, in deco
  File "/usr/lib/spark/python/lib/py4j-0.10.7-src.zip/py4j/protocol.py", line 328, in get_return_value
py4j.protocol.Py4JJavaError: An error occurred while calling o52.load.
: org.apache.spark.sql.AnalysisException: Failed to find data source: avro. Avro is built-in but external data source module since Spark 2.4. Please deploy the application as per the deployment section of "Apache Avro Data Source Guide".;
	at org.apache.spark.sql.execution.datasources.DataSource$.lookupDataSource(DataSource.scala:647)
```
https://console.cloud.google.com/dataproc/jobs/mobile_aggregates_5f7fd77a?project=airflow-dataproc&region=global

This PR adds the relevant spark configuration for the Dataproc cluster, as set in the standalone runner script:

https://github.com/mozilla/python_mozaggregator/blob/e1a76808fb2c39af920a7ec5d784293d6186545d/bin/dataproc.sh#L64