### PR TITLE
Switch BigQuerySQLSensorOperator tasks to `reschedule` mode on a dedicated sensor pool

### DIFF
--- a/dags/operators/bq_sensor.py
+++ b/dags/operators/bq_sensor.py
@@ -60,7 +60,9 @@ class BigQuerySQLSensorOperator(BaseSensorOperator):
         self.sql = sql
         self.bigquery_conn_id = bigquery_conn_id
         self.use_legacy_sql = use_legacy_sql
-        self.mode = 'poke'
+        self.poke_interval = 120
+        self.mode = 'reschedule'
+        self.pool = 'DATA_ENG_EXTERNALTASKSENSOR'
 
     def poke(self, context):
         self.log.info('Running query: %s', self.sql)


### PR DESCRIPTION
This is a follow up to #1233 where other sensors were switched to 'reschedule' mode. This will help us avoid deadlock situation that occured on 2021-01-20, when we had large number of sensor tasks not letting copy_deduplicate jobs to queue.