### PR TITLE
Bug 1590144 - DAG for running missioncontrol-etl (WIP)

### DIFF
--- a/dags/mission_control.py
+++ b/dags/mission_control.py
@@ -49,7 +49,7 @@ with DAG('missioncontrol',
         # Due to the nature of the container run, we set get_logs to False,
         # To avoid urllib3.exceptions.ProtocolError: 'Connection broken: IncompleteRead(0 bytes read)' errors
         # Where the pod continues to run, but airflow loses its connection and sets the status to Failed
-        # get_logs=False,
+        get_logs=False,
         # Give additional time since we will likely always scale up when running this job
         startup_timeout_seconds=360,
         image=docker_image,

--- a/dags/mission_control.py
+++ b/dags/mission_control.py
@@ -1,0 +1,81 @@
+from airflow import DAG
+from datetime import timedelta, datetime
+from operators.gcp_container_operator import GKEPodOperator
+
+from airflow.contrib.hooks.aws_hook import AwsHook
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from airflow.contrib.kubernetes.pod import Resources
+from airflow.operators.sensors import ExternalTaskSensor
+
+default_args = {
+    'owner': 'wlachance@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2019, 12, 30),
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=5),
+}
+
+with DAG('missioncontrol',
+         default_args=default_args,
+         schedule_interval='@daily') as dag:
+
+    gcp_conn_id = "google_cloud_derived_datasets"
+    connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
+
+    gke_location="us-central1-a"
+    gke_cluster_name="bq-load-gke-1"
+
+    # Built from repo https://github.com/mozilla/missioncontrol-v2
+    docker_image='gcr.io/wlach-test-258214/missioncontrol-etl:latest'
+
+    # Cluster autoscaling works on pod resource requests, instead of usage
+    resources = Resources(request_memory='32G', request_cpu='8',
+                          limit_memory='48G', limit_cpu='16')
+
+    missioncontrol_etl = GKEPodOperator(
+        task_id="missioncontrol_etl",
+        gcp_conn_id=gcp_conn_id,
+        project_id=connection.project_id,
+        location=gke_location,
+        cluster_name=gke_cluster_name,
+        name='missioncontrol-etl',
+        namespace='default',
+        # Needed to scale the highcpu pool from 0 -> 1
+        resources=resources,
+        # This job requires a node with a large number of cores to complete in a reasonable amount of time, thus the highcpu node pool
+        # node_selectors={"nodepool" : "highcpu"},
+        # Due to the nature of the container run, we set get_logs to False,
+        # To avoid urllib3.exceptions.ProtocolError: 'Connection broken: IncompleteRead(0 bytes read)' errors
+        # Where the pod continues to run, but airflow loses its connection and sets the status to Failed
+        # get_logs=False,
+        # Give additional time since we will likely always scale up when running this job
+        startup_timeout_seconds=360,
+        image=docker_image,
+        is_delete_operator_pod=True,
+        arguments=[
+            '/mc-etl/complete.runner.sh'
+        ],
+        email=['wlachance@mozilla.com', 'hwoo@mozilla.com'],
+        env_vars={
+            'GCP_PROJECT_ID': connection.project_id,
+            'GCS_OUTPUT_PREFIX': 'gs://missioncontrol-v2',
+            'RAW_OUTPUT_TABLE': 'missioncontrol_v2_raw_data_test',
+            'MODEL_OUTPUT_TABLE': 'missioncontrol_v2_model_output_test',
+            'SIMPLE': '0'
+        },
+        dag=dag)
+
+    # this task depends on clients daily (and telemetry.crash, but we
+    # figure that should be in place by the time this runs)
+    #wait_for_clients_daily = ExternalTaskSensor(
+    #    task_id="wait_for_clients_daily",
+    #    project_id="moz-fx-data-shared-prod",
+    #    external_dag_id="main_summary",
+    #    external_task_id="clients_daily",
+    #    check_existence=True,
+    #    dag=dag,
+    #)
+
+    # wait_for_clients_daily >> missioncontrol_etl


