### PR TITLE
Fix #891 - Use snake_cased cluster definition to match protobuf

### DIFF
--- a/dags/utils/gke.py
+++ b/dags/utils/gke.py
@@ -49,7 +49,7 @@ def create_gke_config(
                     "service_account": service_account,
                     "labels": {"owner": owner_label, "team": team_label},
                     "preemptible": preemptible,
-                    "diskType": disk_type,
+                    "disk_type": disk_type,
                 },
                 "initial_node_count": 1,
                 "autoscaling": {

--- a/dags/utils/gke.py
+++ b/dags/utils/gke.py
@@ -13,27 +13,31 @@ def create_gke_config(
 ):
 
     """
-    Helper function to create gke cluster definition dict.
-    See https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster
+    Helper function to create gke cluster definition dict. All fields must match
+    their protobuf definitions.
 
-    owner and team labels  can contain only lowercase letters, numeric characters,
+    See:
+        https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster
+        https://googleapis.dev/python/container/latest/gapic/v1/types.html#google.cloud.container_v1.types.Cluster
+    owner and team labels can contain only lowercase letters, numeric characters,
     underscores, and dashes. E.g. owner_label='hwoo', team_label='dataops'
 
     """
 
     cluster_def_dict = {
         "name": name,
+        "initial_node_count": None,
         # Setting `{"enabled": true}` will open the GKE cluster to the world.
         # This is config is disabled when run locally, otherwise job submissions
         # will fail.
-        "masterAuthorizedNetworksConfig": {"enabled": not is_dev},
-        "nodePools": [
+        "master_authorized_networks_config": {"enabled": not is_dev},
+        "node_pools": [
             {
                 "name": name,
                 "config": {
-                    "machineType": machine_type,
-                    "diskSizeGb": disk_size_gb,
-                    "oauthScopes": [
+                    "machine_type": machine_type,
+                    "disk_size_gb": disk_size_gb,
+                    "oauth_scopes": [
                         "https://www.googleapis.com/auth/bigquery",
                         "https://www.googleapis.com/auth/devstorage.read_write",
                         "https://www.googleapis.com/auth/logging.write",
@@ -42,13 +46,17 @@ def create_gke_config(
                         "https://www.googleapis.com/auth/servicecontrol",
                         "https://www.googleapis.com/auth/trace.append",
                     ],
-                    "serviceAccount": service_account,
+                    "service_account": service_account,
                     "labels": {"owner": owner_label, "team": team_label},
                     "preemptible": preemptible,
                     "diskType": disk_type,
                 },
-                "initialNodeCount": 1,
-                "autoscaling": {"enabled": True, "minNodeCount": 1, "maxNodeCount": 5},
+                "initial_node_count": 1,
+                "autoscaling": {
+                    "enabled": True,
+                    "min_node_count": 1,
+                    "max_node_count": 5,
+                },
             }
         ],
         "locations": [location],


### PR DESCRIPTION
This fixes #891. When tested locally, the DAG now fails in a new location.

