### PR TITLE
DAG for running the experiment monitoring data export

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -87,49 +87,7 @@ with models.DAG(
 
     copy_deduplicate_main_ping >> bq_main_events
 
-    # Experiment enrollment aggregates chain (depends on events)
-
-    experiment_enrollment_aggregates = bigquery_etl_query(
-        task_id="experiment_enrollment_aggregates",
-        project_id="moz-fx-data-shared-prod",
-        destination_table="experiment_enrollment_aggregates_v1",
-        dataset_id="telemetry_derived",
-        owner="ssuh@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"])
-
-    gen_query_task_id = "experiment_enrollment_aggregates_live_generate_query"
-
-    # setting xcom_push to True outputs this query to an xcom
-    experiment_enrollment_aggregates_live_generate_query = gke_command(
-        task_id=gen_query_task_id,
-        command=[
-            "python",
-            "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_enrollment_aggregates_live/view.sql.py",
-            "--submission-date",
-            "{{ ds }}",
-            "--json-output",
-            "--wait-seconds",
-            "15",
-        ],
-        docker_image="mozilla/bigquery-etl:latest",
-        xcom_push=True,
-        owner="ssuh@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"])
-
-    experiment_enrollment_aggregates_live_run_query = bigquery_xcom_query(
-        task_id="experiment_enrollment_aggregates_live_run_query",
-        destination_table=None,
-        dataset_id="telemetry_derived",
-        xcom_task_id=gen_query_task_id,
-        owner="ssuh@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "ssuh@mozilla.com"])
-
-    bq_main_events >> experiment_enrollment_aggregates
-    (event_events >>
-     experiment_enrollment_aggregates >>
-     experiment_enrollment_aggregates_live_generate_query >>
-     experiment_enrollment_aggregates_live_run_query)
-
+    # todo: remove
     # Experiment search aggregates chain (depends on main)
 
     experiment_search_aggregates = bigquery_etl_query(

--- a/dags/experiment_monitoring_data_export.py
+++ b/dags/experiment_monitoring_data_export.py
@@ -21,10 +21,10 @@ with DAG('experiment_monitoring_data_export',
          default_args=default_args,
          schedule_interval="*/5 * * * *") as dag:
 
-    wait_for_experiment_enrollment_aggregates_recents = ExternalTaskSensor(
-        task_id="wait_for_experiment_enrollment_aggregates_recents",
+    wait_for_experiment_enrollment_cumulative_population_estimate = ExternalTaskSensor(
+        task_id="wait_for_experiment_enrollment_cumulative_population_estimate",
         external_dag_id="bqetl_experiments_live",
-        external_task_id="experiment_enrollment_aggregates_recents",
+        external_task_id="experiment_enrollment_cumulative_population_estimate",
         check_existence=True,
         dag=dag
     )
@@ -39,4 +39,4 @@ with DAG('experiment_monitoring_data_export',
         docker_image=docker_image
     )
 
-    export_monitoring_data.set_upstream(wait_for_experiment_enrollment_aggregates_recents)    
+    export_monitoring_data.set_upstream(wait_for_experiment_enrollment_cumulative_population_estimate)    

--- a/dags/experiment_monitoring_data_export.py
+++ b/dags/experiment_monitoring_data_export.py
@@ -1,0 +1,42 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+
+from utils.gcp import gke_command
+
+from airflow.operators.sensors import ExternalTaskSensor
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+from operators.gcp_container_operator import GKEPodOperator
+
+default_args = {
+    'owner': 'ascholtz@mozilla.com',
+    'depends_on_past': False,
+    'start_date': datetime(2021, 1, 8),
+    'email_on_failure': True,
+    'email_on_retry': True,
+    'retries': 2,
+    'retry_delay': timedelta(minutes=30),
+}
+
+with DAG('experiment_monitoring_data_export',
+         default_args=default_args,
+         schedule_interval="*/5 * * * *") as dag:
+
+    wait_for_experiment_enrollment_aggregates_recents = ExternalTaskSensor(
+        task_id="wait_for_experiment_enrollment_aggregates_recents",
+        external_dag_id="bqetl_experiments_live",
+        external_task_id="experiment_enrollment_aggregates_recents",
+        check_existence=True,
+        dag=dag
+    )
+
+    docker_image = "mozilla/bigquery-etl:latest"
+    export_monitoring_data = gke_command(
+        task_id="export_monitoring_data",
+        command=[
+            "script/experiments/export_experiment_monitoring_data",
+            "--date", "{{ ds }}"
+        ],
+        docker_image=docker_image
+    )
+
+    export_monitoring_data.set_upstream(wait_for_experiment_enrollment_aggregates_recents)    


### PR DESCRIPTION
This adds a DAG for running the experiment monitoring data export script and removes experiments enrollments from `copy_deduplicate`.

Depends on https://github.com/mozilla/bigquery-etl/pull/1656