### PR TITLE
Fix failing prio-processor DAG and keep GKE cluster online

### DIFF
--- a/dags/prio/dataproc.py
+++ b/dags/prio/dataproc.py
@@ -16,7 +16,8 @@ def spark_subdag(
     main,
     pyfiles,
     arguments,
-    dataproc_zone="us-west1-a",
+    bootstrap_bucket,
+    dataproc_region="us-west1",
     num_preemptible_workers=10,
 ):
     """Run the PySpark job for unnesting and range-partitioning Prio pings from
@@ -27,7 +28,7 @@ def spark_subdag(
     :param Dict[str, Any] default_args: Default arguments for the child DAG.
     :param str gcp_conn_id:             Name of the connection string.
     :param str service_account:         The address of the service account.
-    :param str dataproc_zone:           The region of the DataProc cluster.
+    :param str dataproc_region:           The region of the DataProc cluster.
     :param str main:
     :param List[str] pyfiles:
     :param List[str] arguments:
@@ -38,46 +39,52 @@ def spark_subdag(
     connection = GoogleCloudBaseHook(gcp_conn_id=gcp_conn_id)
 
     shared_config = {
-        "cluster_name": "prio-staging",
+        "cluster_name": "prio-staging-{{ds_nodash}}",
         "gcp_conn_id": gcp_conn_id,
         "project_id": connection.project_id,
+        # From an error when not specifying the region:
+        # - Dataproc images 2.0 and higher do not support the to-be
+        #   deprecated global region. Please use any non-global Dataproc
+        #   region instead
+        #  - Must specify a zone in GCE configuration when using
+        #    'regions/global'. To use auto zone placement, specify
+        #    regions/<non-global-region> in request path, e.g.
+        #    regions/us-central1
+        "region": dataproc_region,
     }
 
-    with DAG(
-        "{}.{}".format(parent_dag_name, child_dag_name), default_args=default_args
-    ) as dag:
+    with DAG(f"{parent_dag_name}.{child_dag_name}", default_args=default_args) as dag:
         create_dataproc_cluster = DataprocClusterCreateOperator(
             task_id="create_dataproc_cluster",
-            num_workers=2,
-            image_version="1.4",
-            zone=dataproc_zone,
+            image_version="preview-ubuntu18",
             service_account=service_account,
-            master_machine_type="n1-standard-8",
-            worker_machine_type="n1-standard-8",
+            master_machine_type="n1-standard-4",
+            worker_machine_type="n1-standard-4",
+            num_workers=2,
             num_preemptible_workers=num_preemptible_workers,
-            metadata={"PIP_PACKAGES": "click jsonschema gcsfs==0.2.3"},
-            init_actions_uris=[
-                "gs://dataproc-initialization-actions/python/pip-install.sh"
-            ],
+            init_actions_uris=[f"{bootstrap_bucket}/install-python-requirements.sh"],
+            idle_delete_ttl=600,
             dag=dag,
-            **shared_config
+            **shared_config,
         )
 
         run_dataproc_spark = DataProcPySparkOperator(
             task_id="run_dataproc_spark",
             main=main,
-            dataproc_pyspark_jars=["gs://spark-lib/bigquery/spark-bigquery-latest.jar"],
+            dataproc_pyspark_jars=[
+                "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar"
+            ],
             pyfiles=pyfiles,
             arguments=arguments,
             dag=dag,
-            **shared_config
+            **shared_config,
         )
 
         delete_dataproc_cluster = DataprocClusterDeleteOperator(
             task_id="delete_dataproc_cluster",
             trigger_rule="all_done",
             dag=dag,
-            **shared_config
+            **shared_config,
         )
         create_dataproc_cluster >> run_dataproc_spark >> delete_dataproc_cluster
         return dag

--- a/dags/utils/gke.py
+++ b/dags/utils/gke.py
@@ -33,6 +33,28 @@ def create_gke_config(
         "master_authorized_networks_config": {"enabled": not is_dev},
         "node_pools": [
             {
+                "name": "baseline",
+                "config": {
+                    # smallest node that we can run in GKE
+                    "machine_type": "g1-small",
+                    "disk_size_gb": 10,
+                    "oauth_scopes": [
+                        "https://www.googleapis.com/auth/bigquery",
+                        "https://www.googleapis.com/auth/devstorage.read_write",
+                        "https://www.googleapis.com/auth/logging.write",
+                        "https://www.googleapis.com/auth/monitoring",
+                        "https://www.googleapis.com/auth/service.management.readonly",
+                        "https://www.googleapis.com/auth/servicecontrol",
+                        "https://www.googleapis.com/auth/trace.append",
+                    ],
+                    "service_account": service_account,
+                    "labels": {"owner": owner_label, "team": team_label},
+                    "preemptible": True,
+                    "disk_type": "pd-standard",
+                },
+                "initial_node_count": 1,
+            },
+            {
                 "name": name,
                 "config": {
                     "machine_type": machine_type,
@@ -51,10 +73,10 @@ def create_gke_config(
                     "preemptible": preemptible,
                     "disk_type": disk_type,
                 },
-                "initial_node_count": 1,
+                "initial_node_count": 0,
                 "autoscaling": {
                     "enabled": True,
-                    "min_node_count": 1,
+                    "min_node_count": 0,
                     "max_node_count": 5,
                 },
             }


### PR DESCRIPTION
This departs from the original idea that the GKE clusters for the prio-processor jobs are ephemeral. This creates a new cluster (if it already doesn't exist) with a single baseline node-pool to keep the cluster alive (a single `g1-small` with 10gb of hdd) and a burst-able node-pool (as per https://medium.com/google-cloud/scale-your-kubernetes-cluster-to-almost-zero-with-gke-autoscaler-9c78051cbf40). 

In addition, I've been adding companion changes in a separate PR and testing the deploy using GCR. It helps to use a docker repository in cloud storage to debug deployments in GKE.

