### PR TITLE
Replace connection id for glam-dev-bespoke with airflow_dataproc

### DIFF
--- a/dags/glam_org_mozilla_fenix.py
+++ b/dags/glam_org_mozilla_fenix.py
@@ -49,7 +49,7 @@ export_csv = gke_command(
     env_vars={"DATASET": "glam_etl"},
     command=["script/glam/export_csv"],
     docker_image="mozilla/bigquery-etl:latest",
-    gcp_conn_id="google_cloud_derived_datasets",
+    gcp_conn_id="google_cloud_airflow_dataproc",
     dag=dag,
 )
 
@@ -57,7 +57,7 @@ gcs_delete = GoogleCloudStorageDeleteOperator(
     task_id="gcs_delete",
     bucket_name=glam_bucket,
     prefix="glam-extract-fenix",
-    gcp_conn_id="google_cloud_derived_datasets",
+    gcp_conn_id="google_cloud_airflow_dataproc",
     dag=dag,
 )
 
@@ -66,7 +66,7 @@ gcs_copy = GoogleCloudStorageToGoogleCloudStorageOperator(
     source_bucket="glam-fenix-dev",
     source_object="*.csv",
     destination_bucket=glam_bucket,
-    gcp_conn_id="google_cloud_derived_datasets",
+    gcp_conn_id="google_cloud_airflow_dataproc",
     dag=dag,
 )
 


### PR DESCRIPTION
See https://workflow.telemetry.mozilla.org/log?task_id=gcs_delete&dag_id=glam_org_mozilla_fenix&execution_date=2020-04-17T00%3A00%3A00%2B00%3A00 for example of a failure. This is caused by insufficient permissions on the `google_cloud_derived_datasets` connection. This should be resolved by changing it to use the `google_cloud_airflow_dataproc` connection. 