### PR TITLE
Add support for logical app ids in glam etl for glean

### DIFF
--- a/dags/glam_subdags/generate_query.py
+++ b/dags/glam_subdags/generate_query.py
@@ -62,6 +62,7 @@ def generate_and_run_glean_query(task_id,
                                  source_project_id="moz-fx-data-shared-prod",
                                  docker_image="mozilla/bigquery-etl:latest",
                                  gcp_conn_id="google_cloud_derived_datasets",
+                                 env_vars={},
                                  **kwargs):
     """
     :param task_id:                     Airflow task id
@@ -71,6 +72,7 @@ def generate_and_run_glean_query(task_id,
     :param source_project_id:           Project containing the source datasets
     :param docker_image:                Docker image
     :param gcp_conn_id:                 Airflow GCP connection
+    :param env_vars:                    Additional environment variables to pass
     """
     env_vars = {
         "PRODUCT": product,
@@ -78,6 +80,7 @@ def generate_and_run_glean_query(task_id,
         "PROJECT": destination_project_id,
         "DATASET": destination_dataset_id,
         "SUBMISSION_DATE": "{{ ds }}",
+        **env_vars
     }
 
     return gke_command(


### PR DESCRIPTION
This depends on https://github.com/mozilla/bigquery-etl/pull/1221

This adds the dependencies needed for the logical view of fenix apps. The logical view takes the daily tables generated by the glean etl for scalars and histograms, and concatenates the set of client aggregate rows together.

![image](https://user-images.githubusercontent.com/3304040/89836614-05bc1180-db1c-11ea-8290-4373e5691e80.png)
