### PR TITLE
Move copy_deduplicate_main_ping back to 100 slices

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -53,7 +53,7 @@ with models.DAG(
         billing_projects=("moz-fx-data-shared-prod",),
         only_tables=["telemetry_live.main_v4"],
         parallelism=24,
-        slices=150,
+        slices=100,
         owner="jklukas@mozilla.com",
         email=["telemetry-alerts@mozilla.com", "relud@mozilla.com", "jklukas@mozilla.com"],
         priority_weight=100,


### PR DESCRIPTION
Reverts #1224 which should no longer be needed after changes as discussed in
[GCP case 26581883](https://console.cloud.google.com/support/cases/detail/26581883?caseId=26581883&accountId=gcp-sa-1256631965&folder=&organizationId=&project=moz-fx-data-shared-prod)