### PR TITLE
Set is_delete_operator_pod=False for experiments_live pods

### DIFF
--- a/dags/experiments_live.py
+++ b/dags/experiments_live.py
@@ -34,6 +34,7 @@ with DAG('experiments_live',
         depends_on_past=True,
         parameters=["submission_timestamp:TIMESTAMP:{{ts}}"],
         dag=dag,
+        is_delete_operator_pod=True,
     )
 
     experiment_search_aggregates_recents = bigquery_etl_query(
@@ -47,36 +48,33 @@ with DAG('experiments_live',
         depends_on_past=True,
         parameters=["submission_timestamp:TIMESTAMP:{{ts}}"],
         dag=dag,
+        is_delete_operator_pod=True,
     )
 
 
     # list of datasets to execute query for and export
-    experiment_enrollment_datasets = [
+    experiment_datasets = [
         "moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_other_events_overall_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_cumulative_population_estimate_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_enrollment_overall_v1",
-        "moz-fx-data-shared-prod.telemetry_derived.experiment_unenrollment_overall_v1"
-    ]
-
-    experiment_search_datasets = [
+        "moz-fx-data-shared-prod.telemetry_derived.experiment_unenrollment_overall_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_cumulative_ad_clicks_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_cumulative_search_count_v1",
         "moz-fx-data-shared-prod.telemetry_derived.experiment_cumulative_search_with_ads_count_v1"
     ]
 
-    # export experiment enrollments related datasets
-
-    export_enrollments_monitoring_data = gke_command(
+    export_monitoring_data = gke_command(
         task_id="export_enrollments_monitoring_data",
         command=[
             "python",
             "script/experiments/export_experiment_monitoring_data.py",
             "--datasets"
-        ] + experiment_enrollment_datasets,
-        docker_image=docker_image
+        ] + experiment_datasets,
+        docker_image=docker_image,
+        is_delete_operator_pod=True,
     )
 
-    for dataset in experiment_enrollment_datasets:
+    for dataset in experiment_datasets:
         task_id = dataset.split(".")[-1]
 
         query_etl = bigquery_etl_query(
@@ -89,10 +87,12 @@ with DAG('experiments_live',
             date_partition_parameter=None,
             depends_on_past=True,
             dag=dag,
+            is_delete_operator_pod=True,
         )
 
         query_etl.set_upstream(experiment_enrollment_aggregates_recents)
-        export_enrollments_monitoring_data.set_upstream(query_etl)
+        query_etl.set_upstream(experiment_search_aggregates_recents)
+        export_monitoring_data.set_upstream(query_etl)
 
     export_daily_active_population_monitoring_data = gke_command(
         task_id=f"export_experiment_enrollment_daily_active_population",
@@ -103,33 +103,3 @@ with DAG('experiments_live',
         ],
         docker_image=docker_image
     )
-
-    # export experiment search metrics related datasets
-
-    export_search_monitoring_data = gke_command(
-        task_id="export_search_monitoring_data",
-        command=[
-            "python",
-            "script/experiments/export_experiment_monitoring_data.py",
-            "--datasets"
-        ] + experiment_search_datasets,
-        docker_image=docker_image
-    )
-
-    for dataset in experiment_search_datasets:
-        task_id = dataset.split(".")[-1]
-
-        query_etl = bigquery_etl_query(
-            task_id=task_id,
-            destination_table=task_id,
-            dataset_id="telemetry_derived",
-            project_id="moz-fx-data-shared-prod",
-            owner="ascholtz@mozilla.com",
-            email=["ascholtz@mozilla.com", "telemetry-alerts@mozilla.com"],
-            date_partition_parameter=None,
-            depends_on_past=True,
-            dag=dag,
-        )
-
-        query_etl.set_upstream(experiment_search_aggregates_recents)
-        export_search_monitoring_data.set_upstream(query_etl)

--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -173,6 +173,7 @@ def bigquery_etl_query(
     date_partition_parameter="submission_date",
     multipart=False,
     allow_field_addition_on_date=None,
+    is_delete_operator_pod=False,
     **kwargs
 ):
     """ Generate.
@@ -235,6 +236,7 @@ def bigquery_etl_query(
         )
         + list(arguments)
         + [sql_file_path],
+        is_delete_operator_pod=is_delete_operator_pod,
         **kwargs
     )
 
@@ -395,6 +397,7 @@ def gke_command(
     gke_namespace="default",
     xcom_push=False,
     env_vars={},
+    is_delete_operator_pod=False,
     **kwargs
 ):
     """ Run a docker command on GKE
@@ -435,5 +438,6 @@ def gke_command(
         arguments=command,
         do_xcom_push=xcom_push,
         env_vars=context_env_vars,
+        is_delete_operator_pod=is_delete_operator_pod,
         **kwargs
     )

--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -198,7 +198,9 @@ def bigquery_etl_query(
                                                    GKEPodOperator
     :param Optional[str] allow_field_addition_on_date: Optional {{ds}} value that
                                                    should be run with ALLOW_FIELD_ADDITION
-
+    :param is_delete_operator_pod                  Optional, What to do when the pod reaches its final
+                                                   state, or the execution is interrupted.
+                                                   If False (default): do nothing, If True: delete the pod
     :return: GKEPodOperator
     """
     kwargs["task_id"] = kwargs.get("task_id", destination_table)


### PR DESCRIPTION
Setting `is_delete_operator_pod=True` for tasks in `experiments_live` and merging export tasks to reduce number of tasks spawned