### PR TITLE
Use 20 slices for copy_deduplicate_main_ping

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -88,7 +88,8 @@ with models.DAG(
         billing_projects=("moz-fx-data-shared-prod",),
         only_tables=["telemetry_live.main_v4"],
         priority_weight=100,
-        parallelism=1,
+        parallelism=5,
+        slices=20,
         owner="jklukas@mozilla.com",
         email=[
             "telemetry-alerts@mozilla.com",


### PR DESCRIPTION
We are still running into memory errors when running with a single query
after merging https://github.com/mozilla/telemetry-airflow/pull/1279

This moves back to slices, but decreases the number from 100 to 20.