### PR TITLE
Schedule telemetry_derived.core_clients_first_seen

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -118,6 +118,12 @@ with models.DAG(
 
     # Daily and last seen views on top of every Glean application.
 
+    # The core clients first seen dataset is a dependency to glean usage
+    # queries. Ideally, it would belong inside of a generated bigquery-etl DAG
+    # (e.g. bqetl_core), but this would require splitting this DAG into three
+    # separate parts threaded by sensors. Since the first_seen_table will end up
+    # being part of the clients daily table in this DAG, it will be easier to
+    # reason about dependencies in this single DAG while it is being developed.
     telemetry_derived__core_clients_first_seen__v1 = bigquery_etl_query(
         task_id="telemetry_derived__core_clients_first_seen__v1",
         destination_table="core_clients_first_seen_v1",

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -108,6 +108,20 @@ with models.DAG(
 
     # Daily and last seen views on top of every Glean application.
 
+    telemetry_derived__core_clients_first_seen__v1 = bigquery_etl_query(
+        task_id="telemetry_derived__core_clients_first_seen__v1",
+        destination_table="core_clients_first_seen_v1",
+        dataset_id="telemetry_derived",
+        project_id="moz-fx-data-shared-prod",
+        owner="amiyaguchi@mozilla.com",
+        email=["amiyaguchi@mozilla.com", "telemetry-alerts@mozilla.com"],
+        date_partition_parameter="submission_date",
+        depends_on_past=True,
+        dag=dag,
+    )
+
+    copy_deduplicate_all >> telemetry_derived__core_clients_first_seen__v1
+
     gcp_conn_id = "google_cloud_derived_datasets"
     baseline_etl_kwargs = dict(
         gcp_conn_id=gcp_conn_id,


### PR DESCRIPTION
Dependency of [this jira ticket](https://jira.mozilla.com/browse/DS-1424) and the scheduling of https://github.com/mozilla/bigquery-etl/pull/1934.

This also formats the module with black. This is split across two commits. 