### PR TITLE
Modifying googles cloud-sdk image 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
 
   sync_gcs:
     docker:
-      - image: google/cloud-sdk
+      - image: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0
     working_directory: ~/mozilla/telemetry-airflow
     steps:
       - checkout


### PR DESCRIPTION
- Pulled from gcr repo since they will deprecate dockerhub in 3/21
- Pin the current image since latest may have broken our sync gcs ci step