### PR TITLE
Updating Fission analysis table to utilize `mozdata` project.

### DIFF
--- a/dags/fission_experiment_monitoring.py
+++ b/dags/fission_experiment_monitoring.py
@@ -71,7 +71,7 @@ with models.DAG(
             BQ_BILLING_PROJECT_ID="moz-fx-data-shared-prod",
             BQ_INPUT_MAIN_TABLE="moz-fx-data-shared-prod.telemetry_derived.fission_monitoring_main_v1",
             BQ_INPUT_CRASH_TABLE="moz-fx-data-shared-prod.telemetry_derived.fission_monitoring_crash_v1",
-            BQ_OUTPUT_TABLE="moz-fx-data-shared-prod.analysis.fission_monitoring_analyzed_v1",
+            BQ_OUTPUT_TABLE="mozdata.analysis.fission_monitoring_analyzed_v1",
             GCS_BUCKET="fission-experiment-monitoring-dashboard",
         ),
         image_pull_policy="Always",


### PR DESCRIPTION
Replacing `moz-fx-data-shared-prod` for new `mozdata` project for Fission monitoring experiment analysis table. 