### PR TITLE
Use export instead of extract for glam_org_mozilla_fenix dag

### DIFF
--- a/dags/glam_org_mozilla_fenix.py
+++ b/dags/glam_org_mozilla_fenix.py
@@ -43,11 +43,11 @@ run_sql = gke_command(
     dag=dag,
 )
 
-extract_csv = gke_command(
-    task_id="extract_csv",
+export_csv = gke_command(
+    task_id="export_csv",
     cmds=["bash"],
     env_vars={"DATASET": "glam_etl"},
-    command=["script/glam/extract_csv"],
+    command=["script/glam/export_csv"],
     docker_image="mozilla/bigquery-etl:latest",
     gcp_conn_id="google_cloud_derived_datasets",
     dag=dag,
@@ -70,4 +70,4 @@ gcs_copy = GoogleCloudStorageToGoogleCloudStorageOperator(
     dag=dag,
 )
 
-wait_for_copy_deduplicate >> run_sql >> extract_csv >> gcs_delete >> gcs_copy
+wait_for_copy_deduplicate >> run_sql >> expoty_csv >> gcs_delete >> gcs_copy

--- a/dags/glam_org_mozilla_fenix.py
+++ b/dags/glam_org_mozilla_fenix.py
@@ -70,4 +70,4 @@ gcs_copy = GoogleCloudStorageToGoogleCloudStorageOperator(
     dag=dag,
 )
 
-wait_for_copy_deduplicate >> run_sql >> expoty_csv >> gcs_delete >> gcs_copy
+wait_for_copy_deduplicate >> run_sql >> export_csv >> gcs_delete >> gcs_copy


### PR DESCRIPTION
I made a typo that can only be tested in production:

```
[2020-04-14 20:37:05,402] {logging_mixin.py:112} INFO - [2020-04-14 20:37:05,401] {pod_launcher.py:234} INFO - Event with job id extract-csv-342c80ba Failed
[2020-04-14 20:37:05,486] {logging_mixin.py:112} INFO - [2020-04-14 20:37:05,486] {pod_launcher.py:125} INFO - bash: script/glam/extract_csv: No such file or directory
```