### PR TITLE
Run fxa queries at 01:00 UTC

### DIFF
--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -19,8 +19,7 @@ dag_name = 'fxa_events'
 
 with models.DAG(
         dag_name,
-        # Continue to run DAG once per day
-        schedule_interval='0 10 * * *',
+        schedule_interval='0 1 * * *',
         default_args=default_args) as dag:
 
     fxa_auth_events = bigquery_etl_query(

--- a/dags/kpi_forecasts.py
+++ b/dags/kpi_forecasts.py
@@ -81,7 +81,6 @@ with models.DAG(
         external_dag_id="fxa_events",
         external_task_id="firefox_accounts_exact_mau28_raw",
         check_existence=True,
-        execution_delta=timedelta(hours=-9),
         mode="reschedule",
         dag=dag,
     )


### PR DESCRIPTION
Previously, we had set these queries to run at 10:00 UTC because we didn't
know much about the behavior of the FxA Stackdriver log pipeline. We now have
confirmation from jbuck that allowing 1 hour after UTC midnight should be
plenty of time for logs to flow to BigQuery.