### PR TITLE
client_histogram_probe_counts task should not have a date_partition_parameter for desktop glam.

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -289,6 +289,7 @@ client_histogram_probe_counts = SubDagOperator(
         default_args,
         dag.schedule_interval,
         dataset_id,
+        additional_params=("submission_date:DATE:{{ds}}",),
         date_partition_parameter=None,
     ),
     task_id="clients_histogram_probe_counts",

--- a/dags/glam.py
+++ b/dags/glam.py
@@ -289,6 +289,7 @@ client_histogram_probe_counts = SubDagOperator(
         default_args,
         dag.schedule_interval,
         dataset_id,
+        date_partition_parameter=None,
     ),
     task_id="clients_histogram_probe_counts",
     executor=get_default_executor(),

--- a/dags/glam_subdags/general.py
+++ b/dags/glam_subdags/general.py
@@ -4,7 +4,12 @@ from utils.gcp import bigquery_etl_query
 
 
 def repeated_subdag(
-    parent_dag_name, child_dag_name, default_args, schedule_interval, dataset_id
+    parent_dag_name,
+    child_dag_name,
+    default_args,
+    schedule_interval,
+    dataset_id,
+    date_partition_parameter="submission_date",
 ):
     dag = DAG(
         "%s.%s" % (parent_dag_name, child_dag_name),
@@ -29,6 +34,7 @@ def repeated_subdag(
             "min_sample_id:INT64:0",
             "max_sample_id:INT64:{}".format(PARTITION_SIZE - 1),
         ),
+        date_partition_parameter=date_partition_parameter,
         arguments=("--replace",),
         dag=dag,
     )
@@ -49,6 +55,7 @@ def repeated_subdag(
                 "min_sample_id:INT64:{}".format(min_param),
                 "max_sample_id:INT64:{}".format(max_param),
             ),
+            date_partition_parameter=date_partition_parameter,
             arguments=("--append_table", "--noreplace",),
             dag=dag,
         )


### PR DESCRIPTION
In recent changes, https://github.com/mozilla/telemetry-airflow/commit/33ef0949c411a3513939b868fac6cfec8509fd6e, `client_histogram_probe_counts` was changed to a `repeated_subdag` but lost the `date_partition_parameter=None,` parameter. So now the value is set to the default from here: https://github.com/mozilla/telemetry-airflow/blob/master/dags/utils/gcp.py#L458. This is an issue because the table being written to is not partitioned by date (or at all).

Also in recent changes, https://github.com/mozilla/bigquery-etl/commit/f41ee1a7b1026919ffef046cd513857520aa4d63#diff-3f2a16a41a4eccb0c207033901041bdcR161, `submission_date` was added as a parameter for `client_histogram_probe_counts` and it needs to be passed in 