### PR TITLE
Default GKE to always pull images

### DIFF
--- a/dags/operators/gcp_container_operator.py
+++ b/dags/operators/gcp_container_operator.py
@@ -27,6 +27,9 @@ class GKEPodOperator(UpstreamGKEPodOperator):
     - Preserve XCOM result when xcom_push is True.
 
     """
+    def __init__(self, image_pull_policy='Always', *args,  **kwargs):
+        super(GKEPodOperator, self).__init__(image_pull_policy=image_pull_policy, *args, **kwargs)
+
     def execute(self, context):
         # If gcp_conn_id is not specified gcloud will use the default
         # service account credentials.


### PR DESCRIPTION
Suggesting we default `image_pull_policy` to `Always`. This is a major footgun for existing GKE jobs; we would expect `latest` to always pull (per kubernetes), but that doesn't seem to be the case if `image_pull_policy` isn't set correctly.