### PR TITLE
Burnham python3 fix

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -399,7 +399,7 @@ with models.DAG(
 
     json_encoded = json.dumps(burnham_test_scenarios)
     utf_encoded = json_encoded.encode("utf-8")
-    b64_encoded = base64.b64encode(utf_encoded)
+    b64_encoded = base64.b64encode(utf_encoded).decode("utf-8")
 
     verify_data = burnham_bigquery_run(
         task_id="verify_data",


### PR DESCRIPTION
Recent runs have failed with:

> TypeError: Object of type bytes is not JSON serializable

Which I believe is directly related to the switch to running WTMO on python3.