### PR TITLE
Remove legacy Fenix ETL

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -262,56 +262,6 @@ with models.DAG(
         **baseline_etl_kwargs
     )
 
-    # Daily and last seen views on top of Fenix pings (deprecated);
-    # these legacy tables consider both baseline and metrics pings as activity
-    # and should be removed once GUD and KPI reporting consistently use the
-    # new baseline_clients_* tables.
-
-    fenix_clients_daily = bigquery_etl_query(
-        task_id='fenix_clients_daily',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='clients_daily_v1',
-        dataset_id='org_mozilla_fenix_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
-    )
-
-    fenix_clients_last_seen = bigquery_etl_query(
-        task_id='fenix_clients_last_seen',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='clients_last_seen_v1',
-        dataset_id='org_mozilla_fenix_derived',
-        depends_on_past=True,
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
-    )
-
-    # Daily and last seen views on top of pings from all Fenix apps;
-    # these are also deprecated in favor of baseline_clients_* tables.
-
-    org_mozilla_firefox_baseline_daily = bigquery_etl_query(
-        task_id='org_mozilla_firefox_baseline_daily',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='baseline_daily_v1',
-        dataset_id='org_mozilla_firefox_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
-    )
-
-    org_mozilla_firefox_metrics_daily = bigquery_etl_query(
-        task_id='org_mozilla_firefox_metrics_daily',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='metrics_daily_v1',
-        dataset_id='org_mozilla_firefox_derived',
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
-    )
-
-    org_mozilla_firefox_clients_last_seen = bigquery_etl_query(
-        task_id='org_mozilla_firefox_clients_last_seen',
-        project_id='moz-fx-data-shared-prod',
-        destination_table='clients_last_seen_v1',
-        dataset_id='org_mozilla_firefox_derived',
-        depends_on_past=True,
-        email=['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com'],
-    )
-
     # Aggregated nondesktop tables and their dependency chains.
 
     firefox_nondesktop_exact_mau28 = bigquery_etl_query(
@@ -361,18 +311,6 @@ with models.DAG(
     (copy_deduplicate_all >>
      baseline_clients_daily >>
      baseline_clients_last_seen >>
-     nondesktop_aggregate_tasks)
-
-    # TODO: Remove this dependency chain once we retire fenix_* tasks.
-    (copy_deduplicate_all >>
-     fenix_clients_daily >>
-     fenix_clients_last_seen >>
-     nondesktop_aggregate_tasks)
-
-    # TODO: Remove this dependency chain once we retire org_mozilla_firefox_* tasks.
-    (copy_deduplicate_all >>
-     [org_mozilla_firefox_baseline_daily, org_mozilla_firefox_metrics_daily] >>
-     org_mozilla_firefox_clients_last_seen >>
      nondesktop_aggregate_tasks)
 
     # Nondesktop forecasts.


### PR DESCRIPTION
As announced one week ago on fx-data-dev:

https://mail.mozilla.org/pipermail/fx-data-dev/2020-April/000339.html

I will plan to merge this, then respond to the thread indicating these table are no longer being updated and that the underlying data will be removed at the end of the week. Also, I'll announce that vrbrowser tables are sticking around as I received word that they are being actively used and we don't have a clear transition path.