### PR TITLE
Update python script locations from templates/ to sql/ directory

### DIFF
--- a/dags/attitudes_daily.py
+++ b/dags/attitudes_daily.py
@@ -29,7 +29,7 @@ with models.DAG(
         task_id="surveygizmo_attitudes_daily_import",
         command=[
             "python",
-            "templates/telemetry_derived/surveygizmo_daily_attitudes/import_responses.py",
+            "sql/telemetry_derived/surveygizmo_daily_attitudes/import_responses.py",
             "--date",
             "{{ ds }}",
             "--survey_id",

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -78,7 +78,7 @@ with models.DAG(
         task_id=gen_query_task_id,
         command=[
             "python",
-            "templates/telemetry_derived/experiment_enrollment_aggregates_live/view.sql.py",
+            "sql/telemetry_derived/experiment_enrollment_aggregates_live/view.sql.py",
             "--submission-date",
             "{{ ds }}",
             "--json-output",

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -155,7 +155,7 @@ addon_aggregates = bigquery_etl_query(
 
 main_summary_experiments_get_experiment_list = gke_command(
     task_id="main_summary_experiments_get_experiment_list",
-    command=["python3", "templates/telemetry_derived/experiments_v1/get_experiment_list.py", "{{ds}}"],
+    command=["python3", "sql/telemetry_derived/experiments_v1/get_experiment_list.py", "{{ds}}"],
     docker_image="mozilla/bigquery-etl:latest",
     xcom_push=True,
     owner="ssuh@mozilla.com",


### PR DESCRIPTION
Cleanup of dangling references to the `templates` directory (which caused some failing jobs over the weekend) as a follow-up to mozilla/bigquery-etl#723