### PR TITLE
Use correct connection id for job running in docker

### DIFF
--- a/dags/glam_org_mozilla_fenix.py
+++ b/dags/glam_org_mozilla_fenix.py
@@ -49,7 +49,7 @@ export_csv = gke_command(
     env_vars={"DATASET": "glam_etl"},
     command=["script/glam/export_csv"],
     docker_image="mozilla/bigquery-etl:latest",
-    gcp_conn_id="google_cloud_airflow_dataproc",
+    gcp_conn_id="google_cloud_derived_datasets",
     dag=dag,
 )
 


### PR DESCRIPTION
This is causing job failures, causing aggregated fenix data to not be propagated into the nonprod bucket.