### PR TITLE
Remove outdated emails

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -122,7 +122,7 @@ with models.DAG(
         project_id='moz-fx-data-shared-prod',
         destination_table='core_clients_daily_v1',
         dataset_id='telemetry_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
     core_clients_last_seen = bigquery_etl_query(
@@ -131,7 +131,7 @@ with models.DAG(
         destination_table='core_clients_last_seen_v1',
         dataset_id='telemetry_derived',
         depends_on_past=True,
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
     # Daily and last seen views on top of Fenix pings (deprecated);
@@ -144,7 +144,7 @@ with models.DAG(
         project_id='moz-fx-data-shared-prod',
         destination_table='clients_daily_v1',
         dataset_id='org_mozilla_fenix_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
     fenix_clients_last_seen = bigquery_etl_query(
@@ -153,7 +153,7 @@ with models.DAG(
         destination_table='clients_last_seen_v1',
         dataset_id='org_mozilla_fenix_derived',
         depends_on_past=True,
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
     # Daily and last seen views on top of Fenix pings;
@@ -225,7 +225,7 @@ with models.DAG(
         task_id='firefox_nondesktop_exact_mau28',
         destination_table='firefox_nondesktop_exact_mau28_raw_v1',
         dataset_id='telemetry',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
     smoot_usage_nondesktop_v2 = bigquery_etl_query(

--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -7,7 +7,7 @@ from utils.gcp import bigquery_etl_query
 default_args = {
     'owner': 'jklukas@mozilla.com',
     'start_date': datetime.datetime(2019, 3, 1),
-    'email': ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com'],
+    'email': ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     'email_on_failure': True,
     'email_on_retry': True,
     'depends_on_past': False,

--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -27,7 +27,7 @@ with models.DAG(
         destination_table='firefox_kpi_dashboard_v1',
         dataset_id='telemetry',
         date_partition_parameter=None,
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'pmcdermott@mozilla.com', 'dzielaski@mozilla.com', 'jmundi@mozilla.com']
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com']
     )
 
     smoot_usage_new_profiles_v2 = bigquery_etl_query(

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -71,7 +71,7 @@ main_summary = bigquery_etl_query(
     sql_file_path="sql/telemetry_derived/main_summary_v4/",
     multipart=True,
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com"],
     start_date=datetime(2019, 10, 25),
     dag=dag)
 
@@ -159,7 +159,7 @@ clients_daily = bigquery_etl_query(
     project_id="moz-fx-data-shared-prod",
     dataset_id="telemetry_derived",
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com"],
     start_date=datetime(2019, 11, 5),
     dag=dag)
 
@@ -221,7 +221,7 @@ clients_last_seen = bigquery_etl_query(
     project_id="moz-fx-data-shared-prod",
     dataset_id="telemetry_derived",
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "jklukas@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "jklukas@mozilla.com"],
     depends_on_past=True,
     start_date=datetime(2019, 4, 15),
     dag=dag)
@@ -231,7 +231,7 @@ exact_mau_by_dimensions = bigquery_etl_query(
     destination_table="firefox_desktop_exact_mau28_by_dimensions_v1",
     dataset_id="telemetry",
     owner="relud@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "pmcdermott@mozilla.com", "dzielaski@mozilla.com", "jmundi@mozilla.com"],
+    email=["telemetry-alerts@mozilla.com", "relud@mozilla.com"],
     dag=dag)
 
 exact_mau_by_client_count_dimensions = bigquery_etl_query(


### PR DESCRIPTION
There was a group of folks involved with KPI reporting in 2019 who no longer need to be alerted about failures in these tasks.