### PR TITLE
Enable DEBUG logging for burnham operators

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -285,6 +285,8 @@ def burnham_run(
         "BURNHAM_PLATFORM_URL": BURNHAM_PLATFORM_URL,
         "BURNHAM_TEST_RUN": burnham_test_run,
         "BURNHAM_TEST_NAME": burnham_test_name,
+        "BURNHAM_VERBOSE": "true",
+        "GLEAN_LOG_PINGS": "true",
     }
 
     if burnham_spore_drive is not None:


### PR DESCRIPTION
We currently don't store DEBUG logs from the burnham application and don't log when the Glean SDK is sending pings. This pull-request sets the respective environment variables for the burnham operators which should  help us diagnose any issues.

Resolve https://github.com/mozilla/burnham/issues/73