### PR TITLE
Add generic glean ETL

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -9,6 +9,9 @@ from utils.gcp import (bigquery_etl_copy_deduplicate,
                        gke_command,
                        bigquery_xcom_query)
 
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from operators.gcp_container_operator import GKEPodOperator
+
 default_args = {
     "owner": "jklukas@mozilla.com",
     "start_date": datetime.datetime(2019, 7, 25),
@@ -229,10 +232,39 @@ with models.DAG(
         email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
+    # Daily and last seen views on top of every Glean application.
+
+    gcp_conn_id = "google_cloud_derived_datasets"
+    baseline_etl_kwargs = dict(
+        gcp_conn_id=gcp_conn_id,
+        project_id=GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id).project_id,
+        location="us-central1-a",
+        cluster_name="bq-load-gke-1",
+        namespace="default",
+        image="mozilla/bigquery-etl:latest",
+    )
+    baseline_args = [
+        "--project-id=moz-fx-data-shared-prod",
+        "--date={{ ds }}",
+        "--only=*_stable.baseline_v1"
+    ]
+    baseline_clients_daily = GKEPodOperator(
+        task_id='baseline_clients_daily',
+        name='baseline-clients-daily',
+        arguments=["script/run_glean_baseline_clients_daily"] + baseline_args,
+        **baseline_etl_kwargs
+    )
+    baseline_clients_last_seen = GKEPodOperator(
+        task_id='baseline_clients_last_seen',
+        name='baseline-clients-last-seen',
+        arguments=["script/run_glean_baseline_clients_last_seen"] + baseline_args,
+        **baseline_etl_kwargs
+    )
+
     # Daily and last seen views on top of Fenix pings (deprecated);
     # these legacy tables consider both baseline and metrics pings as activity
     # and should be removed once GUD and KPI reporting consistently use the
-    # new org_mozilla_firefox tables.
+    # new baseline_clients_* tables.
 
     fenix_clients_daily = bigquery_etl_query(
         task_id='fenix_clients_daily',
@@ -251,8 +283,8 @@ with models.DAG(
         email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
     )
 
-    # Daily and last seen views on top of Fenix pings;
-    # these will replace the above
+    # Daily and last seen views on top of pings from all Fenix apps;
+    # these are also deprecated in favor of baseline_clients_* tables.
 
     org_mozilla_firefox_baseline_daily = bigquery_etl_query(
         task_id='org_mozilla_firefox_baseline_daily',
@@ -277,41 +309,6 @@ with models.DAG(
         dataset_id='org_mozilla_firefox_derived',
         depends_on_past=True,
         email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
-    )
-
-    # Daily and last seen views on top of VR browser pings.
-
-    vrbrowser_baseline_daily = bigquery_etl_query(
-        task_id='vrbrowser_baseline_daily',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='baseline_daily_v1',
-        dataset_id='org_mozilla_vrbrowser_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
-    )
-
-    vrbrowser_metrics_daily = bigquery_etl_query(
-        task_id='vrbrowser_metrics_daily',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='metrics_daily_v1',
-        dataset_id='org_mozilla_vrbrowser_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
-    )
-
-    vrbrowser_clients_daily = bigquery_etl_query(
-        task_id='vrbrowser_clients_daily',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='clients_daily_v1',
-        dataset_id='org_mozilla_vrbrowser_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
-    )
-
-    vrbrowser_clients_last_seen = bigquery_etl_query(
-        task_id='vrbrowser_clients_last_seen',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='clients_last_seen_v1',
-        dataset_id='org_mozilla_vrbrowser_derived',
-        depends_on_past=True,
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
     )
 
     # Aggregated nondesktop tables and their dependency chains.
@@ -360,21 +357,21 @@ with models.DAG(
      core_clients_last_seen >>
      nondesktop_aggregate_tasks)
 
+    (copy_deduplicate_all >>
+     baseline_clients_daily >>
+     baseline_clients_last_seen >>
+     nondesktop_aggregate_tasks)
+
     # TODO: Remove this dependency chain once we retire fenix_* tasks.
     (copy_deduplicate_all >>
      fenix_clients_daily >>
      fenix_clients_last_seen >>
      nondesktop_aggregate_tasks)
 
+    # TODO: Remove this dependency chain once we retire org_mozilla_firefox_* tasks.
     (copy_deduplicate_all >>
      [org_mozilla_firefox_baseline_daily, org_mozilla_firefox_metrics_daily] >>
      org_mozilla_firefox_clients_last_seen >>
-     nondesktop_aggregate_tasks)
-
-    (copy_deduplicate_all >>
-     [vrbrowser_baseline_daily, vrbrowser_metrics_daily] >>
-     vrbrowser_clients_daily >>
-     vrbrowser_clients_last_seen >>
      nondesktop_aggregate_tasks)
 
     # Nondesktop forecasts.

--- a/dags/incline_dash.py
+++ b/dags/incline_dash.py
@@ -26,7 +26,13 @@ with DAG('incline_dashboard',
         task_id="wait_for_baseline_clients_last_seen",
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_last_seen",
-        dag=dag)
+    )
+
+    wait_for_core_clients_last_seen = ExternalTaskSensor(
+        task_id="wait_for_core_clients_last_seen",
+        external_dag_id="copy_deduplicate",
+        external_task_id="core_clients_last_seen",
+    )
 
     project = "moz-fx-data-shared-prod"
     dataset = "org_mozilla_firefox_derived"
@@ -51,7 +57,7 @@ with DAG('incline_dashboard',
         dataset_id=dataset,
         owner="frank@mozilla.com",
         email=["telemetry-alerts@mozilla.com", "frank@mozilla.com"],
-        dag=dag)
+    )
 
     gcp_conn_id = 'google_cloud_derived_datasets'
     export_incline_dash = GKEPodOperator(
@@ -67,7 +73,7 @@ with DAG('incline_dashboard',
     )
 
     (
-        wait_for_baseline_clients_last_seen >>
+        [wait_for_baseline_clients_last_seen, wait_for_core_clients_last_seen] >>
         migrated_clients >>
         exec_dash >>
         export_incline_dash

--- a/dags/incline_dash.py
+++ b/dags/incline_dash.py
@@ -22,10 +22,10 @@ with DAG('incline_dashboard',
          default_args=default_args,
          schedule_interval="0 1 * * *") as dag:
 
-    wait_for_copy_deduplicate = ExternalTaskSensor(
-        task_id="wait_for_copy_deduplicate",
+    wait_for_baseline_clients_last_seen = ExternalTaskSensor(
+        task_id="wait_for_baseline_clients_last_seen",
         external_dag_id="copy_deduplicate",
-        external_task_id="copy_deduplicate_all",
+        external_task_id="baseline_clients_last_seen",
         dag=dag)
 
     project = "moz-fx-data-shared-prod"
@@ -67,7 +67,7 @@ with DAG('incline_dashboard',
     )
 
     (
-        wait_for_copy_deduplicate >>
+        wait_for_baseline_clients_last_seen >>
         migrated_clients >>
         exec_dash >>
         export_incline_dash


### PR DESCRIPTION
This will immediately replace the VR browser tables, but there will be follow-up steps to point all downstream Fenix ETL at this source as well, after which we can remove many deprecated tables.

Depends on https://github.com/mozilla/bigquery-etl/pull/887 and https://github.com/mozilla/bigquery-etl/pull/877