### PR TITLE
Bug 1664582 -  Run prio-processor containers on persistent GKE clusters

### DIFF
--- a/dags/prio/kubernetes.py
+++ b/dags/prio/kubernetes.py
@@ -61,55 +61,80 @@ def container_subdag(
         "location": location,
     }
 
-    with DAG(
-        "{}.{}".format(parent_dag_name, child_dag_name), default_args=default_args
-    ) as dag:
-        create_gke_cluster = GKEClusterCreateOperator(
-            task_id="create_gke_cluster",
-            body=create_gke_config(
-                name=cluster_name,
-                service_account=service_account,
-                owner_label=owner_label,
-                team_label=team_label,
-                machine_type=machine_type,
-                location=location,
-                # DataProc clusters require VPC with auto-created subnets
-                subnetwork="default" if server_id == "admin" else "gke-subnet",
-                is_dev=environ.get("DEPLOY_ENVIRONMENT") == "dev",
-            ),
-            dag=dag,
-            **shared_config
-        )
+    with DAG(f"{parent_dag_name}.{child_dag_name}", default_args=default_args) as dag:
+        # https://cloud.google.com/composer/docs/how-to/using/using-kubernetes-pod-operator#kubernetespodoperator_configuration
+        # https://medium.com/google-cloud/scale-your-kubernetes-cluster-to-almost-zero-with-gke-autoscaler-9c78051cbf40
+        # https://docs.openshift.com/container-platform/3.6/admin_guide/scheduling/pod_affinity.html
+        # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+        # https://cloud.google.com/composer/docs/how-to/using/using-kubernetes-pod-operator
+        # https://airflow.apache.org/docs/stable/_api/airflow/contrib/operators/kubernetes_pod_operator/index.html
+        def failure_callback(context):
+            return GKEClusterCreateOperator(
+                task_id="create_gke_cluster",
+                body=create_gke_config(
+                    name=cluster_name,
+                    service_account=service_account,
+                    owner_label=owner_label,
+                    team_label=team_label,
+                    machine_type=machine_type,
+                    location=location,
+                    # DataProc clusters require VPC with auto-created subnets
+                    subnetwork="default" if server_id == "admin" else "gke-subnet",
+                    is_dev=environ.get("DEPLOY_ENVIRONMENT") == "dev",
+                ),
+                # If set as a normal operator, typically a trigger rule as below
+                # would be set.
+                # trigger_rule="one_failed",
+                dag=dag,
+                **shared_config,
+            ).execute(context)
 
-        # Running the pod without any time in-between will cause the scope-based
-        # authentication in Google Cloud Platform to fail. For example:
-        #
-        # `ServiceException: 401 Anonymous caller does not have
-        # storage.objects.get access to moz-fx-prio-dev-a-private/processed/`
-        #
-        # Sleeping by a small amount solves this problem. This issue was first
-        # noticed intermittently on 2019-09-09.
-        sleep = BashOperator(task_id="sleep", bash_command="sleep 60", dag=dag)
-
-        run_prio = GKEPodOperator(
-            task_id="processor_{}".format(server_id),
-            name="run-prio-project-{}".format(server_id),
+        run = GKEPodOperator(
+            task_id=f"processor_{server_id}",
+            name=f"processor_{server_id}",
             cluster_name=cluster_name,
             namespace="default",
             image=image,
             arguments=arguments,
             env_vars=env_vars,
             dag=dag,
-            **shared_config
+            # choose the autoscaling node-pool for any jobs
+            node_selectors={"node-label": "burstable"},
+            labels={"pod-label": "burstable-pod"},
+            affinity={
+                "podAntiAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": [
+                        {
+                            "labelSelector": {
+                                "matchExpressions": [
+                                    {
+                                        "key": "pod-label",
+                                        "operator": "In",
+                                        "values": ["burstable-pod"],
+                                    }
+                                ]
+                            },
+                            "topologyKey": "kubernetes.io/hostname",
+                        }
+                    ]
+                }
+            },
+            # tolerate the tainted node
+            tolerations=[
+                {
+                    "key": "reserved-pool",
+                    "operator": "Equal",
+                    "value": "true",
+                    "effect": "NoSchedule",
+                }
+            ],
+            # A new VM instance may take more than 120 seconds to boot
+            startup_timeout_seconds=240,
+            # delete the pod after running
+            is_delete_operator_pod=True,
+            on_failure_callback=failure_callback,
+            **shared_config,
+            **kwargs,
         )
 
-        delete_gke_cluster = GKEClusterDeleteOperator(
-            task_id="delete_gke_cluster",
-            name=cluster_name,
-            trigger_rule="all_done",
-            dag=dag,
-            **shared_config
-        )
-
-        create_gke_cluster >> sleep >> run_prio >> delete_gke_cluster
         return dag

--- a/dags/utils/gke.py
+++ b/dags/utils/gke.py
@@ -33,7 +33,29 @@ def create_gke_config(
         "master_authorized_networks_config": {"enabled": not is_dev},
         "node_pools": [
             {
-                "name": name,
+                "name": "baseline",
+                "config": {
+                    # smallest node that we can run in GKE
+                    "machine_type": "g1-small",
+                    "disk_size_gb": 10,
+                    "oauth_scopes": [
+                        "https://www.googleapis.com/auth/bigquery",
+                        "https://www.googleapis.com/auth/devstorage.read_write",
+                        "https://www.googleapis.com/auth/logging.write",
+                        "https://www.googleapis.com/auth/monitoring",
+                        "https://www.googleapis.com/auth/service.management.readonly",
+                        "https://www.googleapis.com/auth/servicecontrol",
+                        "https://www.googleapis.com/auth/trace.append",
+                    ],
+                    "service_account": service_account,
+                    "labels": {"owner": owner_label, "team": team_label},
+                    "preemptible": True,
+                    "disk_type": "pd-standard",
+                },
+                "initial_node_count": 1,
+            },
+            {
+                "name": "burstable",
                 "config": {
                     "machine_type": machine_type,
                     "disk_size_gb": disk_size_gb,
@@ -47,17 +69,32 @@ def create_gke_config(
                         "https://www.googleapis.com/auth/trace.append",
                     ],
                     "service_account": service_account,
-                    "labels": {"owner": owner_label, "team": team_label},
+                    "labels": {
+                        "owner": owner_label,
+                        "team": team_label,
+                        "node-label": "burstable",
+                    },
                     "preemptible": preemptible,
                     "disk_type": disk_type,
+                    # prevent non-burstable workloads from running here so we
+                    # can autoscale down to 0
+                    "taints": [
+                        {
+                            "key": "reserved-pool",
+                            "value": "true",
+                            # https://googleapis.dev/python/container/latest/_modules/google/cloud/container_v1/types/cluster_service.html#NodeTaint.Effect
+                            # NodeTaint.Effect.NO_SCHEDULE
+                            "effect": 1,
+                        }
+                    ],
                 },
-                "initial_node_count": 1,
+                "initial_node_count": 0,
                 "autoscaling": {
                     "enabled": True,
-                    "min_node_count": 1,
+                    "min_node_count": 0,
                     "max_node_count": 5,
                 },
-            }
+            },
         ],
         "locations": [location],
         "network": "default",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1664582)

This departs from the original idea that the GKE clusters for the prio-processor jobs are ephemeral. This creates a new cluster (if it already doesn't exist) with a single baseline node-pool to keep the cluster alive (a single `g1-small` with 10gb of hdd) and a burst-able node-pool (as per https://medium.com/google-cloud/scale-your-kubernetes-cluster-to-almost-zero-with-gke-autoscaler-9c78051cbf40). 