### PR TITLE
Convert desktop glam clients daily queries to gke commands

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -31,7 +31,7 @@ default_args = {
 
 GLAM_DAG = "glam"
 GLAM_CLIENTS_HISTOGRAM_AGGREGATES_SUBDAG = "clients_histogram_aggregates"
-PERCENT_RELEASE_WINDOWS_SAMPLING = 10
+PERCENT_RELEASE_WINDOWS_SAMPLING = "10"
 
 dag = DAG(GLAM_DAG, default_args=default_args, schedule_interval="@daily")
 


### PR DESCRIPTION
Goes with https://github.com/mozilla/bigquery-etl/pull/971

For the logging bug https://github.com/mozilla/telemetry-airflow/issues/844, the scalar queries have around 4-5 minutes of headroom before they crash (It looks like the tasks crash at around 9-10 minutes with no logging) so we can allow logs for those.  But the histogram queries go over so we would need to disable logs for those.