### PR TITLE
Remove fxa_email_click_amplitude_export

### DIFF
--- a/dags/fxa_export_to_amplitude.py
+++ b/dags/fxa_export_to_amplitude.py
@@ -102,21 +102,3 @@ with models.DAG(
     )
 
     fxa_amplitude_user_ids >> sync_send_tab_export
-
-    fxa_email_click_task_id = 'fxa_email_click_amplitude_export'
-    fxa_email_click_args = default_args.copy()
-    fxa_email_click_args['email'] = ['telemetry-alerts@mozilla.com', 'jklukas@mozilla.com']
-    fxa_email_click_args['owner'] = 'jklukas@mozilla.com'
-    fxa_email_click_export = SubDagOperator(
-        subdag=export_to_amplitude(
-            dag_name=fxa_email_click_task_id,
-            parent_dag_name=dag_name,
-            default_args=fxa_email_click_args,
-            project='moz-fx-data-shared-prod',
-            dataset='firefox_accounts',
-            table_or_view='fxa_amplitude_email_clicks',
-            s3_prefix='fxa_email_click',
-            recreate_view=True,
-        ),
-        task_id=fxa_email_click_task_id
-    )


### PR DESCRIPTION
Per @cvalaas, the SFMC email system is now retired, so the underlying table
here is no longer receiving updates. The job has been failing due to
waiting for data since 2021-03-09.

See https://github.com/mozilla/bigquery-etl/pull/1892 for removal of the view used here.