### PR TITLE
[glam-fenix] Add SRC_PROJECT to export and use variables

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -20,6 +20,9 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
+PROJECT = "moz-fx-data-glam-prod-fca7"
+BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
+
 # Fenix as a product has a convoluted app_id history. The comments note the
 # start and end dates of the id in the app store.
 # https://docs.google.com/spreadsheets/d/18PzkzZxdpFl23__-CIO735NumYDqu7jHpqllo0sBbPA
@@ -61,7 +64,7 @@ for product in PRODUCTS:
     query = generate_and_run_glean_query(
         task_id=f"daily_{product}",
         product=product,
-        destination_project_id="moz-fx-data-glam-prod-fca7",
+        destination_project_id=PROJECT,
         env_vars=dict(STAGE="daily"),
         dag=dag,
     )
@@ -76,7 +79,7 @@ for product in final_products:
     query = generate_and_run_glean_query(
         task_id=f"incremental_{product}",
         product=product,
-        destination_project_id="moz-fx-data-glam-prod-fca7",
+        destination_project_id=PROJECT,
         env_vars=dict(STAGE="incremental"),
         dag=dag,
     )
@@ -89,9 +92,10 @@ for product in final_products:
         task_id=f"export_{product}",
         cmds=["bash"],
         env_vars={
+            "SRC_PROJECT": PROJECT,
             "DATASET": "glam_etl",
             "PRODUCT": product,
-            "BUCKET": "moz-fx-data-glam-prod-fca7-etl-data",
+            "BUCKET": BUCKET,
         },
         command=["script/glam/export_csv"],
         docker_image="mozilla/bigquery-etl:latest",


### PR DESCRIPTION
I noticed that the SRC_PROJECT wasn't set correctly for the csv exports. 

https://github.com/mozilla/bigquery-etl/blob/0990be8bfa5ec66eff41da898db75e3d75280f0e/script/glam/export_csv#L7-L9