### PR TITLE
Optimize copy_deduplicate parallelism

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -75,8 +75,6 @@ with models.DAG(
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
         only_tables=["telemetry_live.main_v4"],
-        parallelism=24,
-        slices=100,
         owner="jklukas@mozilla.com",
         email=[
             "telemetry-alerts@mozilla.com",

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -27,6 +27,14 @@ A few immediate downstream tables are also included in this DAG.
 In early 2021, manual reruns of `copy_deduplicate` were leading to empty
 partitions, but the root cause has been fixed. See
 [bug 1690363](https://bugzilla.mozilla.org/show_bug.cgi?id=1690363).
+
+## Changelog
+
+In April 2021, `copy_deduplicate_main_ping` was moved from a 100-slice
+configuration to a single-query configuration, which will change the
+performance profile and is intended to be more efficient and slightly
+faster. See [telemetry-airflow#1279](
+https://github.com/mozilla/telemetry-airflow/pull/1279/files)
 """
 
 default_args = {

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -33,7 +33,9 @@ partitions, but the root cause has been fixed. See
 In April 2021, `copy_deduplicate_main_ping` was moved from a 100-slice
 configuration to a single-query configuration, which will change the
 performance profile and is intended to be more efficient and slightly
-faster. See [telemetry-airflow#1279](
+faster. We also increased the number of parallel queries in
+`copy_deduplicate_all` to help it finish more quickly.
+See [telemetry-airflow#1279](
 https://github.com/mozilla/telemetry-airflow/pull/1279/files)
 """
 
@@ -71,8 +73,9 @@ with models.DAG(
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
         priority_weight=100,
+        parallelism=10,
         # Any table listed here under except_tables _must_ have a corresponding
-        # copy_deduplicate job in another DAG.
+        # copy_deduplicate job elsewhere.
         except_tables=["telemetry_live.main_v4"],
         node_selectors={"nodepool": "highmem"},
         resources=resources,
@@ -90,7 +93,6 @@ with models.DAG(
             "jklukas@mozilla.com",
         ],
         priority_weight=100,
-        dag=dag,
     )
 
     # Events.


### PR DESCRIPTION
We have previously been unable to run copy_deduplicate as a single query
for main_v4 due to resource constraints in BigQuery causing queries to fail.
See https://github.com/mozilla/telemetry-airflow/pull/1224 as an example.

BQ engineering, though, has made some backend changes to improve efficiency
for cases like this, and recent testing has shown that running a single query
is effective. This should be somewhat more cost efficient than splitting the
query into slices, and it can potentially lead to more effective clustering
and less fragmentation.

We also increase parallelism for non-main_v4 queries. Most of these are small
and overall time of the job may be dominated by simply waiting for BQ per-query
overhead.

I will plan to immediately rerun a day once this is merged as a sanity check
that the configuration is correct. If we do see a failure in
coming days or weeks, we can revert to the previous configuration.