### PR TITLE
Add DAG for mozfun

### DIFF
--- a/dags/mozfun.py
+++ b/dags/mozfun.py
@@ -1,0 +1,24 @@
+from airflow import DAG
+from datetime import timedelta, datetime
+from utils.gcp import gke_command
+
+default_args = {
+    "owner": "ascholtz@mozilla.com",
+    "email": ["ascholtz@mozilla.com"],
+    "depends_on_past": False,
+    "start_date": datetime(2020, 6, 11),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=30),
+}
+
+with DAG("mozfun", default_args=default_args, schedule_interval="0 1 * * *") as dag:
+    docker_image = "mozilla/bigquery-etl:latest"
+
+    public_data_gcs_metadata = gke_command(
+        task_id="publish_public_udfs",
+        command=["script/publish_public_udfs"],
+        docker_image=docker_image,
+        dag=dag
+    )

--- a/dags/mozfun.py
+++ b/dags/mozfun.py
@@ -19,6 +19,5 @@ with DAG("mozfun", default_args=default_args, schedule_interval="0 1 * * *") as 
     publish_public_udfs = gke_command(
         task_id="publish_public_udfs",
         command=["script/publish_public_udfs"],
-        docker_image=docker_image,
-        dag=dag
+        docker_image=docker_image
     )

--- a/dags/mozfun.py
+++ b/dags/mozfun.py
@@ -16,7 +16,7 @@ default_args = {
 with DAG("mozfun", default_args=default_args, schedule_interval="0 1 * * *") as dag:
     docker_image = "mozilla/bigquery-etl:latest"
 
-    public_data_gcs_metadata = gke_command(
+    publish_public_udfs = gke_command(
         task_id="publish_public_udfs",
         command=["script/publish_public_udfs"],
         docker_image=docker_image,


### PR DESCRIPTION
This is for scheduling when public UDFs should be deployed. Only Airflow has permissions to deploy UDFs to `mozfun`.