### PR TITLE
Bug 1675348 - Refactor prio-processor dag to decouple server components

### DIFF
--- a/dags/prio/kubernetes.py
+++ b/dags/prio/kubernetes.py
@@ -7,10 +7,9 @@ from airflow.contrib.operators.gcp_container_operator import (
     GKEClusterCreateOperator,
     GKEClusterDeleteOperator,
 )
-from operators.gcp_container_operator import GKEPodOperator
-
-from utils.gke import create_gke_config
 from airflow.operators.bash_operator import BashOperator
+from operators.gcp_container_operator import GKEPodOperator
+from utils.gke import create_gke_config
 
 
 def container_subdag(

--- a/dags/prio_processor.py
+++ b/dags/prio_processor.py
@@ -1,1 +1,148 @@
-from prio.processor import dag
+from datetime import datetime, timedelta
+from os import environ
+
+from airflow import DAG
+from airflow.contrib.hooks.gcs_hook import GoogleCloudStorageHook
+from prio.processor import ingestion_subdag, load_bigquery_subdag, prio_processor_subdag
+
+DEFAULT_ARGS = {
+    "owner": "amiyaguchi@mozilla.com",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 8, 22),
+    "email": [
+        "amiyaguchi@mozilla.com",
+        "hwoo@mozilla.com",
+        "dataops+alerts@mozilla.com",
+    ],
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
+    "dagrun_timeout": timedelta(hours=4),
+}
+
+# use a less than desirable method of generating the service account name
+IS_DEV = environ.get("DEPLOY_ENVIRONMENT") != "prod"
+ENVIRONMENT = "dev" if IS_DEV else "prod"
+
+PRIO_ADMIN_CONN = "google_cloud_prio_admin"
+PRIO_A_CONN = "google_cloud_prio_a"
+PRIO_B_CONN = "google_cloud_prio_b"
+
+PROJECT_ADMIN = GoogleCloudStorageHook(PRIO_ADMIN_CONN).project_id
+PROJECT_A = GoogleCloudStorageHook(PRIO_A_CONN).project_id
+PROJECT_B = GoogleCloudStorageHook(PRIO_B_CONN).project_id
+
+SERVICE_ACCOUNT_ADMIN = f"prio-admin-runner@{PROJECT_ADMIN}.iam.gserviceaccount.com"
+SERVICE_ACCOUNT_A = f"prio-runner-{ENVIRONMENT}-a@{PROJECT_A}.iam.gserviceaccount.com"
+SERVICE_ACCOUNT_B = f"prio-runner-{ENVIRONMENT}-b@{PROJECT_B}.iam.gserviceaccount.com"
+
+BUCKET_PRIVATE_A = f"moz-fx-prio-{ENVIRONMENT}-a-private"
+BUCKET_PRIVATE_B = f"moz-fx-prio-{ENVIRONMENT}-b-private"
+BUCKET_SHARED_A = f"moz-fx-prio-{ENVIRONMENT}-a-shared"
+BUCKET_SHARED_B = f"moz-fx-prio-{ENVIRONMENT}-b-shared"
+BUCKET_DATA_ADMIN = f"moz-fx-data-{ENVIRONMENT}-prio-data"
+BUCKET_BOOTSTRAP_ADMIN = f"moz-fx-data-{ENVIRONMENT}-prio-bootstrap"
+
+APP_NAME = "origin-telemetry"
+BUCKET_PREFIX = "data/v1"
+
+# https://airflow.apache.org/faq.html#how-can-my-airflow-dag-run-faster
+# max_active_runs controls the number of DagRuns at a given time.
+dag = DAG(
+    dag_id="prio_processor",
+    max_active_runs=1,
+    default_args=DEFAULT_ARGS,
+    schedule_interval="@daily",
+)
+
+ingest = ingestion_subdag(
+    dag,
+    DEFAULT_ARGS,
+    PRIO_ADMIN_CONN,
+    SERVICE_ACCOUNT_ADMIN,
+    BUCKET_BOOTSTRAP_ADMIN,
+    BUCKET_DATA_ADMIN,
+    BUCKET_PREFIX,
+    APP_NAME,
+    BUCKET_PRIVATE_A,
+    BUCKET_PRIVATE_B,
+    "{{ var.value.prio_public_key_hex_internal }}",
+    "{{ var.value.prio_public_key_hex_external }}",
+)
+
+processor_a = prio_processor_subdag(
+    dag,
+    DEFAULT_ARGS,
+    PRIO_A_CONN,
+    SERVICE_ACCOUNT_A,
+    "a",
+    {
+        "APP_NAME": APP_NAME,
+        "SUBMISSION_DATE": "{{ ds }}",
+        "DATA_CONFIG": "/app/config/content.json",
+        "SERVER_ID": "A",
+        "SHARED_SECRET": "{{ var.value.prio_shared_secret }}",
+        "PRIVATE_KEY_HEX": "{{ var.value.prio_private_key_hex_internal }}",
+        "PUBLIC_KEY_HEX_INTERNAL": "{{ var.value.prio_public_key_hex_internal }}",
+        "PUBLIC_KEY_HEX_EXTERNAL": "{{ var.value.prio_public_key_hex_external }}",
+        "BUCKET_INTERNAL_PRIVATE": "gs://" + BUCKET_PRIVATE_A,
+        "BUCKET_INTERNAL_SHARED": "gs://" + BUCKET_SHARED_A,
+        "BUCKET_EXTERNAL_SHARED": "gs://" + BUCKET_SHARED_B,
+        "BUCKET_PREFIX": BUCKET_PREFIX,
+        # 15 minutes of timeout
+        "RETRY_LIMIT": "90",
+        "RETRY_DELAY": "10",
+        "RETRY_BACKOFF_EXPONENT": "1",
+    },
+)
+
+processor_b = prio_processor_subdag(
+    dag,
+    DEFAULT_ARGS,
+    PRIO_B_CONN,
+    SERVICE_ACCOUNT_B,
+    "b",
+    {
+        "APP_NAME": APP_NAME,
+        "SUBMISSION_DATE": "{{ ds }}",
+        "DATA_CONFIG": "/app/config/content.json",
+        "SERVER_ID": "B",
+        "SHARED_SECRET": "{{ var.value.prio_shared_secret }}",
+        "PRIVATE_KEY_HEX": "{{ var.value.prio_private_key_hex_external }}",
+        "PUBLIC_KEY_HEX_INTERNAL": "{{ var.value.prio_public_key_hex_external }}",
+        "PUBLIC_KEY_HEX_EXTERNAL": "{{ var.value.prio_public_key_hex_internal }}",
+        "BUCKET_INTERNAL_PRIVATE": "gs://" + BUCKET_PRIVATE_B,
+        "BUCKET_INTERNAL_SHARED": "gs://" + BUCKET_SHARED_B,
+        "BUCKET_EXTERNAL_SHARED": "gs://" + BUCKET_SHARED_A,
+        "BUCKET_PREFIX": BUCKET_PREFIX,
+        # 15 minutes of time-out
+        "RETRY_LIMIT": "90",
+        "RETRY_DELAY": "10",
+        "RETRY_BACKOFF_EXPONENT": "1",
+    },
+)
+
+load_bigquery = load_bigquery_subdag(
+    dag,
+    DEFAULT_ARGS,
+    PRIO_ADMIN_CONN,
+    SERVICE_ACCOUNT_ADMIN,
+    env_vars={
+        "APP_NAME": APP_NAME,
+        "SUBMISSION_DATE": "{{ ds }}",
+        "PUBLIC_KEY_HEX_EXTERNAL": "{{ var.value.prio_public_key_hex_external }}",
+        "DATA_CONFIG": "/app/config/content.json",
+        "ORIGIN_CONFIG": "/app/config/telemetry_origin_data_inc.json",
+        "BUCKET_INTERNAL_PRIVATE": "gs://" + BUCKET_PRIVATE_A,
+        "DATASET": "telemetry",
+        "TABLE": "origin_content_blocking",
+        "BQ_REPLACE": "false",
+        "GOOGLE_APPLICATION_CREDENTIALS": "",
+    },
+)
+
+ingest >> processor_a
+ingest >> processor_b
+processor_a >> load_bigquery
+processor_b >> load_bigquery


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1675348)

This PR makes the dag/prio module declare subdag functions that can be used to build separate dag. There are no functional changes. A follow-up dag will separate the dag into two separate dags. 