### PR TITLE
Port TAAR similarity to BigQuery

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -31,7 +31,7 @@ default_args = {
     "email": ["telemetry-alerts@mozilla.com", "amiyaguchi@mozilla.com", "vng@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
-    "retries": 3,
+    "retries": 0,
     "retry_delay": timedelta(minutes=30),
 }
 

--- a/jobs/taar_similarity.py
+++ b/jobs/taar_similarity.py
@@ -12,6 +12,8 @@ Migrated from https://github.com/mozilla/python_mozetl/blob/3d1ca45f7460c3efa333
 
 from datetime import date, timedelta
 
+from collections.abc import Mapping, Iterable
+from decimal import Decimal
 import json
 import logging
 import contextlib
@@ -29,6 +31,7 @@ from pyspark.mllib.stat import KernelDensity
 from pyspark.statcounter import StatCounter
 from scipy.spatial import distance
 import boto3
+from google.cloud import bigquery
 
 
 def aws_env_credentials():
@@ -66,6 +69,7 @@ def write_to_s3(source_file_name, s3_dest_file_name, s3_prefix, bucket):
     # Update the state in the analysis bucket.
     key_path = s3_prefix + s3_dest_file_name
     transfer.upload_file(source_file_name, bucket, key_path)
+    print("Completed saving s3://{}/{}".format(bucket, key_path))
 
 
 def read_from_s3(s3_dest_file_name, s3_prefix, bucket):
@@ -90,6 +94,7 @@ def load_amo_curated_whitelist():
         "telemetry-ml/addon_recommender/",
         "telemetry-parquet",
     )
+    print("Whitelist loaded %d items" % len(whitelist))
     return list(whitelist)
 
 
@@ -137,7 +142,28 @@ logging.getLogger("py4j").setLevel(logging.ERROR)
 logger = logging.getLogger(__name__)
 
 
-def get_samples(spark, date_from, clients_daily_gcs_bucket):
+def get_table(view):
+    """Helper for determining what table underlies a user-facing view, since the Storage API can't read views."""
+    bq = bigquery.Client()
+    view = view.replace(":", ".")
+    # partition filter is required, so try a couple options
+    for partition_column in ["DATE(submission_timestamp)", "submission_date"]:
+        try:
+            job = bq.query(
+                f"SELECT * FROM `{view}` WHERE {partition_column} = CURRENT_DATE",
+                bigquery.QueryJobConfig(dry_run=True),
+            )
+            break
+        except Exception:
+            continue
+    else:
+        raise ValueError("could not determine partition column")
+    assert len(job.referenced_tables) == 1, "View combines multiple tables"
+    table = job.referenced_tables[0]
+    return f"{table.project}:{table.dataset_id}.{table.table_id}"
+
+
+def get_samples(spark, iso_today):
     """
     Get a DataFrame with a valid set of sample to base the next
     processing on.
@@ -152,40 +178,41 @@ def get_samples(spark, date_from, clients_daily_gcs_bucket):
     BUG 1485152: PR include active_addons to clients_daily table:
     https://github.com/mozilla/telemetry-batch-view/pull/490
     """
