### PR TITLE
Fix gke cluster scale down for completed pods without rc

### DIFF
--- a/dags/operators/gcp_container_operator.py
+++ b/dags/operators/gcp_container_operator.py
@@ -58,11 +58,16 @@ class GKEPodOperator(UpstreamGKEPodOperator):
         if do_xcom_push:
             reattach_on_restart = False
 
+        # GKE node pool autoscaling is failing to scale down when completed pods exist on the node
+        # in Completed states, due to the pod not being replicated. E.g. behind an rc or deployment.
+        annotations = {'cluster-autoscaler.kubernetes.io/safe-to-evict': 'true'}
+
         super(GKEPodOperator, self).__init__(
             image_pull_policy=image_pull_policy,
             in_cluster=in_cluster,
             do_xcom_push=do_xcom_push,
             reattach_on_restart=reattach_on_restart,
+            annotations=annotations,
             gcp_conn_id=gcp_conn_id,
             project_id=project_id,
             location=location,


### PR DESCRIPTION
Tested locally and works to add annotation to pods. 

Annotation should tell cluster auto scheduler that these pods are safe to delete even though they aren't under an replication controller or deployment (something that is preventing our current node pools from scaling down).

https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
