### PR TITLE
Use generated error_aggregates DAG

### DIFF
--- a/dags/bqetl_error_aggregates.py
+++ b/dags/bqetl_error_aggregates.py
@@ -1,4 +1,4 @@
-# Generated via query_scheduling/generate_airflow_dags
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor


### PR DESCRIPTION
This depends on https://github.com/mozilla/bigquery-etl/pull/1031

This is DAG is generated in bigquery-etl using the lower-friction scheduled queries machinery.
For now the DAG is copied manually, but eventually we will be
able to remove this definition from telemetry-airflow once WTMO automatically
imports bqetl-generated DAGs. 

The main difference here is that the error_aggregates table now has a version. So before merging, we'd need to create a `error_aggregates_v1` table in `telemetry_derived`, copy existing data over and create a `error_aggregates` view to make sure any queries that depend on `error_aggregates` don't break.