### PR TITLE
Set app store export to two day lag 

### DIFF
--- a/dags/app_store_analytics.py
+++ b/dags/app_store_analytics.py
@@ -1,7 +1,8 @@
-from airflow import DAG
 from datetime import datetime, timedelta
 from utils.gcp import gke_command
 
+from airflow import DAG
+from airflow.macros import ds_add
 
 default_args = {
     "owner": "bewu@mozilla.com",
@@ -45,7 +46,7 @@ with DAG("app_store_analytics",
             "--password={{ var.value.app_store_connect_password }}",
             f"--app-id={app_id}",
             f"--app-name={app_name}",
-            "--start-date={{ yesterday_ds }}",  # previous day data is incomplete
+            f"--start-date={ds_add('{{ ds }}', -2)}",  # previous day data is incomplete
             f"--project={PROJECT_ID}",
             f"--dataset={DATASET_ID}",
         ]

--- a/dags/app_store_analytics.py
+++ b/dags/app_store_analytics.py
@@ -46,7 +46,7 @@ with DAG("app_store_analytics",
             "--password={{ var.value.app_store_connect_password }}",
             f"--app-id={app_id}",
             f"--app-name={app_name}",
-            f"--start-date={ds_add('{{ ds }}', -2)}",  # previous day data is incomplete
+            f"--start-date={{ macros.ds_add(ds, -2) }}",  # previous day data is incomplete
             f"--project={PROJECT_ID}",
             f"--dataset={DATASET_ID}",
         ]


### PR DESCRIPTION
Available data latency seems to be inconsistent and previous day data is available but incomplete for many metrics.  Setting to two day lag should work but I'll check over the next week to see if three days is needed.

Also I'll make a change to the export to warn about incomplete data.