### PR TITLE
Remove plugin tests from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,8 @@ jobs:
     working_directory: ~/mozilla/telemetry-airflow
     steps:
       - checkout
-      - run: pip install tox
       - run: python -m py_compile dags/*.py
       - run: find . -name *.pyc -delete
-      - run: tox -e py37
 
   verify-requirements:
     docker:


### PR DESCRIPTION
This disables the plugin tests to fix #1179. These tested plugins are not being used (moz_databricks and mozetl). 