### PR TITLE
Disable hive for taar similarity job

### DIFF
--- a/jobs/taar_similarity.py
+++ b/jobs/taar_similarity.py
@@ -522,7 +522,6 @@ def main(
 
     spark = (
         SparkSession.builder.appName("taar_similarity")
-        .enableHiveSupport()
         .getOrCreate()
     )
 


### PR DESCRIPTION
It fixes recent job failures. We don't need hive there.