### PR TITLE
Schedule experiment search metrics export

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -89,50 +89,6 @@ with models.DAG(
 
     copy_deduplicate_main_ping >> bq_main_events
 
-    # todo: remove
-
-    # Experiment search aggregates chain (depends on main)
-
-    experiment_search_aggregates = bigquery_etl_query(
-        task_id="experiment_search_aggregates",
-        project_id="moz-fx-data-shared-prod",
-        destination_table="experiment_search_aggregates_v1",
-        dataset_id="telemetry_derived",
-        owner="ascholtz@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "ascholtz@mozilla.com"])
-
-    experiment_search_query_task_id = "experiment_search_aggregates_live_generate_query"
-
-    # setting xcom_push to True outputs this query to an xcom
-    experiment_search_aggregates_live_generate_view = gke_command(
-        task_id=experiment_search_query_task_id,
-        command=[
-            "python",
-            "sql/moz-fx-data-shared-prod/telemetry_derived/experiment_search_aggregates_live_v1/view.sql.py",
-            "--submission-date",
-            "{{ ds }}",
-            "--json-output",
-            "--wait-seconds",
-            "15",
-        ],
-        docker_image="mozilla/bigquery-etl:latest",
-        xcom_push=True,
-        owner="ascholtz@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "ascholtz@mozilla.com"])
-
-    experiment_search_aggregates_live_deploy_view = bigquery_xcom_query(
-        task_id="experiment_search_aggregates_live_deploy_view",
-        destination_table=None,
-        dataset_id="telemetry_derived",
-        xcom_task_id=experiment_search_query_task_id,
-        owner="ascholtz@mozilla.com",
-        email=["telemetry-alerts@mozilla.com", "ascholtz@mozilla.com"])
-
-    (copy_deduplicate_main_ping >>
-     experiment_search_aggregates >>
-     experiment_search_aggregates_live_generate_view >>
-     experiment_search_aggregates_live_deploy_view)
-
     # Daily and last seen views on top of every Glean application.
 
     gcp_conn_id = "google_cloud_derived_datasets"

--- a/dags/experiments_live.py
+++ b/dags/experiments_live.py
@@ -36,26 +36,47 @@ with DAG('experiments_live',
         dag=dag,
     )
 
+    experiment_search_aggregates_recents = bigquery_etl_query(
+        task_id="experiment_search_aggregates_recents",
+        destination_table="experiment_search_aggregates_recents_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="ascholtz@mozilla.com",
+        email=["ascholtz@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter=None,
+        depends_on_past=True,
+        parameters=["submission_timestamp:TIMESTAMP:{{ts}}"],
+        dag=dag,
+    )
+
 
     # list of datasets to execute query for and export
-    datasets = [
+    experiment_enrollment_datasets = [
         "moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_other_events_overall_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_cumulative_population_estimate_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_overall_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_unenrollment_overall_v1"
     ]
 
-    export_monitoring_data = gke_command(
-        task_id="export_monitoring_data",
+    experiment_search_datasets = [
+        "moz-fx-data-shared-prod.telemetry_derived.experiment_cumulative_ad_clicks_v1",
+        "moz-fx-data-shared-prod.telemetry_derived.experiment_cumulative_search_count_v1",
+        "moz-fx-data-shared-prod.telemetry_derived.experiment_cumulative_search_with_ads_count_v1"
+    ]
+
+    # export experiment enrollments related datasets
+
+    export_enrollments_monitoring_data = gke_command(
+        task_id="export_enrollments_monitoring_data",
         command=[
             "python",
             "script/experiments/export_experiment_monitoring_data.py",
             "--datasets"
-        ] + datasets,
+        ] + experiment_enrollment_datasets,
         docker_image=docker_image
     )
 
-    for dataset in datasets:
+    for dataset in experiment_enrollment_datasets:
         task_id = dataset.split(".")[-1]
 
         query_etl = bigquery_etl_query(
@@ -71,7 +92,7 @@ with DAG('experiments_live',
         )
 
         query_etl.set_upstream(experiment_enrollment_aggregates_recents)
-        export_monitoring_data.set_upstream(query_etl)
+        export_enrollments_monitoring_data.set_upstream(query_etl)
 
     export_daily_active_population_monitoring_data = gke_command(
         task_id=f"export_experiment_enrollment_daily_active_population",
@@ -82,3 +103,33 @@ with DAG('experiments_live',
         ],
         docker_image=docker_image
     )
+
+    # export experiment search metrics related datasets
+
+    export_search_monitoring_data = gke_command(
+        task_id="export_search_monitoring_data",
+        command=[
+            "python",
+            "script/experiments/export_experiment_monitoring_data.py",
+            "--datasets"
+        ] + experiment_search_datasets,
+        docker_image=docker_image
+    )
+
+    for dataset in experiment_search_datasets:
+        task_id = dataset.split(".")[-1]
+
+        query_etl = bigquery_etl_query(
+            task_id=task_id,
+            destination_table=task_id,
+            dataset_id="telemetry_derived",
+            project_id="moz-fx-data-shared-prod",
+            owner="ascholtz@mozilla.com",
+            email=["ascholtz@mozilla.com", "telemetry-alerts@mozilla.com"],
+            date_partition_parameter=None,
+            depends_on_past=True,
+            dag=dag,
+        )
+
+        query_etl.set_upstream(experiment_search_aggregates_recents)
+        export_search_monitoring_data.set_upstream(query_etl)


### PR DESCRIPTION
Depends on https://github.com/mozilla/bigquery-etl/pull/1721

This is basically the same approach also used for the experiment enrollments monitoring queries.