### PR TITLE
Add metric and channel to probe count queries for GLAM

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -175,7 +175,7 @@ histogram_percentiles = bigquery_etl_query(
     project_id=project_id,
     owner="msamuel@mozilla.com",
     date_partition_parameter=None,
-    arguments=("--replace",),
+    arguments=("--replace", "--clustering_fields=metric,channel"),
     dag=dag,
 )
 
@@ -228,7 +228,7 @@ clients_histogram_probe_counts = bigquery_etl_query(
     project_id=project_id,
     owner="msamuel@mozilla.com",
     date_partition_parameter=None,
-    arguments=("--replace",),
+    arguments=("--replace", "--clustering_fields=metric,channel"),
     dag=dag,
 )
 


### PR DESCRIPTION
This fixes the other 2/4 queries for fixing https://github.com/mozilla/bigquery-etl/issues/1660 in addition to https://github.com/mozilla/bigquery-etl/pull/1695. Note that the tables will need to be deleted before these jobs are actually scheduled.