### PR TITLE
Factor out clients_daily_* as subdags and generate these queries daily.

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -10,6 +10,10 @@ from airflow.executors import get_default_executor
 from airflow.operators.sensors import ExternalTaskSensor
 from airflow.operators.subdag_operator import SubDagOperator
 
+from glam_subdags.daily_aggregates import (
+    daily_scalar_aggregates_subdag,
+    daily_histogram_aggregates_subdag,
+)
 from glam_subdags.histograms import histogram_aggregates_subdag
 from utils.gcp import bigquery_etl_query
 
@@ -34,6 +38,8 @@ glam_bucket = "glam-dev-bespoke-nonprod-dataops-mozgcp-net"
 
 GLAM_DAG = "glam"
 GLAM_CLIENTS_HISTOGRAM_AGGREGATES_SUBDAG = "clients_histogram_aggregates"
+GLAM_CLIENTS_DAILY_SCALAR_AGGREGATES_SUBDAG = "clients_daily_scalar_aggregates"
+GLAM_CLIENTS_DAILY_HISTOGRAM_AGGREGATES_SUBDAG = "clients_daily_histogram_aggregates"
 
 dag = DAG(GLAM_DAG, default_args=default_args, schedule_interval="@daily")
 
@@ -66,57 +72,16 @@ latest_versions = bigquery_etl_query(
     dag=dag,
 )
 
