### PR TITLE
Change leanplum export to run every 4 hours

### DIFF
--- a/dags/leanplum_export.py
+++ b/dags/leanplum_export.py
@@ -4,60 +4,60 @@ from utils import leanplum
 
 
 default_args = {
-    'owner': 'frank@mozilla.com',
+    "owner": "frank@mozilla.com",
     "email": [
         "bewu@mozilla.com",
         "frank@mozilla.com",
     ],
-    'depends_on_past': False,
-    'start_date': datetime(2019, 10, 10),
-    'email_on_failure': True,
-    'email_on_retry': True,
-    'retries': 2,
-    'retry_delay': timedelta(minutes=30),
+    "depends_on_past": False,
+    "start_date": datetime(2019, 10, 10),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=30),
 }
 
 
-with DAG('leanplum_export',
+with DAG("leanplum_export",
          default_args=default_args,
-         schedule_interval='0 4 * * *') as dag:
+         schedule_interval=timedelta(hours=4)) as dag:
 
     fennec_release_export = leanplum.export(
-        task_id='fennec_release_export',
-        bq_project='moz-fx-data-shared-prod',
-        s3_prefix='firefox_android',
-        bq_dataset_id='firefox_android_release_external',
-        table_prefix='leanplum',
-        version='2',
+        task_id="fennec_release_export",
+        bq_project="moz-fx-data-shared-prod",
+        s3_prefix="firefox_android",
+        bq_dataset_id="firefox_android_release_external",
+        table_prefix="leanplum",
+        version="2",
         dag=dag
     )
 
     firefox_ios_release_export = leanplum.export(
-        task_id='firefox_ios_release_export',
-        bq_project='moz-fx-data-shared-prod',
-        s3_prefix='firefox_ios',
-        bq_dataset_id='firefox_ios_release_external',
-        table_prefix='leanplum',
-        version='2',
+        task_id="firefox_ios_release_export",
+        bq_project="moz-fx-data-shared-prod",
+        s3_prefix="firefox_ios",
+        bq_dataset_id="firefox_ios_release_external",
+        table_prefix="leanplum",
+        version="2",
         dag=dag
     )
 
     firefox_android_beta_export = leanplum.export(
-        task_id='firefox_android_beta_export',
-        bq_project='moz-fx-data-shared-prod',
-        s3_prefix='firefox_android_beta',
-        bq_dataset_id='firefox_android_beta_external',
-        table_prefix='leanplum',
-        version='2',
+        task_id="firefox_android_beta_export",
+        bq_project="moz-fx-data-shared-prod",
+        s3_prefix="firefox_android_beta",
+        bq_dataset_id="firefox_android_beta_external",
+        table_prefix="leanplum",
+        version="2",
         dag=dag
     )
 
     firefox_android_nightly_export = leanplum.export(
-        task_id='firefox_android_nightly_export',
-        bq_project='moz-fx-data-shared-prod',
-        s3_prefix='firefox_android_nightly',
-        bq_dataset_id='firefox_android_nightly_external',
-        table_prefix='leanplum',
-        version='2',
+        task_id="firefox_android_nightly_export",
+        bq_project="moz-fx-data-shared-prod",
+        s3_prefix="firefox_android_nightly",
+        bq_dataset_id="firefox_android_nightly_external",
+        table_prefix="leanplum",
+        version="2",
         dag=dag
     )


### PR DESCRIPTION
Leanplum exports data every 2 hours.  We currently import all the data once per day but release data takes ~8 hours to run.  Increasing the runs per day will reduce the data latency as requested by data science.  There is a mechanism is the export job to skip already imported files so this is safe to run multiple times a day.

Also changes ' to " but the schedule interval is the only real change and highlighted in the diff.