### PR TITLE
Update document sample for appends

### DIFF
--- a/dags/document_sample.py
+++ b/dags/document_sample.py
@@ -6,7 +6,7 @@ from utils.gcp import bigquery_etl_query
 default_args = {
     "owner": "amiyaguchi@mozilla.com",
     "depends_on_past": False,
-    "start_date": datetime(2019, 12, 4),
+    "start_date": datetime(2020, 2, 17),
     "email": ["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
@@ -20,5 +20,7 @@ document_sample_nonprod_v1 = bigquery_etl_query(
     destination_table="document_sample_nonprod_v1",
     dataset_id="monitoring",
     project_id="moz-fx-data-shared-prod",
+    date_partition_parameter=None,
+    arguments=("--append_table"),
     dag=dag,
 )


### PR DESCRIPTION
The errors table is now available for airflow and CI to run queries on. The document sample DAG fails because of the default partitioning set in the `bigquery_etl_query` function. This table does not need partitioning set, since no no two runs will be the same and the query takes into account the timestamp of the run.

https://github.com/mozilla/telemetry-airflow/blob/757bc75c2068652ae758ad69d5e881ae3e1792a6/dags/utils/gcp.py#L443-L458

Error with existing table:
```
[2020-02-19 00:35:19,149] {logging_mixin.py:95} INFO - [2020-02-19 00:35:19,149] {pod_launcher.py:104} INFO - BigQuery error in query operation: Error processing job 'moz-fx-data-shared-
[2020-02-19 00:35:19,150] {logging_mixin.py:95} INFO - [2020-02-19 00:35:19,150] {pod_launcher.py:104} INFO - prod:bqjob_r600c9b56ae7d74d1_000001705aded5de_1': Cannot add storage to a non-
[2020-02-19 00:35:19,152] {logging_mixin.py:95} INFO - [2020-02-19 00:35:19,152] {pod_launcher.py:104} INFO - partitioned table with a partition reference: moz-fx-data-shared-
[2020-02-19 00:35:19,153] {logging_mixin.py:95} INFO - [2020-02-19 00:35:19,152] {pod_launcher.py:104} INFO - prod:monitoring.document_sample_nonprod_v1
```

and error with no table:
```
[2020-02-19 00:49:53,402] {logging_mixin.py:95} INFO - [2020-02-19 00:49:53,402] {pod_launcher.py:104} INFO - BigQuery error in query operation: Error processing job 'moz-fx-data-shared-
[2020-02-19 00:49:53,404] {logging_mixin.py:95} INFO - [2020-02-19 00:49:53,404] {pod_launcher.py:104} INFO - prod:bqjob_r1fcd9459006828ad_000001705aec2945_1': Partitioning specification
[2020-02-19 00:49:53,405] {logging_mixin.py:95} INFO - [2020-02-19 00:49:53,405] {pod_launcher.py:104} INFO - must be provided in order to create partitioned table
```

