### PR TITLE
Deduplicate burnham documents

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -74,7 +74,7 @@ WHERE
   submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR)
   AND metrics.uuid.test_run = @burnham_test_run
 LIMIT
-  10
+  20
 """
 WANT_TEST_CLIENT_IDS = [{"count_client_ids": 3}]
 
@@ -99,7 +99,7 @@ WITH
     submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR)
     AND metrics.uuid.test_run = @burnham_test_run
   LIMIT
-    10 ),
+    20 ),
   experiment_counts AS (
   SELECT
     experiment,
@@ -156,7 +156,7 @@ WHERE
 ORDER BY
   metrics.string.mission_identifier
 LIMIT
-  10
+  20
 """
 
 WANT_TEST_GLEAN_ERROR_INVALID_VALUE = [


### PR DESCRIPTION
Hi folks! 👋 

I updated the SQL queries in the burnham DAG to deduplicate documents submitted through automation. As discussed on Slack there is no guarantee live tables don't have duplicates, so we need this extra step to ensure reproducibility.

We don't need to deduplicate rows for the distinct client IDs test, I think. I ran an example for each of the updated queries manually and they seem to produce the expected values.

Resolve https://github.com/mozilla/burnham/issues/61