### PR TITLE
Add saved_session export for mozaggregator_prerelease

### DIFF
--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -116,7 +116,7 @@ if EXPORT_TO_AVRO:
             "bin/export-avro.sh",
             "moz-fx-data-shared-prod",
             "moz-fx-data-shared-prod:analysis",
-            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator",
+            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/mobile",
             "mobile_metrics_v1",
             '""',
             "{{ ds }}",
@@ -132,7 +132,7 @@ if EXPORT_TO_AVRO:
             "bin/export-avro.sh",
             "moz-fx-data-shared-prod",
             "moz-fx-data-shared-prod:analysis",
-            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator",
+            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/mobile",
             "saved_session_v4",
             "'nightly', 'beta'",
             "{{ ds }}",
@@ -144,7 +144,7 @@ if EXPORT_TO_AVRO:
     GoogleCloudStorageDeleteOperator(
         task_id="delete_mobile_metrics_avro",
         bucket_name="moz-fx-data-derived-datasets-parquet-tmp",
-        prefix="avro/mozaggregator/moz-fx-data-shared-prod/{{ ds_nodash }}/mobile_metrics_v1",
+        prefix="avro/mozaggregator/mobile/moz-fx-data-shared-prod/{{ ds_nodash }}/mobile_metrics_v1",
         gcp_conn_id=gcp_conn.gcp_conn_id,
         dag=dag
     ).set_upstream(mobile_aggregate_view_dataproc)
@@ -152,7 +152,7 @@ if EXPORT_TO_AVRO:
     GoogleCloudStorageDeleteOperator(
         task_id="delete_saved_session_avro",
         bucket_name="moz-fx-data-derived-datasets-parquet-tmp",
-        prefix="avro/mozaggregator/moz-fx-data-shared-prod/{{ ds_nodash }}/saved_session_v4",
+        prefix="avro/mozaggregator/mobile/moz-fx-data-shared-prod/{{ ds_nodash }}/saved_session_v4",
         gcp_conn_id=gcp_conn.gcp_conn_id,
         dag=dag
     ).set_upstream(mobile_aggregate_view_dataproc)

--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -96,7 +96,7 @@ mobile_aggregate_view_dataproc = SubDagOperator(
                 "--source",
                 "avro",
                 "--avro-prefix",
-                "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/moz-fx-data-shared-prod",
+                "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/mobile/moz-fx-data-shared-prod",
             ]
         ),
         gcp_conn_id=gcp_conn.gcp_conn_id,

--- a/dags/mozaggregator_prerelease.py
+++ b/dags/mozaggregator_prerelease.py
@@ -109,7 +109,7 @@ prerelease_telemetry_aggregate_view_dataproc = SubDagOperator(
                 "--source",
                 "avro",
                 "--avro-prefix",
-                "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/moz-fx-data-shared-prod",
+                "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/prerelease/moz-fx-data-shared-prod",
             ]
         ),
         gcp_conn_id=gcp_conn.gcp_conn_id,
@@ -129,8 +129,24 @@ if EXPORT_TO_AVRO:
             "bin/export-avro.sh",
             "moz-fx-data-shared-prod",
             "moz-fx-data-shared-prod:analysis",
-            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator",
+            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/prerelease",
             "main_v4",
+            "'nightly', 'beta'",
+            "{{ ds }}",
+        ],
+        docker_image="mozilla/python_mozaggregator:latest",
+        dag=dag,
+    ).set_downstream(prerelease_telemetry_aggregate_view_dataproc)
+
+    gke_command(
+        task_id="export_saved_session_avro",
+        cmds=["bash"],
+        command=[
+            "bin/export-avro.sh",
+            "moz-fx-data-shared-prod",
+            "moz-fx-data-shared-prod:analysis",
+            "gs://moz-fx-data-derived-datasets-parquet-tmp/avro/mozaggregator/prerelease",
+            "saved_session_v4",
             "'nightly', 'beta'",
             "{{ ds }}",
         ],
@@ -142,9 +158,17 @@ if EXPORT_TO_AVRO:
     GoogleCloudStorageDeleteOperator(
         task_id="delete_main_avro",
         bucket_name="moz-fx-data-derived-datasets-parquet-tmp",
-        prefix="avro/mozaggregator/moz-fx-data-shared-prod/{{ ds_nodash }}/main_v4",
+        prefix="avro/mozaggregator/prerelease/moz-fx-data-shared-prod/{{ ds_nodash }}/main_v4",
         gcp_conn_id=gcp_conn.gcp_conn_id,
         dag=dag,
+    ).set_upstream(prerelease_telemetry_aggregate_view_dataproc)
+
+    GoogleCloudStorageDeleteOperator(
+        task_id="delete_saved_session_avro",
+        bucket_name="moz-fx-data-derived-datasets-parquet-tmp",
+        prefix="avro/mozaggregator/prerelease/moz-fx-data-shared-prod/{{ ds_nodash }}/saved_session_v4",
+        gcp_conn_id=gcp_conn.gcp_conn_id,
+        dag=dag
     ).set_upstream(prerelease_telemetry_aggregate_view_dataproc)
 
 # copy over artifacts if we're running in dev


### PR DESCRIPTION
This PR exports the saved_session ping for prerelease aggregates. This also adds an additional namespace to the path so the mobile aggregates and prerelease aggregates can run without interference of each other. 