-# This task runs first and replaces the relevant partition, followed
-# by the next two tasks that append to the same partition of the same table.
-clients_daily_scalar_aggregates = bigquery_etl_query(
-    task_id="clients_daily_scalar_aggregates",
-    destination_table="clients_daily_scalar_aggregates_v1",
-    dataset_id=dataset_id,
-    project_id=project_id,
-    owner="msamuel@mozilla.com",
-    email=[
-        "telemetry-alerts@mozilla.com",
-        "msamuel@mozilla.com",
-        "robhudson@mozilla.com",
-    ],
-    dag=dag,
-)
-
-sql_file_path = "sql/{}/{}/query.sql".format(
-    dataset_id, "clients_daily_keyed_scalar_aggregates_v1"
-)
-clients_daily_keyed_scalar_aggregates = bigquery_etl_query(
-    task_id="clients_daily_keyed_scalar_aggregates",
-    destination_table="clients_daily_scalar_aggregates_v1",
-    sql_file_path=sql_file_path,
-    dataset_id=dataset_id,
-    project_id=project_id,
-    owner="msamuel@mozilla.com",
-    email=[
-        "telemetry-alerts@mozilla.com",
-        "msamuel@mozilla.com",
-        "robhudson@mozilla.com",
-    ],
-    arguments=("--append_table", "--noreplace",),
-    dag=dag,
-)
-
-sql_file_path = "sql/{}/{}/query.sql".format(
-    dataset_id, "clients_daily_keyed_boolean_aggregates_v1"
-)
-clients_daily_keyed_boolean_aggregates = bigquery_etl_query(
-    task_id="clients_daily_keyed_boolean_aggregates",
-    destination_table="clients_daily_scalar_aggregates_v1",
-    sql_file_path=sql_file_path,
-    dataset_id=dataset_id,
-    project_id=project_id,
-    owner="msamuel@mozilla.com",
-    email=[
-        "telemetry-alerts@mozilla.com",
-        "msamuel@mozilla.com",
-        "robhudson@mozilla.com",
-    ],
-    arguments=("--append_table", "--noreplace",),
+clients_daily_scalar_aggregates = SubDagOperator(
+    subdag=daily_scalar_aggregates_subdag(
+        GLAM_DAG,
+        GLAM_CLIENTS_DAILY_SCALAR_AGGREGATES_SUBDAG,
+        default_args,
+        dag.schedule_interval,
+        dataset_id,
+    ),
+    task_id=GLAM_CLIENTS_DAILY_SCALAR_AGGREGATES_SUBDAG,
+    executor=get_default_executor(),
     dag=dag,
 )
 
@@ -170,38 +135,16 @@ clients_scalar_bucket_counts = bigquery_etl_query(
     dag=dag,
 )
 
-# This task runs first and replaces the relevant partition, followed
-# by the next task below that appends to the same partition of the same table.
-clients_daily_histogram_aggregates = bigquery_etl_query(
-    task_id="clients_daily_histogram_aggregates",
-    destination_table="clients_daily_histogram_aggregates_v1",
-    dataset_id=dataset_id,
-    project_id=project_id,
-    owner="msamuel@mozilla.com",
-    email=[
-        "telemetry-alerts@mozilla.com",
-        "msamuel@mozilla.com",
-        "robhudson@mozilla.com",
-    ],
-    dag=dag,
-)
-
-sql_file_path = "sql/{}/{}/query.sql".format(
-    dataset_id, "clients_daily_keyed_histogram_aggregates_v1"
-)
-clients_daily_keyed_histogram_aggregates = bigquery_etl_query(
-    task_id="clients_daily_keyed_histogram_aggregates",
-    destination_table="clients_daily_histogram_aggregates_v1",
-    sql_file_path=sql_file_path,
-    dataset_id=dataset_id,
-    project_id=project_id,
-    owner="msamuel@mozilla.com",
-    email=[
-        "telemetry-alerts@mozilla.com",
-        "msamuel@mozilla.com",
-        "robhudson@mozilla.com",
-    ],
-    arguments=("--append_table", "--noreplace",),
+clients_daily_histogram_aggregates = SubDagOperator(
+    subdag=daily_histogram_aggregates_subdag(
+        GLAM_DAG,
+        GLAM_CLIENTS_DAILY_HISTOGRAM_AGGREGATES_SUBDAG,
+        default_args,
+        dag.schedule_interval,
+        dataset_id,
+    ),
+    task_id=GLAM_CLIENTS_DAILY_HISTOGRAM_AGGREGATES_SUBDAG,
+    executor=get_default_executor(),
     dag=dag,
 )
 
@@ -346,16 +289,12 @@ glam_extract_to_csv = BigQueryToCloudStorageOperator(
 wait_for_main_ping >> latest_versions
 
 latest_versions >> clients_daily_scalar_aggregates
-clients_daily_scalar_aggregates >> clients_daily_keyed_scalar_aggregates
-clients_daily_scalar_aggregates >> clients_daily_keyed_boolean_aggregates
-clients_daily_keyed_boolean_aggregates >> clients_scalar_aggregates
-clients_daily_keyed_scalar_aggregates >> clients_scalar_aggregates
+clients_daily_scalar_aggregates >> clients_scalar_aggregates
 clients_scalar_aggregates >> clients_scalar_bucket_counts
 clients_scalar_aggregates >> scalar_percentiles
 
 latest_versions >> clients_daily_histogram_aggregates
-clients_daily_histogram_aggregates >> clients_daily_keyed_histogram_aggregates
-clients_daily_keyed_histogram_aggregates >> clients_histogram_aggregates
+clients_daily_histogram_aggregates >> clients_histogram_aggregates
 
 clients_histogram_aggregates >> clients_histogram_bucket_counts
 clients_histogram_aggregates >> glam_user_counts

--- a/dags/glam_subdags/daily_aggregates.py
+++ b/dags/glam_subdags/daily_aggregates.py
@@ -1,0 +1,114 @@
+from airflow import DAG
+
+from utils.gcp import gke_command, bigquery_xcom_query
+
+dags = {}
+
+
+def generate_tasks_for_clients_daily(
+    metric_type, agg_type, dataset_id, dag, arguments=()
+):
+    gen_query_task_id = "clients_daily_{}_aggregates_generate_query".format(agg_type)
+
+    # setting xcom_push to True outputs this query to an xcom
+    generate_query = gke_command(
+        task_id=gen_query_task_id,
+        command=[
+            "python",
+            "sql/telemetry_derived/clients_daily_{}_aggregates_v1.sql.py".format(
+                metric_type
+            ),
+            "--agg-type",
+            agg_type,
+        ],
+        docker_image="mozilla/bigquery-etl:latest",
+        xcom_push=True,
+        owner="msamuel@mozilla.com",
+        email=[
+            "telemetry-alerts@mozilla.com",
+            "msamuel@mozilla.com",
+            "robhudson@mozilla.com",
+        ],
+        dag=dags[dag],
+    )
+
+    run_query = bigquery_xcom_query(
+        task_id="clients_daily_{}_aggregates_run_query".format(agg_type),
+        destination_table="clients_daily_{}_aggregates_v1".format(metric_type),
+        dataset_id=dataset_id,
+        xcom_task_id=gen_query_task_id,
+        owner="msamuel@mozilla.com",
+        email=[
+            "telemetry-alerts@mozilla.com",
+            "msamuel@mozilla.com",
+            "robhudson@mozilla.com",
+        ],
+        arguments=arguments,
+        dag=dags[dag],
+    )
+    generate_query >> run_query
+    return run_query
+
+
+def daily_scalar_aggregates_subdag(
+    parent_dag_name, child_dag_name, default_args, schedule_interval, dataset_id
+):
+    GLAM_DAILY_SCALAR_AGGREGATES_SUBDAG = "%s.%s" % (parent_dag_name, child_dag_name)
+    dags[GLAM_DAILY_SCALAR_AGGREGATES_SUBDAG] = DAG(
+        GLAM_DAILY_SCALAR_AGGREGATES_SUBDAG,
+        default_args=default_args,
+        schedule_interval=schedule_interval,
+    )
+
+    # This task runs first and replaces the relevant partition, followed
+    # by the next two tasks that append to the same partition of the same table.
+    clients_daily_scalar_aggregates = generate_tasks_for_clients_daily(
+        "scalar", "scalars", dataset_id, GLAM_DAILY_SCALAR_AGGREGATES_SUBDAG,
+    )
+    clients_daily_keyed_scalar_aggregates = generate_tasks_for_clients_daily(
+        "scalar",
+        "keyed_scalars",
+        dataset_id,
+        GLAM_DAILY_SCALAR_AGGREGATES_SUBDAG,
+        ("--append_table", "--noreplace",),
+    )
+    clients_daily_keyed_boolean_aggregates = generate_tasks_for_clients_daily(
+        "scalar",
+        "keyed_booleans",
+        dataset_id,
+        GLAM_DAILY_SCALAR_AGGREGATES_SUBDAG,
+        ("--append_table", "--noreplace",),
+    )
+
+    clients_daily_scalar_aggregates >> clients_daily_keyed_scalar_aggregates
+    clients_daily_scalar_aggregates >> clients_daily_keyed_boolean_aggregates
+
+    return dags[GLAM_DAILY_SCALAR_AGGREGATES_SUBDAG]
+
+
+def daily_histogram_aggregates_subdag(
+    parent_dag_name, child_dag_name, default_args, schedule_interval, dataset_id
+):
+    GLAM_DAILY_HISTOGRAM_AGGREGATES_SUBDAG = "%s.%s" % (parent_dag_name, child_dag_name)
+    dags[GLAM_DAILY_HISTOGRAM_AGGREGATES_SUBDAG] = DAG(
+        GLAM_DAILY_HISTOGRAM_AGGREGATES_SUBDAG,
+        default_args=default_args,
+        schedule_interval=schedule_interval,
+    )
+
+    # This task runs first and replaces the relevant partition, followed
+    # by the next task below that appends to the same partition of the same table.
+    clients_daily_histogram_aggregates = generate_tasks_for_clients_daily(
+        "histogram", "histograms", dataset_id, GLAM_DAILY_HISTOGRAM_AGGREGATES_SUBDAG
+    )
+    clients_daily_keyed_histogram_aggregates = generate_tasks_for_clients_daily(
+        "histogram",
+        "keyed_histograms",
+        dataset_id,
+        GLAM_DAILY_HISTOGRAM_AGGREGATES_SUBDAG,
+        ("--append_table", "--noreplace",),
+    )
+
+    clients_daily_histogram_aggregates >> clients_daily_keyed_histogram_aggregates
+
+    return dags[GLAM_DAILY_HISTOGRAM_AGGREGATES_SUBDAG]


### PR DESCRIPTION
This PR is mainly doing 2 things:

1. All clients daily processing now generates the sql queries on the fly that it needs before running them. This means that new probes added would be included daily (https://github.com/mozilla/bigquery-etl/issues/760).

2. Factors out `clients_daily_*` tasks into scalar and histogram subdags