### PR TITLE
Don't send alert emails on rescheduled sensor retry

### DIFF
--- a/dags/attitudes_daily.py
+++ b/dags/attitudes_daily.py
@@ -51,6 +51,7 @@ with models.DAG(
         execution_delta=datetime.timedelta(hours=2),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag)
 
 
@@ -61,6 +62,7 @@ with models.DAG(
         execution_delta=datetime.timedelta(hours=1),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag)
 
 

--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -39,6 +39,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 

--- a/dags/bq_events_to_amplitude.py
+++ b/dags/bq_events_to_amplitude.py
@@ -77,6 +77,7 @@ with models.DAG(
         execution_delta=datetime.timedelta(hours=1),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag)
     wait_for_copy_deduplicate_main_ping = ExternalTaskSensor(
         task_id="wait_for_copy_deduplicate_main_ping",
@@ -85,6 +86,7 @@ with models.DAG(
         execution_delta=datetime.timedelta(hours=1),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -176,6 +178,7 @@ with models.DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         execution_delta=datetime.timedelta(minutes=30),
         dag=dag,
     )

--- a/dags/crash_symbolication.py
+++ b/dags/crash_symbolication.py
@@ -51,6 +51,7 @@ with DAG(
         execution_delta=datetime.timedelta(hours=5),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 

--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -47,6 +47,7 @@ wait_for_main_ping = ExternalTaskSensor(
     check_existence=True,
     mode="reschedule",
     pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
     dag=dag,
 )
 
@@ -94,6 +95,7 @@ wait_for_clients_last_seen = ExternalTaskSensor(
     check_existence=True,
     mode="reschedule",
     pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
     dag=dag,
 )
 

--- a/dags/glam.py
+++ b/dags/glam.py
@@ -49,6 +49,7 @@ wait_for_main_ping = ExternalTaskSensor(
     check_existence=True,
     mode="reschedule",
     pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
     dag=dag,
 )
 

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -58,6 +58,7 @@ wait_for_copy_deduplicate = ExternalTaskSensor(
     check_existence=True,
     mode="reschedule",
     pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
     dag=dag,
 )
 

--- a/dags/graphics_telemetry.py
+++ b/dags/graphics_telemetry.py
@@ -49,6 +49,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 

--- a/dags/incline_dash.py
+++ b/dags/incline_dash.py
@@ -29,6 +29,7 @@ with DAG('incline_dashboard',
         execution_delta=timedelta(hours=3),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     wait_for_core_clients_last_seen = ExternalTaskSensor(
@@ -38,6 +39,7 @@ with DAG('incline_dashboard',
         execution_delta=timedelta(hours=2),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
     )
 
     project = "moz-fx-data-shared-prod"

--- a/dags/jetstream.py
+++ b/dags/jetstream.py
@@ -42,6 +42,7 @@ with DAG("jetstream", default_args=default_args, schedule_interval="0 4 * * *") 
         execution_delta=timedelta(hours=2),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -52,6 +53,7 @@ with DAG("jetstream", default_args=default_args, schedule_interval="0 4 * * *") 
         execution_delta=timedelta(hours=2),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -62,6 +64,7 @@ with DAG("jetstream", default_args=default_args, schedule_interval="0 4 * * *") 
         execution_delta=timedelta(hours=1),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -72,6 +75,7 @@ with DAG("jetstream", default_args=default_args, schedule_interval="0 4 * * *") 
         execution_delta=timedelta(hours=3),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 
@@ -82,6 +86,7 @@ with DAG("jetstream", default_args=default_args, schedule_interval="0 4 * * *") 
         execution_delta=timedelta(hours=3),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 

--- a/dags/kpi_forecasts.py
+++ b/dags/kpi_forecasts.py
@@ -42,6 +42,7 @@ with models.DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         execution_delta=timedelta(hours=1),
         dag=dag,
     )
@@ -65,6 +66,7 @@ with models.DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         execution_delta=timedelta(hours=2),
         dag=dag,
     )
@@ -87,6 +89,7 @@ with models.DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         execution_delta=timedelta(hours=2, minutes=30),
         dag=dag,
     )

--- a/dags/ltv.py
+++ b/dags/ltv.py
@@ -100,6 +100,7 @@ else:
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
     wait_for_search_clients_last_seen >> ltv_daily

--- a/dags/parquet_export.py
+++ b/dags/parquet_export.py
@@ -151,6 +151,7 @@ wait_for_clients_daily = ExternalTaskSensor(
     execution_delta=timedelta(hours=1),
     mode="reschedule",
     pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
     dag=dag)
 
 wait_for_main_summary = ExternalTaskSensor(
@@ -160,6 +161,7 @@ wait_for_main_summary = ExternalTaskSensor(
     execution_delta=timedelta(hours=1),
     mode="reschedule",
     pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
     dag=dag)
 
 main_summary_export.set_upstream(wait_for_main_summary)

--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -93,6 +93,7 @@ wait_for_clients_daily_export = ExternalTaskSensor(
     execution_delta=timedelta(hours=1),
     mode="reschedule",
     pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
     dag=dag)
 
 taar_locale = SubDagOperator(

--- a/dags/webrender.py
+++ b/dags/webrender.py
@@ -27,6 +27,7 @@ with DAG(
         check_existence=True,
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
         dag=dag,
     )
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla/telemetry-airflow/pull/1233, limiting number of alert emails sent from Airflow.