### PR TITLE
Move sync send tab export to fxa_amplitude_export DAG

### DIFF
--- a/dags/bq_events_to_amplitude.py
+++ b/dags/bq_events_to_amplitude.py
@@ -83,19 +83,3 @@ with models.DAG(
         ),
         task_id=devtools_task_id
     )
-
-    sync_send_tab_task_id = 'sync_send_tab_amplitude_export'
-    sync_send_tab_args = default_args.copy()
-    sync_send_tab_args["start_date"] = datetime.datetime(2020, 4, 12)
-    SubDagOperator(
-        subdag=export_to_amplitude(
-            dag_name=sync_send_tab_task_id,
-            parent_dag_name=dag_name,
-            default_args=sync_send_tab_args,
-            project='moz-fx-data-shared-prod',
-            dataset='telemetry_derived',
-            table_or_view='sync_send_tab_events_v1',
-            s3_prefix='sync_send_tab',
-        ),
-        task_id=sync_send_tab_task_id
-    )

--- a/dags/fxa_amplitude_export.py
+++ b/dags/fxa_amplitude_export.py
@@ -58,11 +58,13 @@ with models.DAG(
     fxa_export_table_create >> fxa_amplitude_export
 
     sync_send_tab_task_id = 'sync_send_tab_amplitude_export'
+    sync_send_tab_args = default_args.copy()
+    sync_send_tab_args['email'] = ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com']
     sync_send_tab_export = SubDagOperator(
         subdag=export_to_amplitude(
             dag_name=sync_send_tab_task_id,
             parent_dag_name=dag_name,
-            default_args=default_args,
+            default_args=sync_send_tab_args,
             project='moz-fx-data-shared-prod',
             dataset='telemetry_derived',
             table_or_view='sync_send_tab_events_v1',

--- a/dags/fxa_amplitude_export.py
+++ b/dags/fxa_amplitude_export.py
@@ -56,3 +56,19 @@ with models.DAG(
     )
 
     fxa_export_table_create >> fxa_amplitude_export
+
+    sync_send_tab_task_id = 'sync_send_tab_amplitude_export'
+    sync_send_tab_export = SubDagOperator(
+        subdag=export_to_amplitude(
+            dag_name=sync_send_tab_task_id,
+            parent_dag_name=dag_name,
+            default_args=default_args,
+            project='moz-fx-data-shared-prod',
+            dataset='telemetry_derived',
+            table_or_view='sync_send_tab_events_v1',
+            s3_prefix='sync_send_tab',
+        ),
+        task_id=sync_send_tab_task_id
+    )
+
+    fxa_export_table_create >> sync_send_tab_export


### PR DESCRIPTION
As of https://github.com/mozilla/bigquery-etl/pull/966
this export now depends on the table created in this chain.