### PR TITLE
TAARlite GUID Ranking job

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -244,6 +244,10 @@ taar_lite_guidranking = SubDagOperator(
         ],
         aws_conn_id=taar_aws_conn_id,
         gcp_conn_id=taar_gcpdataproc_conn_id,
+        # The SSDs are added here to improve the spark
+        # execution speed.  They can probably be removed as this job
+        # runs fairly quickly (single digit minutes) using the current
+        # configuration.
         master_disk_type="pd-ssd",
         worker_disk_type="pd-ssd",
         master_disk_size=1024,

--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -254,35 +254,6 @@ taar_lite_guidranking = SubDagOperator(
     dag=dag,
 )
 
-taar_delete_requests = SubDagOperator(
-    task_id="taar_locale",
-    subdag=moz_dataproc_pyspark_runner(
-        parent_dag_name=dag.dag_id,
-        dag_name="taar_locale",
-        default_args=default_args,
-        cluster_name=taar_locale_cluster_name,
-        job_name="TAAR_Locale",
-        python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_locale.py",
-        num_workers=12,
-        py_args=[
-            "--date",
-            "{{ ds_nodash }}",
-            "--aws_access_key_id",
-            taar_aws_access_key,
-            "--aws_secret_access_key",
-            taar_aws_secret_key,
-            "--bucket",
-            "telemetry-private-analysis-2",
-            "--prefix",
-            "taar/locale/",
-        ],
-        aws_conn_id=taar_aws_conn_id,
-        gcp_conn_id=taar_gcpdataproc_conn_id,
-    ),
-    dag=dag,
-)
-
-
 amodump >> amowhitelist
 amodump >> editorial_whitelist
 

--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -218,6 +218,34 @@ taar_lite = SubDagOperator(
     dag=dag,
 )
 
+taar_delete_requests = SubDagOperator(
+    task_id="taar_locale",
+    subdag=moz_dataproc_pyspark_runner(
+        parent_dag_name=dag.dag_id,
+        dag_name="taar_locale",
+        default_args=default_args,
+        cluster_name=taar_locale_cluster_name,
+        job_name="TAAR_Locale",
+        python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_locale.py",
+        num_workers=12,
+        py_args=[
+            "--date",
+            "{{ ds_nodash }}",
+            "--aws_access_key_id",
+            taar_aws_access_key,
+            "--aws_secret_access_key",
+            taar_aws_secret_key,
+            "--bucket",
+            "telemetry-private-analysis-2",
+            "--prefix",
+            "taar/locale/",
+        ],
+        aws_conn_id=taar_aws_conn_id,
+        gcp_conn_id=taar_gcpdataproc_conn_id,
+    ),
+    dag=dag,
+)
+
 
 amodump >> amowhitelist
 amodump >> editorial_whitelist

--- a/jobs/taar_lite_guidranking.py
+++ b/jobs/taar_lite_guidranking.py
@@ -1,0 +1,80 @@
+"""
+This ETL job computes the installation rate of all addons and then
+cross references against the whitelist to compute the total install
+rate for all whitelisted addons.
+"""
+
+
+import click
+import json
+import logging
+from pyspark.sql import SparkSession
+import mozetl.taar.taar_utils as taar_utils
+
+
+OUTPUT_BUCKET = "telemetry-parquet"
+OUTPUT_PREFIX = "taar/lite/"
+OUTPUT_BASE_FILENAME = "guid_install_ranking"
+
+
+def extract_telemetry(sparkSession):
+    """ Load some training data from telemetry given a sparkContext
+    """
+    frame = sparkSession.sql(
+        """
+    SELECT
+        addon_row.addon_id as addon_guid,
+        count(*) as install_count
+    FROM
+        (SELECT
+            explode(active_addons) as addon_row
+        FROM
+            clients_daily
+        WHERE
+            channel='release' AND
+            app_name='Firefox' and
+            size(active_addons) > 0
+        )
+        GROUP BY addon_row.addon_id
+    """
+    )
+    return frame
+
+
+def transform(frame):
+    """ Convert the dataframe to JSON and augment each record to
+    include the install count for each addon.
+    """
+
+    def lambda_func(x):
+        return (x.addon_guid, x.install_count)
+
+    return dict(frame.rdd.map(lambda_func).collect())
+
+
+def load_s3(result_data, date, prefix, bucket):
+    taar_utils.store_json_to_s3(
+        json.dumps(result_data, indent=2), OUTPUT_BASE_FILENAME, date, prefix, bucket
+    )
+
+
+@click.command()
+@click.option("--date", required=True)
+@click.option("--bucket", default=OUTPUT_BUCKET)
+@click.option("--prefix", default=OUTPUT_PREFIX)
+def main(date, bucket, prefix):
+    spark = (
+        SparkSession.builder.appName("taar_lite_ranking")
+        .enableHiveSupport()
+        .getOrCreate()
+    )
+
+    logging.info("Processing GUID install rankings")
+
+    data_frame = extract_telemetry(spark)
+    result_data = transform(data_frame)
+    load_s3(result_data, date, prefix, bucket)
+
+
+if __name__ == "__main__":
+    main()

--- a/jobs/taar_lite_guidranking.py
+++ b/jobs/taar_lite_guidranking.py
@@ -6,10 +6,13 @@ rate for all whitelisted addons.
 
 
 import click
