### PR TITLE
Add additional tests for two new burnham tables

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -24,14 +24,14 @@ PROJECT_ID = "moz-fx-data-shared-prod"
 
 # Live tables are not guaranteed to be deduplicated. To ensure reproducibility,
 # we need to deduplicate Glean pings produced by burnham for these tests.
-WITH_DISCOVERY_V1_DEDUPED = f"""
+WITH_DEDUPED_TABLE = """
 WITH
   numbered AS (
   SELECT
     ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) AS _n,
     *
   FROM
-    `{PROJECT_ID}.burnham_live.discovery_v1`
+    `{project_id}.burnham_live.{table}`
   WHERE
     submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR)
     AND metrics.uuid.test_run = @burnham_test_run ),
@@ -43,43 +43,17 @@ WITH
   WHERE
     _n = 1 )"""
 
-WITH_STARBASE46_V1_DEDUPED = f"""
-WITH
-  numbered AS (
-  SELECT
-    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) AS _n,
-    *
-  FROM
-    `{PROJECT_ID}.burnham_live.starbase46_v1`
-  WHERE
-    submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR)
-    AND metrics.uuid.test_run = @burnham_test_run ),
-  deduped AS (
-  SELECT
-    * EXCEPT(_n)
-  FROM
-    numbered
-  WHERE
-    _n = 1 )"""
+WITH_DISCOVERY_V1_DEDUPED = WITH_DEDUPED_TABLE.format(
+    project_id=PROJECT_ID, table="discovery_v1"
+)
 
-WITH_SPACE_SHIP_READY_V1_DEDUPED = f"""
-WITH
-  numbered AS (
-  SELECT
-    ROW_NUMBER() OVER (PARTITION BY document_id ORDER BY submission_timestamp) AS _n,
-    *
-  FROM
-    `{PROJECT_ID}.burnham_live.space_ship_ready_v1`
-  WHERE
-    submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR)
-    AND metrics.uuid.test_run = @burnham_test_run ),
-  deduped AS (
-  SELECT
-    * EXCEPT(_n)
-  FROM
-    numbered
-  WHERE
-    _n = 1 )"""
+WITH_STARBASE46_V1_DEDUPED = WITH_DEDUPED_TABLE.format(
+    project_id=PROJECT_ID, table="starbase46_v1"
+)
+
+WITH_SPACE_SHIP_READY_V1_DEDUPED = WITH_DEDUPED_TABLE.format(
+    project_id=PROJECT_ID, table="space_ship_ready_v1"
+)
 
 # Test scenario test_labeled_counter_metrics: Verify that labeled_counter
 # metric values reported by the Glean SDK across several documents from three

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -212,8 +212,6 @@ SELECT
   COUNT(*) AS count_documents
 FROM
   deduped
-LIMIT
-  20
 """
 
 WANT_TEST_STARBASE46_PING = [{"count_documents": 1}]
@@ -225,8 +223,6 @@ SELECT
   COUNT(*) AS count_documents
 FROM
   deduped
-LIMIT
-  20
 """
 
 WANT_TEST_SPACE_SHIP_READY_PING = [{"count_documents": 3}]

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -560,7 +560,7 @@ with models.DAG(
     # Tasks related to the space_ship_ready table
     wait_for_space_ship_ready_data = burnham_sensor(
         task_id="wait_for_space_ship_ready_data",
-        sql=STARBASE46_SENSOR_TEMPLATE.format(
+        sql=SPACE_SHIP_READY_SENSOR_TEMPLATE.format(
             project_id=PROJECT_ID,
             test_run=burnham_test_run,
             test_name=burnham_test_name,


### PR DESCRIPTION
The burnham DAG currently creates three clients. Every burnham client will submit exactly one `space_ship_ready` ping after Glean is initialized and a space ship is created. When a client completes `MISSION E: ONE JUMP, ONE METRIC ERROR` the `starbase46` ping is submitted, which happens exactly once in this DAG. The updated DAG will now verify the document counts.
 
This is currently blocked on the schema deploy for the new pings.

See https://github.com/mozilla/probe-scraper/issues/225