### PR TITLE
Pin pip to <20.3.0 for now until we fix resolution issue (#1198)

### DIFF
--- a/dataproc_bootstrap/dataproc_init.sh
+++ b/dataproc_bootstrap/dataproc_init.sh
@@ -25,5 +25,5 @@ gsutil cp $TSPA_GS_PATH $TSPA_JAR
 # Install python packages
 PIP_REQUIREMENTS_FILE=/tmp/requirements.txt
 gsutil cp $ARTIFACTS_BUCKET/bootstrap/python-requirements.txt $PIP_REQUIREMENTS_FILE
-/opt/conda/default/bin/pip install --upgrade pip
+/opt/conda/default/bin/pip install --upgrade 'pip<20.3.0'
 /opt/conda/default/bin/pip install -r $PIP_REQUIREMENTS_FILE


### PR DESCRIPTION
Currently, `dataproc_init.sh` updates pip to 20.3.1 which tries to
install the dependencies, but takes > 10 minutes to figure out a
solution set that satisfies the version dependencies.

This has us go back to the previous pip which has the old resolver which
works while we figure out how to straighten out the dependency
requirements.