### PR TITLE
Fix upstream for verify_deletion_request_data

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -781,5 +781,5 @@ with models.DAG(
     )
 
     verify_deletion_request_data.set_upstream(
-        [wait_for_discovery_data, wait_for_deletion_request_data]
+        [wait_for_discovery_data_disable_upload, wait_for_deletion_request_data]
     )


### PR DESCRIPTION
I realized that I copied the wrong task as an upstream for `verify_deletion_request_data`. FWIW this is not related to the recent failures on Airflow, which will hopefully be resolved by https://github.com/mozilla/burnham/pull/115.

Follow-up for #1195