### PR TITLE
Fix python 3 string handling issue with backfill UI

### DIFF
--- a/plugins/backfill/main.py
+++ b/plugins/backfill/main.py
@@ -130,7 +130,7 @@ class Backfill(get_baseview()):
             while g.is_pending():
                 lines = g.readlines()
                 for proc, line in lines:
-                    result = re.match(pattern, line)
+                    result = re.match(pattern, line.decode("utf-8"))
 
                     if result:
                         # Adhere to text/event-stream format

--- a/plugins/backfill/main.py
+++ b/plugins/backfill/main.py
@@ -130,7 +130,8 @@ class Backfill(get_baseview()):
             while g.is_pending():
                 lines = g.readlines()
                 for proc, line in lines:
-                    result = re.match(pattern, line.decode("utf-8"))
+                    line = line.decode("utf-8")
+                    result = re.match(pattern, line)
 
                     if result:
                         # Adhere to text/event-stream format


### PR DESCRIPTION
I've not had success over the past few days getting the backfill UI to work.
I submit jobs, but they never produce output or result in BQ output.

I checked in cloud logging and found ERROR messages with tracebacks ([example](https://console.cloud.google.com/logs/query;pinnedLogId=2020-10-15T13:57:27.221935242Z%2Fr7d2ll39deckufib8;query=backfill%0Aseverity%3DERROR?project=moz-fx-data-airflow-prod-88e0)):

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base_async.py", line 56, in handle
    self.handle_request(listener_name, req, client, addr)
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/ggevent.py", line 160, in handle_request
    addr)
  File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base_async.py", line 114, in handle_request
    for item in respiter:
  File "/usr/local/lib/python3.7/site-packages/werkzeug/wsgi.py", line 506, in __next__
    return self._next()
  File "/usr/local/lib/python3.7/site-packages/werkzeug/wrappers/base_response.py", line 45, in _iter_encoded
    for item in iterable:
  File "/app/pvmount/telemetry-airflow/plugins/backfill/main.py", line 133, in read_process
    result = re.match(pattern, line)
  File "/usr/local/lib/python3.7/re.py", line 175, in match
    return _compile(pattern, flags).match(string)
TypeError: cannot use a string pattern on a bytes-like object
```

So looks like a Python 3 migration bug, and submitted tasks are generating
exceptions before they're able to run.