### PR DESCRIPTION
This is the basic airflow job for running the [missioncontrol-v2 job](https://github.com/mozilla/missioncontrol-v2). It requires a fair amount of memory and CPU, so we'll probably need to create a new nodepool for it to run in (like the probe scraper) which spins up and down as necessary. 

Unfortunately it doesn't presently work when I test it locally in non-simple mode, ending halfway through with this error:

```
[2020-01-21 19:09:44,861] {logging_mixin.py:95} INFO - [2020-01-21 19:09:44,861] {pod_launcher.py:104} INFO - 2:      Linux    beta    2020-01-12
[2020-01-21 19:09:44,861] {logging_mixin.py:95} INFO - [2020-01-21 19:09:44,861] {pod_launcher.py:104} INFO - 3: Windows_NT    beta    2020-01-12
[2020-01-21 19:09:44,862] {logging_mixin.py:95} INFO - [2020-01-21 19:09:44,862] {pod_launcher.py:104} INFO -            os channel UsingDateTill
[2020-01-21 19:09:44,863] {logging_mixin.py:95} INFO - [2020-01-21 19:09:44,863] {pod_launcher.py:104} INFO - 1:     Darwin nightly    2020-01-12
[2020-01-21 19:09:44,863] {logging_mixin.py:95} INFO - [2020-01-21 19:09:44,863] {pod_launcher.py:104} INFO - 2:      Linux nightly    2020-01-12
[2020-01-21 19:09:44,864] {logging_mixin.py:95} INFO - [2020-01-21 19:09:44,864] {pod_launcher.py:104} INFO - 3: Windows_NT nightly    2020-01-12
[2020-01-21 19:09:44,864] {logging_mixin.py:95} INFO - [2020-01-21 19:09:44,864] {pod_launcher.py:104} INFO - 2020-01-21 19:09:44 INFO::Started Release Models, simple.mode = 0
[2020-01-21 19:15:12,926] {models.py:1788} ERROR - ('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/airflow/models.py", line 1657, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/app/dags/operators/gcp_container_operator.py", line 60, in execute
    result = super(UpstreamGKEPodOperator, self).execute(context)
  File "/usr/local/lib/python2.7/site-packages/airflow/contrib/operators/kubernetes_pod_operator.py", line 133, in execute
    get_logs=self.get_logs)
  File "/usr/local/lib/python2.7/site-packages/airflow/contrib/kubernetes/pod_launcher.py", line 90, in run_pod
    return self._monitor_pod(pod, get_logs)
  File "/usr/local/lib/python2.7/site-packages/airflow/contrib/kubernetes/pod_launcher.py", line 103, in _monitor_pod
    for line in logs:
  File "/usr/local/lib/python2.7/site-packages/urllib3/response.py", line 796, in __iter__
    for chunk in self.stream(decode_content=True):
  File "/usr/local/lib/python2.7/site-packages/urllib3/response.py", line 560, in stream
    for line in self.read_chunked(amt, decode_content=decode_content):
  File "/usr/local/lib/python2.7/site-packages/urllib3/response.py", line 781, in read_chunked
    self._original_response.close()
  File "/usr/local/lib/python2.7/contextlib.py", line 35, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python2.7/site-packages/urllib3/response.py", line 443, in _error_catcher
    raise ProtocolError("Connection broken: %r" % e, e)
ProtocolError: ('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))
[2020-01-21 19:15:12,933] {models.py:1811} INFO - Marking task as UP_FOR_RETRY
```

I am very confused about what's going on since it runs fine inside a docker container allocated on a google cloud instance (at least if the instance is sufficiently large). Am I specifying the resource constraints incorrectly so that it's not allocating enough to the container in the pod? It's very hard to tell what's going on. From the kubernetes console I am not seeing any graphs of either CPU/memory use or any stackdriver logs...