### PR TITLE
Fix shredder dag timing

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -5,7 +5,7 @@ from utils.gcp import gke_command
 default_args = {
     "owner": "dthorn@mozilla.com",
     "depends_on_past": True,
-    "start_date": datetime(2020, 3, 9),
+    "start_date": datetime(2020, 4, 7),
     "email": [
         "telemetry-alerts@mozilla.com",
         "dthorn@mozilla.com",
@@ -21,13 +21,19 @@ docker_image = "mozilla/bigquery-etl:latest"
 base_command = [
     "script/shredder_delete",
     "--state-table=moz-fx-data-shredder.shredder_state.shredder_state",
-    "--start-date={{'2019-11-20' if ds == '2020-03-09' else macros.ds_add(ds, -7*4*2)}}",
-    "--end-date={{ds}}",
+    # dags run schedule_interval after ds, and end date should be one day
+    # before the dag runs, so 28-1 = 27 days after ds.
+    "--end-date={{macros.ds_add(ds, 27)}}",
+    # start date should be two schedule intervals before end date, to avoid
+    # race conditions with downstream tables and pings received shortly after a
+    # deletion request.
+    "--start-date={{macros.ds_add(ds, 27-28*2)}}",
 ]
 
 # main_v4 is cheaper to handle in a project without flat-rate query pricing
 on_demand = gke_command(
     task_id="on_demand",
+    name="shredder-on-demand",
     command=base_command + [
         "--parallelism=2",
         "--billing-project=moz-fx-data-shredder",
@@ -42,6 +48,7 @@ on_demand = gke_command(
 # than 2 DML DELETE statements at once on a single table
 flat_rate_main_summary = gke_command(
     task_id="flat_rate_main_summary",
+    name="shredder-flat-rate-main-summary",
     command=base_command + [
         "--parallelism=2",
         "--billing-project=moz-fx-data-bq-batch-prod",
@@ -54,6 +61,7 @@ flat_rate_main_summary = gke_command(
 # everything else
 flat_rate = gke_command(
     task_id="flat_rate",
+    name="shredder-flat-rate",
     command=base_command + [
         "--parallelism=4",
         "--billing-project=moz-fx-data-bq-batch-prod",


### PR DESCRIPTION
This was misconfigured because I misunderstood how `schedule_interval` impacts `ds` relative to actual run date.

This should run on Tuesday mornings UTC every 28 days, with `--end-date` set to the day before the run actually started, and with `--start-date` set to two `schedule_interval`s before that.