### PR TITLE
Prevent copy_deduplicate xfocsp_error_report_live.xfocsp_error_report_v4

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -39,7 +39,7 @@ with models.DAG(
         priority_weight=100,
         # Any table listed here under except_tables _must_ have a corresponding
         # copy_deduplicate job in another DAG.
-        except_tables=["telemetry_live.main_v4"])
+        except_tables=["telemetry_live.main_v4", "xfocsp_error_report_live.xfocsp_error_report_v4"])
 
     copy_deduplicate_main_ping = bigquery_etl_copy_deduplicate(
         task_id="copy_deduplicate_main_ping",


### PR DESCRIPTION
Airflow is currently failing with 

```
google.api_core.exceptions.Forbidden: 403 Access Denied: Table moz-fx-data-shared-prod:xfocsp_error_report_live.xfocsp_error_report_v4: User does not have permission to query table 
```

This will prevent processing `xfocsp_error_report_live.xfocsp_error_report_v4`