### PR TITLE
Factor AMO stats queries to their own DAG

### DIFF
--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -1,0 +1,84 @@
+# Generated via query_scheduling/generate_airflow_dags
+
+from airflow import DAG
+from airflow.operators.sensors import ExternalTaskSensor
+import datetime
+from utils.gcp import bigquery_etl_query
+
+default_args = {
+    "owner": "jklukas@mozilla.com",
+    "start_date": datetime.datetime(2020, 6, 1, 0, 0),
+    "email": ["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=1800),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+}
+
+with DAG(
+    "bqetl_amo_stats", default_args=default_args, schedule_interval="0 1 * * *"
+) as dag:
+
+    amo_dev__amo_stats_dau__v1 = bigquery_etl_query(
+        task_id="amo_dev__amo_stats_dau__v1",
+        destination_table="amo_stats_dau_v1",
+        dataset_id="amo_dev",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    amo_dev__amo_stats_installs__v1 = bigquery_etl_query(
+        task_id="amo_dev__amo_stats_installs__v1",
+        destination_table="amo_stats_installs_v1",
+        dataset_id="amo_dev",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    amo_prod__amo_stats_dau__v1 = bigquery_etl_query(
+        task_id="amo_prod__amo_stats_dau__v1",
+        destination_table="amo_stats_dau_v1",
+        dataset_id="amo_prod",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    amo_prod__amo_stats_installs__v1 = bigquery_etl_query(
+        task_id="amo_prod__amo_stats_installs__v1",
+        destination_table="amo_stats_installs_v1",
+        dataset_id="amo_prod",
+        project_id="moz-fx-data-shared-prod",
+        owner="jklukas@mozilla.com",
+        email=["jklukas@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=False,
+        dag=dag,
+    )
+
+    amo_dev__amo_stats_dau__v1.set_upstream(amo_prod__amo_stats_dau__v1)
+
+    amo_dev__amo_stats_installs__v1.set_upstream(amo_prod__amo_stats_installs__v1)
+
+    wait_for_main_summary_clients_daily = ExternalTaskSensor(
+        task_id="wait_for_main_summary_clients_daily",
+        external_dag_id="main_summary",
+        external_task_id="clients_daily",
+        dag=dag,
+    )
+
+    amo_prod__amo_stats_dau__v1.set_upstream(wait_for_main_summary_clients_daily)
+
+    amo_prod__amo_stats_installs__v1.set_upstream(wait_for_main_summary_clients_daily)

--- a/dags/main_summary.py
+++ b/dags/main_summary.py
@@ -308,24 +308,6 @@ devtools_panel_usage = bigquery_etl_query(
     start_date=datetime(2019, 11, 25),
     dag=dag)
 
-amo_stats_dau = bigquery_etl_query(
-    task_id="amo_stats_dau",
-    destination_table="amo_stats_dau_v1",
-    project_id="moz-fx-data-shared-prod",
-    dataset_id="telemetry_derived",
-    owner="jklukas@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
-    dag=dag)
-
-amo_stats_installs = bigquery_etl_query(
-    task_id="amo_stats_installs",
-    destination_table="amo_stats_installs_v1",
-    project_id="moz-fx-data-shared-prod",
-    dataset_id="telemetry_derived",
-    owner="jklukas@mozilla.com",
-    email=["telemetry-alerts@mozilla.com", "jklukas@mozilla.com"],
-    dag=dag)
-
 search_clients_daily_bigquery = bigquery_etl_query(
     task_id="search_clients_daily_bigquery",
     destination_table="search_clients_daily_v8",
@@ -381,8 +363,6 @@ smoot_usage_desktop_v2.set_upstream(clients_last_seen)
 smoot_usage_desktop_compressed_v2.set_upstream(smoot_usage_desktop_v2)
 simpleprophet_forecasts_desktop.set_upstream(exact_mau_by_dimensions)
 devtools_panel_usage.set_upstream(clients_daily)
-amo_stats_dau.set_upstream(clients_daily)
-amo_stats_installs.set_upstream(clients_daily)
 
 search_clients_daily_bigquery.set_upstream(main_summary)
 search_aggregates_bigquery.set_upstream(search_clients_daily_bigquery)


### PR DESCRIPTION
This is the first DAG generated bigquery-etl that we're including here.
We're manually copying over the DAG for now, but eventually we will be
able to remove this definition from telemetry-airflow once WTMO automatically
imports bqetl-generated DAGs.