### PR TITLE
Add vng to email notifications list for taar_daily DAG

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -35,7 +35,7 @@ default_args = {
     "owner": "vng@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 10, 7),
-    "email": ["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com"],
+    "email": ["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com", "vng@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 3,


### PR DESCRIPTION
I thought the owner is notified about failures but turns out vng is not in the recipient list of failure emails :man_shrugging: 