### PR TITLE
Increase number of slices in main ping deduplication task

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -53,7 +53,7 @@ with models.DAG(
         billing_projects=("moz-fx-data-shared-prod",),
         only_tables=["telemetry_live.main_v4"],
         parallelism=24,
-        slices=100,
+        slices=150,
         owner="jklukas@mozilla.com",
         email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "jklukas@mozilla.com"],
         priority_weight=100,


### PR DESCRIPTION
copy_deduplicate_main_ping task fails consistently on 2020-01-20 due to increased volume of data. By increasing number of slices we deduplicate in we should be able to avoid out of memory BigQuery errors.