### PR TITLE
Fixup execution_delta for fxa mau in kpi_dashboard

### DIFF
--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -89,7 +89,7 @@ with models.DAG(
         external_dag_id="fxa_events",
         external_task_id="firefox_accounts_exact_mau28_raw",
         check_existence=True,
-        execution_delta=timedelta(hours=9),
+        execution_delta=timedelta(hours=-9),
         mode="reschedule",
         dag=dag,
     )

--- a/dags/kpi_dashboard.py
+++ b/dags/kpi_dashboard.py
@@ -95,3 +95,9 @@ with models.DAG(
     )
 
     simpleprophet_forecasts_fxa.set_upstream(wait_for_firefox_accounts_exact_mau28_raw)
+
+    kpi_dashboard.set_upstream([
+        simpleprophet_forecasts_desktop,
+        simpleprophet_forecasts_mobile,
+        simpleprophet_forecasts_fxa,
+    ])


### PR DESCRIPTION
This task is stuck in up_for_reschedule. It's looking for a task run on the
previous day at 16:00 rather than the current day at 10:00.