### PR TITLE
Reschedule vrbrowser_clients_daily

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -262,6 +262,43 @@ with models.DAG(
         **baseline_etl_kwargs
     )
 
+
+    # Daily and last seen views on top of VR browser pings.
+
+    vrbrowser_baseline_daily = bigquery_etl_query(
+        task_id='vrbrowser_baseline_daily',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='baseline_daily_v1',
+        dataset_id='org_mozilla_vrbrowser_derived',
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
+    )
+
+    vrbrowser_metrics_daily = bigquery_etl_query(
+        task_id='vrbrowser_metrics_daily',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='metrics_daily_v1',
+        dataset_id='org_mozilla_vrbrowser_derived',
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
+    )
+
+    vrbrowser_clients_daily = bigquery_etl_query(
+        task_id='vrbrowser_clients_daily',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='clients_daily_v1',
+        dataset_id='org_mozilla_vrbrowser_derived',
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
+    )
+
+    vrbrowser_clients_last_seen = bigquery_etl_query(
+        task_id='vrbrowser_clients_last_seen',
+        project_id='moz-fx-data-shared-prod',
+        destination_table='clients_last_seen_v1',
+        dataset_id='org_mozilla_vrbrowser_derived',
+        depends_on_past=True,
+        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com', 'ascholtz@mozilla.com'],
+    )
+
+
     # Aggregated nondesktop tables and their dependency chains.
 
     firefox_nondesktop_exact_mau28 = bigquery_etl_query(
@@ -312,6 +349,12 @@ with models.DAG(
      baseline_clients_daily >>
      baseline_clients_last_seen >>
      nondesktop_aggregate_tasks)
+
+    (copy_deduplicate_all >>
+     [vrbrowser_baseline_daily, vrbrowser_metrics_daily] >>
+     vrbrowser_clients_daily >>
+     vrbrowser_clients_last_seen)
+
 
     # Nondesktop forecasts.
 


### PR DESCRIPTION
These were descheduled in #940 in favor of generic Glean baseline ETL, but
VR Browser folks have existing dashboards which rely on some features here that
don't exist in the baseline-only ETL. We will continue to support this for now
until we develop a more robust strategy for incorporating per-product metrics
into the generic ETL.