### PR TITLE
Add missing GROUP BY clause to burnham query

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -240,6 +240,8 @@ FROM
   deduped
 WHERE
   metrics.string.test_name = "test_disable_upload"
+GROUP BY
+  metrics.string.mission_identifier
 ORDER BY
   metrics.string.mission_identifier
 LIMIT


### PR DESCRIPTION
The `verify_discovery_data_disable_upload` task failed last night due to the following error:

```
SELECT list expression references metrics.string.mission_identifier which is neither grouped nor aggregated
```

This pull-request adds the missing `GROUP BY` clause to the respective query. I tested the query manually in the BigQuery Console and it returns the expected results now.

Follow-up pull-request for #1182 
