### PR TITLE
Specify cluster name for mad_server

### DIFF
--- a/dags/mad_server.py
+++ b/dags/mad_server.py
@@ -22,6 +22,7 @@ with DAG("mad_server", default_args=default_args, schedule_interval="@daily") as
         ],
         docker_image="gcr.io/malicious-addons-detection/mad-server:latest",
         gcp_conn_id="google_cloud_airflow_gke",
+        gke_cluster_name="workloads-prod-v1",
         aws_conn_id="aws_dev_mad_resources_training",
         env_vars=dict(
             S3_BUCKET="mad-resources-training",


### PR DESCRIPTION
Follow-up to #1284 

The DAG is merged and the initial task failed ([logs](https://workflow.telemetry.mozilla.org/log?task_id=mad_server_pull&dag_id=mad_server&execution_date=2021-04-18T00%3A00%3A00%2B00%3A00)) with a message that mentioned 'bq-load-gke-1', so I think the problem is simply that we were using a default argument for cluster_name.