-    gs_url = "gs://{}/clients_daily/v6/".format(
-        clients_daily_gcs_bucket, date_from
-    )
-    parquetFile = spark.read.parquet(gs_url)
-
-    # Use the parquet files to create a temporary view and then used in SQL statements.
-    parquetFile.createOrReplaceTempView("clients_daily")
-
     df = (
-        spark.sql("SELECT * FROM clients_daily")
-        .where("client_id IS NOT null")
-        .where("active_addons IS NOT null")
-        .where("size(active_addons) > 2")
-        .where("size(active_addons) < 100")
-        .where("channel = 'release'")
-        .where("app_name = 'Firefox'")
-        .where("submission_date_s3 >= {}".format(date_from))
-        .selectExpr(
-            "client_id as client_id",
-            "active_addons as active_addons",
-            "city as city",
-            "cast(subsession_hours_sum as double)",
-            "locale as locale",
-            "os as os",
-            "places_bookmarks_count_mean AS bookmark_count",
-            "scalar_parent_browser_engagement_tab_open_event_count_sum "
-            "AS tab_open_count",
-            "scalar_parent_browser_engagement_total_uri_count_sum AS total_uri",
-            "scalar_parent_browser_engagement_unique_domains_count_mean AS unique_tlds",
-            "row_number() OVER (PARTITION BY client_id ORDER BY submission_date_s3 desc) as rn",
+        spark.read.format("bigquery")
+        .option(
+            "table",
+            get_table("moz-fx-data-shared-prod.telemetry.clients_last_seen"),
         )
-        .where("rn = 1")
-        .drop("rn")
+        .option("filter", "submission_date = '{}'".format(iso_today))
+        .load()
     )
+    df.createOrReplaceTempView("tiny_clients_daily")
+
+    df = spark.sql(
+        """
+       select
+            client_id,
+            active_addons as active_addons,
+            city as city,
+            subsession_hours_sum,
+            locale as locale,
+            os as os,
+            places_bookmarks_count_mean AS bookmark_count,
+            scalar_parent_browser_engagement_tab_open_event_count_sum AS tab_open_count,
+            scalar_parent_browser_engagement_total_uri_count_sum AS total_uri,
+            scalar_parent_browser_engagement_unique_domains_count_mean AS unique_tlds
+        FROM
+            tiny_clients_daily
+        WHERE
+            client_id is not null and
+            size(active_addons) > 2 and
+            size(active_addons) < 100 and
+            channel = 'release' and
+            app_name = 'Firefox'
+     """
+    )
+
     return df
 
 
@@ -193,6 +220,8 @@ def get_addons_per_client(users_df, addon_whitelist, minimum_addons_count):
     """ Extracts a DataFrame that contains one row
     for each client along with the list of active add-on GUIDs.
     """
+
+    print("min addon count = {}".format(minimum_addons_count))
 
     def is_valid_addon(guid, addon):
         return not (
@@ -235,7 +264,9 @@ def compute_clusters(addons_df, num_clusters, random_seed):
     # Build the stages of the pipeline. We need hashing to make the next
     # steps work.
     hashing_stage = HashingTF(inputCol="addon_ids", outputCol="hashed_features")
-    idf_stage = IDF(inputCol="hashed_features", outputCol="features", minDocFreq=1)
+    idf_stage = IDF(
+        inputCol="hashed_features", outputCol="features", minDocFreq=1
+    )
     # As a future improvement, we may add a sane value for the minimum cluster size
     # to BisectingKMeans (e.g. minDivisibleClusterSize). For now, just make sure
     # to pass along the random seed if needed for tests.
@@ -252,7 +283,9 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
     """ Samples users from each cluster.
     """
     cluster_population = clusters_df.groupBy("prediction").count().collect()
-    clusters_histogram = [(x["prediction"], x["count"]) for x in cluster_population]
+    clusters_histogram = [
+        (x["prediction"], x["count"]) for x in cluster_population
+    ]
 
     # Sort in-place from highest to lowest populated cluster.
     clusters_histogram.sort(key=lambda x: x[0], reverse=False)
@@ -263,6 +296,7 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
 
     # Compute the proportion of user in each cluster.
     total_donors_in_clusters = sum(counts)
+    print("Total donors in cluster: %d" % total_donors_in_clusters)
     clust_sample = [float(t) / total_donors_in_clusters for t in counts]
     sampling_proportions = dict(list(zip(clusters, clust_sample)))
 
@@ -275,6 +309,8 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
     # Get the specific number of donors for each cluster and drop the
     # predicted cluster number information.
     current_sample_size = donor_df.count()
+    print("num_donors: %f" % float(num_donors))
+    print("current_sample_size: %d" % current_sample_size)
     donor_pool_df = donor_df.sample(
         False, float(num_donors) / current_sample_size, **sampling_kwargs
     )
@@ -282,10 +318,15 @@ def get_donor_pools(users_df, clusters_df, num_donors, random_seed=None):
 
 
 def get_donors(
-    spark, num_clusters, num_donors, addon_whitelist, date_from, clients_daily_gcs_bucket, random_seed=None
+    spark,
+    num_clusters,
+    num_donors,
+    addon_whitelist,
+    iso_today,
+    random_seed=None,
 ):
     # Get the data for the potential add-on donors.
-    users_sample = get_samples(spark, date_from, clients_daily_gcs_bucket)
+    users_sample = get_samples(spark, iso_today)
     # Get add-ons from selected users and make sure they are
     # useful for making a recommendation.
     addons_df = get_addons_per_client(users_sample, addon_whitelist, 2)
@@ -335,9 +376,13 @@ def similarity_function(x, y):
     # the x and y samples. Use an empty string as the default value for missing
     # categorical fields and 0 for the continuous ones.
     x_categorical_features = [safe_get(k, x, "") for k in CATEGORICAL_FEATURES]
-    x_continuous_features = [safe_get(k, x, 0) for k in CONTINUOUS_FEATURES]
     y_categorical_features = [safe_get(k, y, "") for k in CATEGORICAL_FEATURES]
-    y_continuous_features = [safe_get(k, y, 0) for k in CONTINUOUS_FEATURES]
+    x_continuous_features = [
+        float(safe_get(k, x, 0)) for k in CONTINUOUS_FEATURES
+    ]
+    y_continuous_features = [
+        float(safe_get(k, y, 0)) for k in CONTINUOUS_FEATURES
+    ]
 
     # Here a larger distance indicates a poorer match between categorical variables.
     j_d = distance.hamming(x_categorical_features, y_categorical_features)
@@ -362,7 +407,12 @@ def generate_non_cartesian_pairs(first_rdd, second_rdd):
 
 
 def get_lr_curves(
-    spark, features_df, cluster_ids, kernel_bandwidth, num_pdf_points, random_seed=None
+    spark,
+    features_df,
+    cluster_ids,
+    kernel_bandwidth,
+    num_pdf_points,
+    random_seed=None,
 ):
     """ Compute the likelihood ratio curves for clustered clients.
 
@@ -394,9 +444,13 @@ def get_lr_curves(
 
     for cluster_number in cluster_ids:
         # Pick the features for users belonging to the current cluster.
-        current_cluster_df = features_df.where(col("prediction") == cluster_number)
+        current_cluster_df = features_df.where(
+            col("prediction") == cluster_number
+        )
         # Pick the features for users belonging to all the other clusters.
-        other_clusters_df = features_df.where(col("prediction") != cluster_number)
+        other_clusters_df = features_df.where(
+            col("prediction") != cluster_number
+        )
 
         logger.debug(
             "Computing scores for cluster", extra={"cluster_id": cluster_number}
@@ -408,7 +462,9 @@ def get_lr_curves(
         )
         pair_rdd = generate_non_cartesian_pairs(cluster_half_1, cluster_half_2)
         intra_scores_rdd = pair_rdd.map(lambda r: similarity_function(*r))
-        same_cluster_scores_rdd = same_cluster_scores_rdd.union(intra_scores_rdd)
+        same_cluster_scores_rdd = same_cluster_scores_rdd.union(
+            intra_scores_rdd
+        )
 
         # Compares the similarity score between pairs of clients in different clusters.
         pair_rdd = generate_non_cartesian_pairs(
@@ -420,7 +476,9 @@ def get_lr_curves(
         )
 
     # Determine a range of observed similarity values linearly spaced.
-    all_scores_rdd = same_cluster_scores_rdd.union(different_clusters_scores_rdd)
+    all_scores_rdd = same_cluster_scores_rdd.union(
+        different_clusters_scores_rdd
+    )
     stats = all_scores_rdd.aggregate(
         StatCounter(), StatCounter.merge, StatCounter.mergeStats
     )
@@ -445,11 +503,27 @@ def get_lr_curves(
     numerator_density = kd_sc.estimate(lr_index)
 
     # Structure this in the correct output format.
-    return list(zip(lr_index, list(zip(numerator_density, denominator_density))))
+    return list(
+        zip(lr_index, list(zip(numerator_density, denominator_density)))
+    )
 
 
-def today_minus_90_days():
-    return (date.today() + timedelta(days=-90)).strftime("%Y%m%d")
+class DecimalEncoder(json.JSONEncoder):
+    def encode(self, obj):
+        if isinstance(obj, Mapping):
+            return (
+                "{"
+                + ", ".join(
+                    f"{self.encode(k)}: {self.encode(v)}"
+                    for (k, v) in obj.items()
+                )
+                + "}"
+            )
+        if isinstance(obj, Iterable) and (not isinstance(obj, str)):
+            return "[" + ", ".join(map(self.encode, obj)) + "]"
+        if isinstance(obj, Decimal):
+            return f"{obj.normalize():f}"  # using normalize() gets rid of trailing 0s, using ':f' prevents scientific notation
+        return super().encode(obj)
 
 
 @click.command()
@@ -462,8 +536,6 @@ def today_minus_90_days():
 @click.option("--num_donors", default=1000)
 @click.option("--kernel_bandwidth", default=0.35)
 @click.option("--num_pdf_points", default=1000)
-@click.option("--clients_sample_date_from", default=today_minus_90_days())
-@click.option("--clients_daily_gcs_bucket", default="moz-fx-data-derived-datasets-parquet")
 def main(
     date,
     aws_access_key_id,
@@ -474,10 +546,8 @@ def main(
     num_donors,
     kernel_bandwidth,
     num_pdf_points,
-    clients_sample_date_from,
-    clients_daily_gcs_bucket,
 ):
-    logger.info("Sampling clients since {}".format(clients_sample_date_from))
+    logger.info("Sampling clients since {}".format(date))
 
     # Clobber the AWS access credentials
     os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id
@@ -502,7 +572,7 @@ def main(
 
     # Compute the donors clusters and the LR curves.
     cluster_ids, donors_df = get_donors(
-        spark, num_clusters, num_donors, whitelist, clients_sample_date_from, clients_daily_gcs_bucket
+        spark, num_clusters, num_donors, whitelist, date,
     )
     donors_df.cache()
     lr_curves = get_lr_curves(
@@ -511,8 +581,21 @@ def main(
 
     # Store them.
     donors = format_donors_dictionary(donors_df)
-    store_json_to_s3(json.dumps(donors, indent=2), "donors", date, prefix, bucket)
-    store_json_to_s3(json.dumps(lr_curves, indent=2), "lr_curves", date, prefix, bucket)
+
+    store_json_to_s3(
+        json.dumps(donors, indent=2, cls=DecimalEncoder),
+        "donors",
+        date,
+        prefix,
+        bucket,
+    )
+    store_json_to_s3(
+        json.dumps(lr_curves, indent=2, cls=DecimalEncoder),
+        "lr_curves",
+        date,
+        prefix,
+        bucket,
+    )
     spark.stop()
 
 


### PR DESCRIPTION
This updates the TAAR similarity job to run on BigQuery instead of using parquet files on GCS.

The retry limit has been reduced to 0 as retrying a job in TAAR daily is not helpful as the cluster typically goes into an invalid state.

Note that the number of worker nodes has been adjusted to get the runtime down.

Running the job with a local instance of Airflow - this configuration completes execution in just under 12 minutes.

<img width="916" alt="TAAR_similarity_28a0f3cf_-_airflow-dataproc-prod_-_Google_Cloud_Platform_and_vng_Victor-MBPrTouch____dev_telemetry-airflow" src="https://user-images.githubusercontent.com/4829/84546171-b0f04c00-acce-11ea-9412-b6c4092a5342.png">
