### PR TITLE
Remove some dag warnings

### DIFF
--- a/dags/bq_events_to_amplitude.py
+++ b/dags/bq_events_to_amplitude.py
@@ -12,14 +12,14 @@ default_args = {
     'email_on_retry': True,
     'retries': 2,
     'retry_delay': datetime.timedelta(minutes=10),
-    'schedule_interval': '0 1 * * *',
 }
 
 dag_name = 'bq_events_to_amplitude'
 
 with models.DAG(
         dag_name,
-        default_args=default_args) as dag:
+        default_args=default_args,
+        schedule_interval='0 1 * * *') as dag:
 
     fenix_task_id = 'fenix_amplitude_export'
     SubDagOperator(

--- a/dags/prio/processor.py
+++ b/dags/prio/processor.py
@@ -59,7 +59,6 @@ DEFAULT_ARGS = {
     "email_on_retry": True,
     "retries": 0,
     "retry_delay": timedelta(minutes=5),
-    "schedule_interval": "@daily",
     "dagrun_timeout": timedelta(hours=4),
 }
 
@@ -94,8 +93,7 @@ BUCKET_BOOTSTRAP_ADMIN = "moz-fx-data-{}-prio-bootstrap".format(ENVIRONMENT)
 
 # https://airflow.apache.org/faq.html#how-can-my-airflow-dag-run-faster
 # max_active_runs controls the number of DagRuns at a given time.
-dag = DAG(dag_id="prio_processor", max_active_runs=1, default_args=DEFAULT_ARGS)
-
+dag = DAG(dag_id="prio_processor", max_active_runs=1, default_args=DEFAULT_ARGS, schedule_interval="@daily")
 
 # Copy the dependencies necessary for running the `prio-processor staging` job
 # into the relevant GCS locations. This includes the runner and the egg


### PR DESCRIPTION
 when schedule_interval is used as a task parameter rather than a dag parameter