### PR TITLE
Fix types for burnham test scenarios

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -181,7 +181,7 @@ def burnham_bigquery_run(
         image="gcr.io/moz-fx-data-airflow-prod-88e0/burnham-bigquery:latest",
         image_pull_policy="Always",
         arguments=[
-            "--verbose",
+            "-vv",
             "--project-id",
             project_id,
             "--run-id",
@@ -268,8 +268,8 @@ with models.DAG(
                 project_id=project_id, test_name=burnham_test_name, limit=10,
             ),
             "want": [
-                {"key": "spore_drive", "value_sum": "13"},
-                {"key": "warp_drive", "value_sum": "18"},
+                {"key": "spore_drive", "value_sum": 13},
+                {"key": "warp_drive", "value_sum": 18},
             ],
         },
     ]


### PR DESCRIPTION
The `verify_data` task in the burnham DAG currently fails because the types for the `SUM` values don't match. This pull-request updates the `value_sum` values in the test scenario to integers.

I also updated the arguments for this task, so the logs show the full pytest test report.