### PR TITLE
Add fenix variants to glam

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -9,7 +9,7 @@ from airflow.operators.subdag_operator import SubDagOperator
 from glam_subdags.extract import extracts_subdag, extract_user_counts
 from glam_subdags.histograms import histogram_aggregates_subdag
 from glam_subdags.general import repeated_subdag
-from glam_subdags.generate_query import generate_and_run_query
+from glam_subdags.generate_query import generate_and_run_desktop_query
 from utils.gcp import bigquery_etl_query, gke_command
 
 
@@ -68,7 +68,7 @@ latest_versions = bigquery_etl_query(
 
 # This task runs first and replaces the relevant partition, followed
 # by the next two tasks that append to the same partition of the same table.
-clients_daily_scalar_aggregates = generate_and_run_query(
+clients_daily_scalar_aggregates = generate_and_run_desktop_query(
     task_id="clients_daily_scalar_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -78,7 +78,7 @@ clients_daily_scalar_aggregates = generate_and_run_query(
     dag=dag,
 )
 
-clients_daily_keyed_scalar_aggregates = generate_and_run_query(
+clients_daily_keyed_scalar_aggregates = generate_and_run_desktop_query(
     task_id="clients_daily_keyed_scalar_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -88,7 +88,7 @@ clients_daily_keyed_scalar_aggregates = generate_and_run_query(
     dag=dag,
 )
 
-clients_daily_keyed_boolean_aggregates = generate_and_run_query(
+clients_daily_keyed_boolean_aggregates = generate_and_run_desktop_query(
     task_id="clients_daily_keyed_boolean_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -135,7 +135,7 @@ scalar_percentiles = bigquery_etl_query(
 
 # This task runs first and replaces the relevant partition, followed
 # by the next task below that appends to the same partition of the same table.
-clients_daily_histogram_aggregates_parent = generate_and_run_query(
+clients_daily_histogram_aggregates_parent = generate_and_run_desktop_query(
     task_id="clients_daily_histogram_aggregates_parent",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -147,7 +147,7 @@ clients_daily_histogram_aggregates_parent = generate_and_run_query(
     dag=dag,
 )
 
-clients_daily_histogram_aggregates_content = generate_and_run_query(
+clients_daily_histogram_aggregates_content = generate_and_run_desktop_query(
     task_id="clients_daily_histogram_aggregates_content",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -159,7 +159,7 @@ clients_daily_histogram_aggregates_content = generate_and_run_query(
     dag=dag,
 )
 
-clients_daily_keyed_histogram_aggregates = generate_and_run_query(
+clients_daily_keyed_histogram_aggregates = generate_and_run_desktop_query(
     task_id="clients_daily_keyed_histogram_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -17,7 +17,7 @@ default_args = {
 }
 
 dag = DAG(
-    "glam_org_mozilla_fenix", default_args=default_args, schedule_interval="0 2 * * *"
+    "glam_fenix", default_args=default_args, schedule_interval="0 2 * * *"
 )
 
 wait_for_copy_deduplicate = ExternalTaskSensor(

--- a/dags/glam_org_mozilla_fenix.py
+++ b/dags/glam_org_mozilla_fenix.py
@@ -36,10 +36,30 @@ org_mozilla_fenix = generate_and_run_glean_query(
     dag=dag,
 )
 
+
+export_org_mozilla_fenix = gke_command(
+    task_id="export_org_mozilla_fenix",
+    cmds=["bash"],
+    env_vars={"DATASET": "glam_etl", "PRODUCT": "org_mozilla_fenix"},
+    command=["script/glam/export_csv"],
+    docker_image="mozilla/bigquery-etl:latest",
+    gcp_conn_id="google_cloud_derived_datasets",
+    dag=dag,
+)
 org_mozilla_firefox = generate_and_run_glean_query(
     task_id="org_mozilla_firefox",
     product="org_mozilla_firefox",
     destination_project_id="glam-fenix-dev",
+    dag=dag,
+)
+
+export_org_mozilla_firefox = gke_command(
+    task_id="export_org_mozilla_firefox",
+    cmds=["bash"],
+    env_vars={"DATASET": "glam_etl", "PRODUCT": "org_mozilla_firefox"},
+    command=["script/glam/export_csv"],
+    docker_image="mozilla/bigquery-etl:latest",
+    gcp_conn_id="google_cloud_derived_datasets",
     dag=dag,
 )
 
@@ -50,6 +70,16 @@ org_mozilla_firefox_beta = generate_and_run_glean_query(
     dag=dag,
 )
 
+export_org_mozilla_firefox_beta = gke_command(
+    task_id="export_org_mozilla_firefox_beta",
+    cmds=["bash"],
+    env_vars={"DATASET": "glam_etl", "PRODUCT": "org_mozilla_firefox_beta"},
+    command=["script/glam/export_csv"],
+    docker_image="mozilla/bigquery-etl:latest",
+    gcp_conn_id="google_cloud_derived_datasets",
+    dag=dag,
+)
+
 org_mozilla_fennec_aurora = generate_and_run_glean_query(
     task_id="org_mozilla_fennec_aurora",
     product="org_mozilla_fennec_aurora",
@@ -57,10 +87,10 @@ org_mozilla_fennec_aurora = generate_and_run_glean_query(
     dag=dag,
 )
 
-export_org_mozilla_fenix = gke_command(
-    task_id="export_org_mozilla_fenix",
+export_org_mozilla_fennec_aurora = gke_command(
+    task_id="export_org_mozilla_fennec_aurora",
     cmds=["bash"],
-    env_vars={"DATASET": "glam_etl"},
+    env_vars={"DATASET": "glam_etl", "PRODUCT": "org_mozilla_fennec_aurora"},
     command=["script/glam/export_csv"],
     docker_image="mozilla/bigquery-etl:latest",
     gcp_conn_id="google_cloud_derived_datasets",
@@ -68,3 +98,9 @@ export_org_mozilla_fenix = gke_command(
 )
 
 wait_for_copy_deduplicate >> org_mozilla_fenix >> export_org_mozilla_fenix
+
+wait_for_copy_deduplicate >> org_mozilla_firefox >> export_org_mozilla_firefox
+
+wait_for_copy_deduplicate >> org_mozilla_firefox_beta >> export_org_mozilla_firefox_beta
+
+wait_for_copy_deduplicate >> org_mozilla_fennec_aurora >> export_org_mozilla_fennec_aurora

--- a/dags/glam_org_mozilla_fenix.py
+++ b/dags/glam_org_mozilla_fenix.py
@@ -36,7 +36,6 @@ org_mozilla_fenix = generate_and_run_glean_query(
     dag=dag,
 )
 
-
 export_org_mozilla_fenix = gke_command(
     task_id="export_org_mozilla_fenix",
     cmds=["bash"],
@@ -46,6 +45,7 @@ export_org_mozilla_fenix = gke_command(
     gcp_conn_id="google_cloud_derived_datasets",
     dag=dag,
 )
+
 org_mozilla_firefox = generate_and_run_glean_query(
     task_id="org_mozilla_firefox",
     product="org_mozilla_firefox",

--- a/dags/glam_subdags/generate_query.py
+++ b/dags/glam_subdags/generate_query.py
@@ -1,17 +1,17 @@
 from utils.gcp import gke_command
 
 
-def generate_and_run_query(task_id,
-                           project_id,
-                           source_dataset_id,
-                           sample_size,
-                           overwrite,
-                           probe_type,
-                           destination_dataset_id=None,
-                           process=None,
-                           docker_image="mozilla/bigquery-etl:latest",
-                           gcp_conn_id="google_cloud_derived_datasets",
-                           **kwargs):
+def generate_and_run_desktop_query(task_id,
+                                   project_id,
+                                   source_dataset_id,
+                                   sample_size,
+                                   overwrite,
+                                   probe_type,
+                                   destination_dataset_id=None,
+                                   process=None,
+                                   docker_image="mozilla/bigquery-etl:latest",
+                                   gcp_conn_id="google_cloud_derived_datasets",
+                                   **kwargs):
     """
     :param task_id:                     Airflow task id
     :param project_id:                  GCP project to write to
@@ -49,6 +49,45 @@ def generate_and_run_query(task_id,
         cmds=["bash"],
         env_vars=env_vars,
         command=command,
+        docker_image=docker_image,
+        gcp_conn_id=gcp_conn_id,
+        **kwargs
+    )
+
+
+def generate_and_run_glean_query(task_id,
+                                 product,
+                                 destination_project_id,
+                                 destination_dataset_id="glam_etl",
+                                 source_project_id="moz-fx-data-shared-prod",
+                                 docker_image="mozilla/bigquery-etl:latest",
+                                 gcp_conn_id="google_cloud_derived_datasets",
+                                 **kwargs):
+    """
+    :param task_id:                     Airflow task id
+    :param project_id:                  GCP project to write to
+    :param source_dataset_id:           Bigquery dataset to read from in queries
+    :param sample_size:                 Value to use for windows release client sampling
+    :param overwrite:                   Overwrite the destination table
+    :param probe_type:                  Probe type to generate query
+    :param destination_dataset_id:      Bigquery dataset to write results to.  Defaults to source_dataset_id
+    :param process:                     Process to filter probes for.  Gets all processes by default.
+    :param docker_image:                Docker image
+    :param gcp_conn_id:                 Airflow GCP connection
+    """
+    env_vars = {
+        "PRODUCT": product,
+        "SOURCE_PROJECT": source_project_id,
+        "PROJECT": destination_project_id,
+        "DATASET": destination_dataset_id,
+        "SUBMISSION_DATE": "{{ ds }}",
+    }
+
+    return gke_command(
+        task_id=task_id,
+        cmds=["bash", "-c"],
+        env_vars=env_vars,
+        command=["script/glam/generate_glean_sql && script/glam/run_glam_sql"],
         docker_image=docker_image,
         gcp_conn_id=gcp_conn_id,
         **kwargs

--- a/dags/glam_subdags/generate_query.py
+++ b/dags/glam_subdags/generate_query.py
@@ -65,19 +65,16 @@ def generate_and_run_glean_query(task_id,
                                  **kwargs):
     """
     :param task_id:                     Airflow task id
-    :param project_id:                  GCP project to write to
-    :param source_dataset_id:           Bigquery dataset to read from in queries
-    :param sample_size:                 Value to use for windows release client sampling
-    :param overwrite:                   Overwrite the destination table
-    :param probe_type:                  Probe type to generate query
-    :param destination_dataset_id:      Bigquery dataset to write results to.  Defaults to source_dataset_id
-    :param process:                     Process to filter probes for.  Gets all processes by default.
+    :param product:                     Product name of glean app
+    :param destination_project_id:      Project to store derived tables
+    :param destination_dataset_id:      Name of the dataset to store derived tables
+    :param source_project_id:           Project containing the source datasets
     :param docker_image:                Docker image
     :param gcp_conn_id:                 Airflow GCP connection
     """
     env_vars = {
         "PRODUCT": product,
-        "SOURCE_PROJECT": source_project_id,
+        "SRC_PROJECT": source_project_id,
         "PROJECT": destination_project_id,
         "DATASET": destination_dataset_id,
         "SUBMISSION_DATE": "{{ ds }}",


### PR DESCRIPTION
bq-etl pr: https://github.com/mozilla/bigquery-etl/pull/1183
issue: https://github.com/mozilla/bigquery-etl/issues/1130

This adds `org_mozilla_firefox`, `org_mozilla_firefox_beta`, and `org_mozilla_fennec_aurora` to the dag and renames the dag to `glam_fenix`.  This erases the task history for the dag but I don't expect that to be an issue.