### PR TITLE
Use default executor to run tasks in parallel in SubDags.

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -5,6 +5,7 @@ from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.contrib.operators.bigquery_to_gcs import BigQueryToCloudStorageOperator
 from airflow.operators.sensors import ExternalTaskSensor
 from airflow.operators.subdag_operator import SubDagOperator
+from airflow.executors import get_default_executor
 
 from airflow.contrib.operators.gcs_delete_operator import GoogleCloudStorageDeleteOperator
 from glam_subdags.histograms import histogram_aggregates_subdag
@@ -154,6 +155,7 @@ clients_histogram_aggregates = SubDagOperator(
     dag.schedule_interval,
     dataset_id),
   task_id=GLAM_CLIENTS_HISTOGRAM_AGGREGATES_SUBDAG,
+  executor=get_default_executor(),
   dag=dag)
 
 clients_histogram_bucket_counts = bigquery_etl_query(

--- a/dags/glam_subdags/histograms.py
+++ b/dags/glam_subdags/histograms.py
@@ -1,6 +1,7 @@
 from airflow.models import DAG
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.subdag_operator import SubDagOperator
+from airflow.executors import get_default_executor
 
 from glam_subdags.general import repeated_subdag
 from utils.gcp import bigquery_etl_query
@@ -44,6 +45,7 @@ def histogram_aggregates_subdag(
             dataset_id,
         ),
         task_id=GLAM_HISTOGRAM_AGGREGATES_OLD_SUBDAG,
+        executor=get_default_executor(),
         dag=dag,
     )
 
@@ -56,6 +58,7 @@ def histogram_aggregates_subdag(
             dataset_id,
         ),
         task_id=GLAM_HISTOGRAM_AGGREGATES_MERGED_SUBDAG,
+        executor=get_default_executor(),
         dag=dag,
     )
 
@@ -68,6 +71,7 @@ def histogram_aggregates_subdag(
             dataset_id,
         ),
         task_id=GLAM_HISTOGRAM_AGGREGATES_FINAL_SUBDAG,
+        executor=get_default_executor(),
         dag=dag,
     )
 


### PR DESCRIPTION
In my local tests, this seemed to allow tasks to run concurrently in a subdag.