### PR TITLE
fixup! Use Auto Zone Placement for Dataproc clusters (#916)

### DIFF
--- a/dags/utils/dataproc.py
+++ b/dags/utils/dataproc.py
@@ -160,6 +160,7 @@ class DataProcHelper:
         return DataprocClusterDeleteOperator(
             task_id='delete_dataproc_cluster',
             cluster_name=self.cluster_name,
+            region=self.region,
             gcp_conn_id=self.gcp_conn_id,
             project_id=self.connection.project_id)
 # End DataProcHelper


### PR DESCRIPTION
This fixes #916 by setting region in cluster delete operation.

Delete operator uses [`global`](https://github.com/apache/airflow/blob/1.10.7/airflow/contrib/operators/dataproc_operator.py#L608) region by default which causes [failures](https://workflow.telemetry.mozilla.org/log?task_id=delete_dataproc_cluster&dag_id=update_orphaning_dashboard_etl.update_orphaning_dashboard_etl&execution_date=2020-03-23T02%3A00%3A00%2B00%3A00) in DAGs that use DataprocHelper.
