### PR TITLE
Make client_scalar_probe_counts depend on scalar_percentiles

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -266,7 +266,9 @@ clients_daily_scalar_aggregates >> clients_daily_keyed_boolean_aggregates
 clients_daily_keyed_boolean_aggregates >> clients_scalar_aggregates
 clients_daily_keyed_scalar_aggregates >> clients_scalar_aggregates
 clients_scalar_aggregates >> scalar_percentiles
-clients_scalar_aggregates >> client_scalar_probe_counts
+# workaround resources exceeded exception
+# client_scalar_probe_counts is not dependent on scalar_percentiles
+scalar_percentiles >> client_scalar_probe_counts
 
 latest_versions >> clients_daily_histogram_aggregates_parent
 clients_daily_histogram_aggregates_parent >> clients_daily_histogram_aggregates_content


### PR DESCRIPTION
This is a temporary workaround for a resources exceeded exception when running clients_scalar_probe_counts tracked here: https://github.com/mozilla/bigquery-etl/issues/1432

The task almost always fails on the first run but succeeds afterwards.  My guess is other queries are taking up too many slots on the first run.  This graph https://workflow.telemetry.mozilla.org/gantt?dag_id=glam shows the successful re-run.  The first run starts at the same time as scalar_percentiles.  My hypothesis is that making these two run sequentially will avoid the exception.  

This is a temporary workaround to avoid daily failures.  There's no guarantee that other queries in the project won't also cause the issue.