+import contextlib
+import boto3
+import tempfile
 import json
 import logging
 from pyspark.sql import SparkSession
-import mozetl.taar.taar_utils as taar_utils
+import os
 
 
 OUTPUT_BUCKET = "telemetry-parquet"
@@ -17,10 +20,39 @@ OUTPUT_PREFIX = "taar/lite/"
 OUTPUT_BASE_FILENAME = "guid_install_ranking"
 
 
-def extract_telemetry(sparkSession):
+def aws_env_credentials():
+    """
+    Load the AWS credentials from the enviroment
+    """
+    result = {
+        "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", None),
+        "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY", None),
+    }
+    logging.info(
+        "Loading AWS credentials from enviroment: {}".format(str(result))
+    )
+    return result
+
+
+@contextlib.contextmanager
+def selfdestructing_path(dirname):
+    import shutil
+
+    yield dirname
+    shutil.rmtree(dirname)
+
+
+def extract_telemetry(spark):
     """ Load some training data from telemetry given a sparkContext
     """
-    frame = sparkSession.sql(
+
+    gs_url = "gs://moz-fx-data-derived-datasets-parquet/clients_daily/v6"
+    parquetFile = spark.read.parquet(gs_url)
+    # Use the parquet files to create a temporary view and then used
+    # in SQL statements.
+    parquetFile.createOrReplaceTempView("clients_daily")
+
+    frame = spark.sql(
         """
     SELECT
         addon_row.addon_id as addon_guid,
@@ -52,17 +84,76 @@ def transform(frame):
     return dict(frame.rdd.map(lambda_func).collect())
 
 
+def write_to_s3(source_file_name, s3_dest_file_name, s3_prefix, bucket):
+    """Store the new json file containing current top addons per locale to S3.
+
+    :param source_file_name: The name of the local source file.
+    :param s3_dest_file_name: The name of the destination file on S3.
+    :param s3_prefix: The S3 prefix in the bucket.
+    :param bucket: The S3 bucket.
+    """
+    client = boto3.client(
+        service_name="s3", region_name="us-west-2", **aws_env_credentials()
+    )
+    transfer = boto3.s3.transfer.S3Transfer(client)
+
+    # Update the state in the analysis bucket.
+    key_path = s3_prefix + s3_dest_file_name
+    transfer.upload_file(source_file_name, bucket, key_path)
+
+
+def store_json_to_s3(json_data, base_filename, date, prefix, bucket):
+    """Saves the JSON data to a local file and then uploads it to S3.
+
+    Two copies of the file will get uploaded: one with as
+    "<base_filename>.json"
+    and the other as "<base_filename><YYYYMMDD>.json" for backup purposes.
+
+    :param json_data: A string with the JSON content to write.
+    :param base_filename: A string with the base name of the file to
+                            use for saving locally and uploading to S3.
+    :param date: A date string in the "YYYYMMDD" format.
+    :param prefix: The S3 prefix.
+    :param bucket: The S3 bucket name.
+    """
+
+    tempdir = tempfile.mkdtemp()
+
+    with selfdestructing_path(tempdir):
+        JSON_FILENAME = "{}.json".format(base_filename)
+        FULL_FILENAME = os.path.join(tempdir, JSON_FILENAME)
+        with open(FULL_FILENAME, "w+") as json_file:
+            json_file.write(json_data)
+
+        archived_file_copy = "{}{}.json".format(base_filename, date)
+
+        # Store a copy of the current JSON with datestamp.
+        write_to_s3(FULL_FILENAME, archived_file_copy, prefix, bucket)
+        write_to_s3(FULL_FILENAME, JSON_FILENAME, prefix, bucket)
+
+
 def load_s3(result_data, date, prefix, bucket):
-    taar_utils.store_json_to_s3(
-        json.dumps(result_data, indent=2), OUTPUT_BASE_FILENAME, date, prefix, bucket
+    store_json_to_s3(
+        json.dumps(result_data, indent=2),
+        OUTPUT_BASE_FILENAME,
+        date,
+        prefix,
+        bucket,
     )
 
 
 @click.command()
 @click.option("--date", required=True)
+@click.option("--aws_access_key_id", required=True)
+@click.option("--aws_secret_access_key", required=True)
 @click.option("--bucket", default=OUTPUT_BUCKET)
 @click.option("--prefix", default=OUTPUT_PREFIX)
-def main(date, bucket, prefix):
+def main(date, aws_access_key_id, aws_secret_access_key, bucket, prefix):
+
+    # Clobber the AWS access credentials
+    os.environ["AWS_ACCESS_KEY_ID"] = aws_access_key_id
+    os.environ["AWS_SECRET_ACCESS_KEY"] = aws_secret_access_key
+
     spark = (
         SparkSession.builder.appName("taar_lite_ranking")
         .enableHiveSupport()


### PR DESCRIPTION
The TAARlite guid ranking job was accidentally removed during the rewrite of many jobs.

This adds it back in.

The job successfully generated the JSON file at `s3://telemetry-parquet/taar/lite/guid_install_ranking.json` which contains a map of GUIDs to installation counts

```
$ aws s3 ls s3://telemetry-parquet/taar/lite/guid_install_ranking.json
2020-09-02 15:22:53    6194266 guid_install_ranking.json
```