### PR TITLE
Increase play store backfill to 60 days

### DIFF
--- a/dags/play_store_export.py
+++ b/dags/play_store_export.py
@@ -24,7 +24,7 @@ with DAG("play_store_export",
         command=[
             "python", "play_store_export/export.py",
             "--date={{ yesterday_ds }}",
-            "--backfill-day-count=35",
+            "--backfill-day-count=60",
             "--project", project_id,
             "--transfer-config={{ var.value.play_store_transfer_config_id }}",
         ],


### PR DESCRIPTION
This is to account for the ~2 week delay on data availability for some of the tables.  Pricing isn't based on number of days so cost shouldn't increase.