### PR TITLE
Use correct user id field in shredder_amplitude_fxa

### DIFF
--- a/dags/fxa_events.py
+++ b/dags/fxa_events.py
@@ -76,7 +76,7 @@ with models.DAG(
             '--api-key={{ var.value.fxa_amplitude_api_key }}',
             '--secret-key={{ var.value.fxa_amplitude_secret_key }}',
             '--table-id=moz-fx-data-shared-prod.firefox_accounts_derived.fxa_delete_events_v1',
-            '--user-id-field=amplitude_user_id',
+            '--user-id-field=hmac_user_id',
         ],
         docker_image='mozilla/bigquery-etl:latest',
     )


### PR DESCRIPTION
I changed it in bigquery-etl before I merged, but I forgot to fix it here.