### PR TITLE
Remove fxa_oauth_events query

### DIFF
--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -45,13 +45,6 @@ with models.DAG(
         arguments=('--schema_update_option=ALLOW_FIELD_ADDITION',),
     )
 
-    fxa_oauth_events = bigquery_etl_query(
-        task_id='fxa_oauth_events',
-        destination_table='fxa_oauth_events_v1',
-        dataset_id='telemetry',
-        arguments=('--schema_update_option=ALLOW_FIELD_ADDITION',),
-    )
-
     fxa_users_daily = bigquery_etl_query(
         task_id='fxa_users_daily',
         destination_table='fxa_users_daily_v1',
@@ -61,7 +54,6 @@ with models.DAG(
     fxa_users_daily << fxa_auth_events
     fxa_users_daily << fxa_auth_bounce_events
     fxa_users_daily << fxa_content_events
-    fxa_users_daily << fxa_oauth_events
 
     fxa_users_last_seen = bigquery_etl_query(
         task_id='fxa_users_last_seen',
@@ -121,7 +113,6 @@ with models.DAG(
     fxa_users_services_daily << fxa_auth_events
     fxa_users_services_daily << fxa_auth_bounce_events
     fxa_users_services_daily << fxa_content_events
-    fxa_users_services_daily << fxa_oauth_events
 
     fxa_users_services_first_seen = bigquery_etl_query(
         task_id='fxa_users_services_first_seen',
@@ -140,7 +131,6 @@ with models.DAG(
     fxa_users_services_first_seen << fxa_auth_events
     fxa_users_services_first_seen << fxa_auth_bounce_events
     fxa_users_services_first_seen << fxa_content_events
-    fxa_users_services_first_seen << fxa_oauth_events
 
     fxa_users_services_last_seen = bigquery_etl_query(
         task_id='fxa_users_services_last_seen',


### PR DESCRIPTION
Closes https://github.com/mozilla/bigquery-etl/issues/785

This should get us unstuck without having to change anything in bigquery-etl.
The fxa_oauth_events_v1 table in shared-prod will continue to exist, but just
won't receive any more updates.

I will follow up with a bigquery-etl PR to add commentary that marks the
query as deprecated.