### PR TITLE
Set mode=reschedule and rename telemetry_derived__firefox_nondesktop_exact_mau28__v1

### DIFF
--- a/dags/bqetl_amo_stats.py
+++ b/dags/bqetl_amo_stats.py
@@ -1,4 +1,4 @@
-# Generated via query_scheduling/generate_airflow_dags
+# Generated via https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/query_scheduling/generate_airflow_dags.py
 
 from airflow import DAG
 from airflow.operators.sensors import ExternalTaskSensor
@@ -76,6 +76,8 @@ with DAG(
         task_id="wait_for_main_summary_clients_daily",
         external_dag_id="main_summary",
         external_task_id="clients_daily",
+        check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_core.py
+++ b/dags/bqetl_core.py
@@ -47,6 +47,7 @@ with DAG("bqetl_core", default_args=default_args, schedule_interval="0 1 * * *")
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_deviations.py
+++ b/dags/bqetl_deviations.py
@@ -40,6 +40,8 @@ with DAG(
         task_id="wait_for_anomdtct_anomdtct",
         external_dag_id="anomdtct",
         external_task_id="anomdtct",
+        check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_gud.py
+++ b/dags/bqetl_gud.py
@@ -95,6 +95,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 1 * * *") 
         external_dag_id="main_summary",
         external_task_id="clients_last_seen",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 
@@ -127,6 +128,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 1 * * *") 
         external_dag_id="bqetl_core",
         external_task_id="telemetry_derived__core_clients_last_seen__v1",
         check_existence=True,
+        mode="reschedule",
     )
 
     telemetry_derived__smoot_usage_nondesktop__v2.set_upstream(
@@ -137,6 +139,7 @@ with DAG("bqetl_gud", default_args=default_args, schedule_interval="0 1 * * *") 
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_last_seen",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_mobile_search.py
+++ b/dags/bqetl_mobile_search.py
@@ -49,6 +49,7 @@ with DAG(
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/bqetl_nondesktop.py
+++ b/dags/bqetl_nondesktop.py
@@ -32,9 +32,9 @@ with DAG(
         dag=dag,
     )
 
-    firefox_nondesktop_exact_mau28_by_client_count_dimensions = bigquery_etl_query(
-        task_id="firefox_nondesktop_exact_mau28_by_client_count_dimensions",
-        destination_table="firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1",
+    telemetry_derived__firefox_nondesktop_exact_mau28__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__firefox_nondesktop_exact_mau28__v1",
+        destination_table="firefox_nondesktop_exact_mau28_v1",
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="jklukas@mozilla.com",
@@ -44,9 +44,9 @@ with DAG(
         dag=dag,
     )
 
-    telemetry_derived__firefox_nondesktop_exact_mau28_raw__v1 = bigquery_etl_query(
-        task_id="telemetry_derived__firefox_nondesktop_exact_mau28_raw__v1",
-        destination_table="firefox_nondesktop_exact_mau28_raw_v1",
+    firefox_nondesktop_exact_mau28_by_client_count_dimensions = bigquery_etl_query(
+        task_id="firefox_nondesktop_exact_mau28_by_client_count_dimensions",
+        destination_table="firefox_nondesktop_exact_mau28_by_client_count_dimensions_v1",
         dataset_id="telemetry_derived",
         project_id="moz-fx-data-shared-prod",
         owner="jklukas@mozilla.com",
@@ -61,6 +61,7 @@ with DAG(
         external_dag_id="bqetl_core",
         external_task_id="telemetry_derived__core_clients_last_seen__v1",
         check_existence=True,
+        mode="reschedule",
     )
 
     telemetry_derived__firefox_nondesktop_day_2_7_activation__v1.set_upstream(
@@ -71,6 +72,7 @@ with DAG(
         external_dag_id="copy_deduplicate",
         external_task_id="baseline_clients_last_seen",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 
@@ -78,16 +80,16 @@ with DAG(
         wait_for_copy_deduplicate_baseline_clients_last_seen
     )
 
-    firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
+    telemetry_derived__firefox_nondesktop_exact_mau28__v1.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
     )
-    firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
+    telemetry_derived__firefox_nondesktop_exact_mau28__v1.set_upstream(
         wait_for_copy_deduplicate_baseline_clients_last_seen
     )
 
-    telemetry_derived__firefox_nondesktop_exact_mau28_raw__v1.set_upstream(
+    firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
         wait_for_telemetry_derived__core_clients_last_seen__v1
     )
-    telemetry_derived__firefox_nondesktop_exact_mau28_raw__v1.set_upstream(
+    firefox_nondesktop_exact_mau28_by_client_count_dimensions.set_upstream(
         wait_for_copy_deduplicate_baseline_clients_last_seen
     )

--- a/dags/bqetl_vrbrowser.py
+++ b/dags/bqetl_vrbrowser.py
@@ -77,6 +77,7 @@ with DAG(
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         check_existence=True,
+        mode="reschedule",
         dag=dag,
     )
 

--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -46,7 +46,7 @@ with models.DAG(
     wait_for_firefox_nondesktop_exact_mau28 = ExternalTaskSensor(
         task_id="wait_for_firefox_nondesktop_exact_mau28",
         external_dag_id="bqetl_nondesktop",
-        external_task_id="telemetry__firefox_nondesktop_exact_mau28_raw__v1",
+        external_task_id="telemetry_derived__firefox_nondesktop_exact_mau28__v1",
         check_existence=True,
         mode="reschedule",
         dag=dag,


### PR DESCRIPTION
Updated bqetl_nondesktop DAG generated by https://github.com/mozilla/bigquery-etl/pull/1050

Before merging, I'll rename the table `firefox_nondesktop_exact_mau28_raw_v1` to `firefox_nondesktop_exact_mau28_v1` in BigQuery and update the corresponding view in derived-datasets.