### PR TITLE
Update burnham glean error test

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -143,9 +143,9 @@ WANT_TEST_EXPERIMENTS = [
     {"experiment": "spore_drive:tardigrade-dna", "document_count": 6},
 ]
 
-# Test scenario test_glean_error_invalid_value: Verify that the Glean SDK
+# Test scenario test_glean_error_invalid_overflow: Verify that the Glean SDK
 # correctly reports the number of times a metric was set to an invalid value.
-TEST_GLEAN_ERROR_INVALID_VALUE = f"""{WITH_DISCOVERY_V1_DEDUPED}
+TEST_GLEAN_ERROR_INVALID_OVERFLOW = f"""{WITH_DISCOVERY_V1_DEDUPED}
 SELECT
   metrics.string.mission_identifier,
   metrics.labeled_counter.glean_error_invalid_overflow
@@ -159,7 +159,7 @@ LIMIT
   20
 """
 
-WANT_TEST_GLEAN_ERROR_INVALID_VALUE = [
+WANT_TEST_GLEAN_ERROR_INVALID_OVERFLOW = [
     {
         "mission_identifier": "MISSION E: ONE JUMP, ONE METRIC ERROR",
         "glean_error_invalid_overflow": [{"key": "mission.status", "value": 1}],
@@ -408,9 +408,9 @@ with models.DAG(
             "want": WANT_TEST_EXPERIMENTS,
         },
         {
-            "name": "test_glean_error_invalid_value",
-            "query": TEST_GLEAN_ERROR_INVALID_VALUE,
-            "want": WANT_TEST_GLEAN_ERROR_INVALID_VALUE,
+            "name": "test_glean_error_invalid_overflow",
+            "query": TEST_GLEAN_ERROR_INVALID_OVERFLOW,
+            "want": WANT_TEST_GLEAN_ERROR_INVALID_OVERFLOW,
         },
     ]
 

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -144,7 +144,9 @@ WANT_TEST_EXPERIMENTS = [
 ]
 
 # Test scenario test_glean_error_invalid_overflow: Verify that the Glean SDK
-# correctly reports the number of times a metric was set to an invalid value.
+# correctly reports the number of times a string metric was set to a value that
+# exceeds the maximum string length measured in the number of bytes when the
+# string is encoded in UTF-8.
 TEST_GLEAN_ERROR_INVALID_OVERFLOW = f"""{WITH_DISCOVERY_V1_DEDUPED}
 SELECT
   metrics.string.mission_identifier,

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -148,11 +148,11 @@ WANT_TEST_EXPERIMENTS = [
 TEST_GLEAN_ERROR_INVALID_VALUE = f"""{WITH_DISCOVERY_V1_DEDUPED}
 SELECT
   metrics.string.mission_identifier,
-  metrics.labeled_counter.glean_error_invalid_value
+  metrics.labeled_counter.glean_error_invalid_overflow
 FROM
   deduped
 WHERE
-  ARRAY_LENGTH(metrics.labeled_counter.glean_error_invalid_value) > 0
+  ARRAY_LENGTH(metrics.labeled_counter.glean_error_invalid_overflow) > 0
 ORDER BY
   metrics.string.mission_identifier
 LIMIT
@@ -162,7 +162,7 @@ LIMIT
 WANT_TEST_GLEAN_ERROR_INVALID_VALUE = [
     {
         "mission_identifier": "MISSION E: ONE JUMP, ONE METRIC ERROR",
-        "glean_error_invalid_value": [{"key": "mission.status", "value": 1}],
+        "glean_error_invalid_overflow": [{"key": "mission.status", "value": 1}],
     }
 ]
 


### PR DESCRIPTION
[Glean v31.5.0][glean] changed the error reporting behavior. String values that are too long now record `invalid_overflow` rather than `invalid_value`.

Resolve https://github.com/mozilla/burnham/issues/70

[glean]: https://github.com/mozilla/glean/releases/tag/v31.5.0
