### PR TITLE
Don't delete from GCS in fxa_basket_export

### DIFF
--- a/dags/fxa_basket_export.py
+++ b/dags/fxa_basket_export.py
@@ -62,14 +62,6 @@ with models.DAG(
     directory = "/".join((GCS_PREFIX, "{{ ds_nodash }}"))
     extension = ".csv"
 
-    # Remove any existing data in the destination directory from previous runs.
-    gcs_delete = GoogleCloudStorageDeleteOperator(
-        task_id="gcs_delete",
-        bucket_name=GCS_BUCKET,
-        prefix=directory,
-        google_cloud_storage_conn_id=gcp_conn_id,
-    )
-
     # Export from bq to gcs
     # Docs: https://github.com/apache/airflow/blob/master/airflow/contrib/operators/bigquery_to_gcs.py#L28 # noqa: E501
     gcs_uri = "gs://{}/{}/*{}".format(GCS_BUCKET, directory, extension)
@@ -93,4 +85,4 @@ with models.DAG(
         use_legacy_sql=False,
     )
 
-    create_table >> gcs_delete >> table_extract >> table_drop
+    create_table >> table_extract >> table_drop


### PR DESCRIPTION
The service account is only granted access to create objects,
not to list or delete, so the gcs_delete step was failing.

It seems reasonable to maintain those limited privs and to remove the
delete step. We can revisit later if we find this causes issues in reprocessing.
I believe the overwrite behavior should be sufficient.