### PR TITLE
Fix schedule_interval in public_data DAG

### DIFF
--- a/dags/public_data.py
+++ b/dags/public_data.py
@@ -14,7 +14,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-with DAG("public_data", default_args=default_args, schedule_interval="0 6 * * *") as dag:
+with DAG("public_data", default_args=default_args, schedule_interval="0 1 * * *") as dag:
     docker_image = "mozilla/bigquery-etl:latest"
 
     public_data_gcs_metadata = gke_command(
@@ -35,7 +35,7 @@ with DAG("public_data", default_args=default_args, schedule_interval="0 6 * * *"
         task_id="wait_for_ssl_ratios",
         external_dag_id="ssl_ratios",
         external_task_id="ssl_ratios",
-        execution_delta=timedelta(hours=6),
+        execution_delta=timedelta(hours=1),
         dag=dag,
     )
 


### PR DESCRIPTION
I forgot to update the `schedule_interval` in the DAG for exporting public metadata after moving the anomdtc pipeline to a docker container.