### PR TITLE
Bug 1627091  - Cast date column to a date

### DIFF
--- a/jobs/ltv_daily.py
+++ b/jobs/ltv_daily.py
@@ -164,7 +164,9 @@ def main(
 
     model_pred_data = model_pred_data.withColumn("predictions", predictions)
     model_perf_data["active_days"] = model_perf_data.index
-    model_perf_data_sdf = spark.createDataFrame(model_perf_data)
+    model_perf_data_sdf = spark.createDataFrame(model_perf_data).withColumn(
+        "date", F.to_date("date")
+    )
 
     (
         model_perf_data_sdf.write.format("bigquery")


### PR DESCRIPTION
The `partitionField` option doesn't work unless the field is actually a date. I tested this in a sandbox project and confirmed that the resulting table is partitioned. 