### PR TITLE
Use 'main' in references to telemetry-batch-view

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -168,7 +168,7 @@ taar_collaborative_recommender = SubDagOperator(
         main_class="com.mozilla.telemetry.ml.AddonRecommender",
         jar_urls=[
             "https://s3-us-west-2.amazonaws.com/net-mozaws-data-us-west-2-ops-ci-artifacts"
-            "/mozilla/telemetry-batch-view/master/telemetry-batch-view.jar",
+            "/mozilla/telemetry-batch-view/main/telemetry-batch-view.jar",
         ],
         jar_args=[
           "train",

--- a/jobs/telemetry_batch_view.py
+++ b/jobs/telemetry_batch_view.py
@@ -38,7 +38,7 @@ def retrieve_jar():
     # Historical version only had the query string [1],
     # so we need to handle that case separately.
     #
-    # [0] https://github.com/mozilla/telemetry-batch-view/blob/master/.circleci/deploy.sh#L37
+    # [0] https://github.com/mozilla/telemetry-batch-view/blob/main/.circleci/deploy.sh#L37
     # [1] https://github.com/mozilla/telemetry-batch-view/blob/14741db20dd3873b94944b8238dfc48a003c744d/deploy.sh#L50
 
     txt_url = jar_url.replace(".jar", ".txt")


### PR DESCRIPTION
Adapts to the new default branch in telemetry-batch-view.

See https://github.com/mozilla/telemetry-batch-view/pull/565