### PR TITLE
Burnham prune deps

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -522,7 +522,7 @@ with DAG(
     "burnham",
     schedule_interval="@daily",
     default_args=DEFAULT_ARGS,
-    docs_md=DOCS,
+    doc_md=DOCS,
 ) as dag:
 
     # Generate a UUID for this test run

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -7,7 +7,7 @@ import datetime
 import json
 import uuid
 
-from airflow import models
+from airflow import DAG
 from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
 from airflow.operators import PythonOperator
 from operators.bq_sensor import BigQuerySQLSensorOperator
@@ -518,7 +518,7 @@ def encode_test_scenarios(test_scenarios):
     return b64_encoded
 
 
-with models.DAG(
+with DAG(
     "burnham",
     schedule_interval="@daily",
     default_args=DEFAULT_ARGS,

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -593,7 +593,7 @@ with models.DAG(
         timeout=60 * 60 * 1,
     )
     wait_for_discovery_data.set_upstream(
-        [generate_burnham_test_run_uuid, client1, client2, client3]
+        [client1, client2, client3]
     )
 
     discovery_test_scenarios = [
@@ -643,7 +643,7 @@ with models.DAG(
         timeout=60 * 60 * 1,
     )
     wait_for_starbase46_data.set_upstream(
-        [generate_burnham_test_run_uuid, client1, client2, client3]
+        [client1, client2, client3]
     )
 
     starbase46_test_scenarios = [
@@ -678,7 +678,7 @@ with models.DAG(
         timeout=60 * 60 * 1,
     )
     wait_for_space_ship_ready_data.set_upstream(
-        [generate_burnham_test_run_uuid, client1, client2, client3]
+        [client1, client2, client3]
     )
 
     space_ship_ready_test_scenarios = [
@@ -712,7 +712,7 @@ with models.DAG(
         timeout=60 * 60 * 1,
     )
     wait_for_discovery_data_disable_upload.set_upstream(
-        [generate_burnham_test_run_uuid, client4]
+        [client4]
     )
 
     discovery_test_scenarios_disable_upload = [
@@ -755,7 +755,7 @@ with models.DAG(
         timeout=60 * 60 * 1,
     )
     wait_for_deletion_request_data.set_upstream(
-        [generate_burnham_test_run_uuid, client4]
+        [client4]
     )
 
     deletion_request_test_scenarios = [

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -13,6 +13,18 @@ from airflow.operators import PythonOperator
 from operators.bq_sensor import BigQuerySQLSensorOperator
 from operators.gcp_container_operator import GKEPodOperator
 
+DOCS = """\
+# burnham 👩‍🚀📈🤖
+
+The burnham project is an end-to-end test suite that aims to automatically
+verify that Glean-based products correctly measure, collect, and submit
+non-personal information to the GCP-based Data Platform and that the received
+telemetry data is then correctly processed, stored to the respective tables
+and made available in BigQuery.
+
+See https://github.com/mozilla/burnham
+"""
+
 DAG_OWNER = "rpierzina@mozilla.com"
 DAG_EMAIL = ["glean-team@mozilla.com", "rpierzina@mozilla.com"]
 
@@ -507,7 +519,10 @@ def encode_test_scenarios(test_scenarios):
 
 
 with models.DAG(
-    "burnham", schedule_interval="@daily", default_args=DEFAULT_ARGS,
+    "burnham",
+    schedule_interval="@daily",
+    default_args=DEFAULT_ARGS,
+    docs_md=DOCS,
 ) as dag:
 
     # Generate a UUID for this test run
@@ -592,9 +607,7 @@ with models.DAG(
         ),
         timeout=60 * 60 * 1,
     )
-    wait_for_discovery_data.set_upstream(
-        [client1, client2, client3]
-    )
+    wait_for_discovery_data.set_upstream([client1, client2, client3])
 
     discovery_test_scenarios = [
         {
@@ -642,9 +655,7 @@ with models.DAG(
         ),
         timeout=60 * 60 * 1,
     )
-    wait_for_starbase46_data.set_upstream(
-        [client1, client2, client3]
-    )
+    wait_for_starbase46_data.set_upstream([client1, client2, client3])
 
     starbase46_test_scenarios = [
         {
@@ -677,9 +688,7 @@ with models.DAG(
         ),
         timeout=60 * 60 * 1,
     )
-    wait_for_space_ship_ready_data.set_upstream(
-        [client1, client2, client3]
-    )
+    wait_for_space_ship_ready_data.set_upstream([client1, client2, client3])
 
     space_ship_ready_test_scenarios = [
         {
@@ -711,9 +720,7 @@ with models.DAG(
         ),
         timeout=60 * 60 * 1,
     )
-    wait_for_discovery_data_disable_upload.set_upstream(
-        [client4]
-    )
+    wait_for_discovery_data_disable_upload.set_upstream([client4])
 
     discovery_test_scenarios_disable_upload = [
         {
@@ -754,9 +761,7 @@ with models.DAG(
         ),
         timeout=60 * 60 * 1,
     )
-    wait_for_deletion_request_data.set_upstream(
-        [client4]
-    )
+    wait_for_deletion_request_data.set_upstream([client4])
 
     deletion_request_test_scenarios = [
         {


### PR DESCRIPTION
The DAG currently looks a bit cluttered. By pruning these dependencies,
it will be easier to tell what's going on at a glance in the tree view:

https://workflow.telemetry.mozilla.org/tree?dag_id=burnham

Also, Airflow now can render docs on the tree view page.