### PR TITLE
Move dashboard and amplitude ETL to shared-prod tables

### DIFF
--- a/dags/bq_events_to_amplitude.py
+++ b/dags/bq_events_to_amplitude.py
@@ -27,7 +27,7 @@ with models.DAG(
             dag_name=fenix_task_id,
             parent_dag_name=dag_name,
             default_args=default_args,
-            project='moz-fx-data-derived-datasets',
+            project='moz-fx-data-shared-prod',
             dataset='telemetry',
             table_or_view='fenix_events_v1',
             s3_prefix='fenix',

--- a/jobs/hardware_report.py
+++ b/jobs/hardware_report.py
@@ -717,7 +717,7 @@ def get_data_bigquery(spark, chunk_start, chunk_end):
 
     print("Query is: " + filtered_data_sql)
 
-    TABLE_PROJECT = "moz-fx-data-derived-datasets"
+    TABLE_PROJECT = "moz-fx-data-shared-prod"
     TABLE_DATASET = "analysis"
     TABLE_NAME = "hardware_report_filtered_data"
 

--- a/jobs/update_orphaning_dashboard_etl.py
+++ b/jobs/update_orphaning_dashboard_etl.py
@@ -99,7 +99,7 @@ print("latest_ver_date_str : " + latest_ver_date_str)
 
 ##################################### BEGIN LONGITUDINAL SHIM ##########################################################
 GCS_TABLE_DUMP_PATH = f"gs://{args.gcs_bucket}/{args.gcs_prefix}/longitudinal-shim-dump/"
-AGGREGATION_TABLE_PROJECT = "moz-fx-data-derived-datasets"
+AGGREGATION_TABLE_PROJECT = "moz-fx-data-shared-prod"
 AGGREGATION_TABLE_DATASET = "analysis"
 AGGREGATION_TABLE_NAME = "out_of_date_longitudinal_shim"
 


### PR DESCRIPTION
We should be able to merge these changes immediately. They are internal details that don't need to hit derived-datasets anymore.