### PR TITLE
Add make target for sandbox gke clusters to simplify local dev/testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ help:
 	@echo "  run        Run a airflow command"
 	@echo "  secret     Create a secret to be used for a config variable"
 	@echo "  shell      Opens a Bash shell"
-	@echo "  up         Runs the whole stack, served under http://localhost:8000/\n"
+	@echo "  up         Runs the whole stack, served under http://localhost:8000/"
+	@echo "  gke        Create a sandbox gke cluster for testing"
+	@echo "  clean-gke  Delete the sandbox gke cluster"
 	@echo "  stop       Stops the docker containers"
 
 build:
@@ -39,6 +41,12 @@ stop:
 
 up:
 	docker-compose up
+
+gke:
+	bin/start_gke
+
+clean-gke:
+	bin/stop_gke
 
 test:
 	tox

--- a/README.md
+++ b/README.md
@@ -101,13 +101,14 @@ sed -i "s/10001/$(id -u)/g" Dockerfile.dev
 
 ### Testing GKE Jobs (including BigQuery-etl changes)
 
-For now, follow the steps outlined here to create a service account: https://bugzilla.mozilla.org/show_bug.cgi?id=1553559#c1.
-
-Enable that service account in Airflow with the following:
+See https://go.corp.mozilla.com/wtmodev for more details.
 
 ```
 make build && make up
-./bin/add_gcp_creds $GOOGLE_APPLICATION_CREDENTIALS
+make gke
+
+When done:
+make clean-gke
 ```
 
 From there, [connect to Airflow](localhost:8000) and enable your job.

--- a/bin/start_gke
+++ b/bin/start_gke
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This is to be used by the Makefile for a start gke target.
+
+set -eo pipefail
+
+# Set Env var MY_LOCAL_IP or use icanhazip.com to fetch it
+# https://major.io/icanhazip-com-faq/#what-about-my-privacy
+MY_IP=${MY_LOCAL_IP:-$(curl icanhazip.com)}
+echo "local ip is $MY_IP"
+
+USERNAME=$(gcloud config get-value account | awk -F"@" '{print $1}')
+CLUSTERNAME=$USERNAME-gke-sandbox
+
+# Create GKE Cluster - No TTL available, will need a external monitor with cleanup
+if gcloud container clusters describe $CLUSTERNAME --project moz-fx-data-gke-sandbox --region us-west1 >/dev/null 2>&1; then
+    echo "cluster $CLUSTERNAME exists"
+else
+    echo "cluster $CLUSTERNAME doesn't exist. creating..."
+    gcloud container clusters create $CLUSTERNAME \
+           --enable-stackdriver-kubernetes \
+           -m n1-standard-4 \
+           --release-channel="stable" \
+           --enable-master-authorized-networks \
+           --master-authorized-networks="$MY_IP/32" \
+           --region us-west1 \
+           --num-nodes=1 \
+           --scopes="cloud-platform" \
+           --service-account="data-gke-sandbox-runner@moz-fx-data-gke-sandbox.iam.gserviceaccount.com" \
+           --project moz-fx-data-gke-sandbox
+
+fi
+
+echo "fetching secret..."
+JSON_CREDS=$(gcloud secrets versions access latest --secret="gke-sandbox-creds" --project moz-fx-data-gke-sandbox)
+
+# Upload secret to local wtmo
+GCP_CONN_ID="google_cloud_gke_sandbox"
+
+if ! docker ps | grep _web; then
+    echo "ERROR: Airflow container is likely not running (or docker). Run 'make up' to start airflow containers"
+fi
+
+CONTAINER_ID=$(docker ps | grep _web | cut -d' ' -f1)
+
+echo "Web container id is $CONTAINER_ID. Adding gcp connection..."
+docker exec $CONTAINER_ID airflow connections -d --conn_id $GCP_CONN_ID
+
+docker exec $CONTAINER_ID airflow connections -a --conn_id $GCP_CONN_ID \
+       --conn_type google_cloud_platform \
+       --conn_extra "$JSON_CREDS"
+
+echo "visit https://go.corp.mozilla.com/wtmodev for more info"

--- a/bin/stop_gke
+++ b/bin/stop_gke
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This is to be used by the Makefile for a stop gke target.
+
+set -eo pipefail
+
+USERNAME=$(gcloud config get-value account | awk -F"@" '{print $1}')
+CLUSTERNAME=$USERNAME-gke-sandbox
+
+if gcloud container clusters describe $CLUSTERNAME --region us-west1 --project moz-fx-data-gke-sandbox >/dev/null 2>&1; then
+    gcloud container clusters delete $CLUSTERNAME --region us-west1 --quiet --project moz-fx-data-gke-sandbox
+else
+    echo "cluster $CLUSTERNAME does not exist"
+fi


### PR DESCRIPTION
Open for suggestions/comments/concerns

- Adds `make gke` and `make clean-gke` targets
~~Changes local environment to only load dags in the new devdags/ folder. (This may be controversial, but saves about 3-4 minutes of startup time involving importing dummy variables and connections)~~
- More info: go/wtmodev

infra pr https://github.com/mozilla-services/cloudops-infra/pull/2967