### PR TITLE
Pin prio-processor to v1.6.1

### DIFF
--- a/dags/prio/kubernetes.py
+++ b/dags/prio/kubernetes.py
@@ -23,7 +23,7 @@ def container_subdag(
     env_vars={},
     arguments=[],
     machine_type="n1-standard-1",
-    image="mozilla/prio-processor:latest",
+    image="mozilla/prio-processor:v1.6.1",
     location="us-west1-b",
     owner_label="amiyaguchi",
     team_label="dataeng",


### PR DESCRIPTION
The job currently fails because v2.0 changes the top-level project layout. 