### PR TITLE
Move addons tasks to write into shared-prod

### DIFF
--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -142,12 +142,14 @@ register_status(main_summary, "Main Summary", "A summary view of main pings.")
 addons = bigquery_etl_query(
     task_id="addons",
     destination_table="addons_v2",
+    project_id="moz-fx-data-shared-prod",
     dataset_id="telemetry_derived",
     dag=dag)
 
 addon_aggregates = bigquery_etl_query(
     task_id="addon_aggregates",
     destination_table="addon_aggregates_v2",
+    project_id="moz-fx-data-shared-prod",
     dataset_id="telemetry_derived",
     owner="bmiroglio@mozilla.com",
     email=["telemetry-alerts@mozilla.com", "bmiroglio@mozilla.com"],


### PR DESCRIPTION
With this change and https://github.com/mozilla/telemetry-airflow/pull/889 we will no longer be writing any new data into `moz-fx-data-derived-datasets:telemetry_derived`.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1612541