### PR TITLE
Use modern convention for variable access

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -140,9 +140,9 @@ init_variables() {
     airflow variables -s "taar_dataflow_subnetwork" "taar_dataflow_subnetwork"
     airflow variables -s "taar_dataflow_service_account_email" "taar_dataflow_service_account_email"
 
-    airflow variable -s "looker_repos_secret_git_ssh_key_b64" "looker_repos_secret_git_ssh_key_b64"
-    airflow variable -s "looker_api_client_id_staging" "looker_api_client_id_staging"
-    airflow variable -s "looker_api_client_secret_staging" "looker_api_client_secret_staging"
+    airflow variables -s "looker_repos_secret_git_ssh_key_b64" "looker_repos_secret_git_ssh_key_b64"
+    airflow variables -s "looker_api_client_id_staging" "looker_api_client_id_staging"
+    airflow variables -s "looker_api_client_secret_staging" "looker_api_client_secret_staging"
 }
 
 [ $# -lt 1 ] && usage

--- a/bin/run
+++ b/bin/run
@@ -139,6 +139,10 @@ init_variables() {
     airflow variables -s "taar_gcp_project_id" "taar_gcp_project_id"
     airflow variables -s "taar_dataflow_subnetwork" "taar_dataflow_subnetwork"
     airflow variables -s "taar_dataflow_service_account_email" "taar_dataflow_service_account_email"
+
+    airflow variable -s "looker_repos_secret_git_ssh_key_b64" "looker_api_client_id_staging"
+    airflow variable -s "looker_api_client_id_staging" "looker_api_client_id_staging"
+    airflow variable -s "looker_api_client_secret_staging" "looker_api_client_secret_staging"
 }
 
 [ $# -lt 1 ] && usage

--- a/bin/run
+++ b/bin/run
@@ -140,7 +140,7 @@ init_variables() {
     airflow variables -s "taar_dataflow_subnetwork" "taar_dataflow_subnetwork"
     airflow variables -s "taar_dataflow_service_account_email" "taar_dataflow_service_account_email"
 
-    airflow variable -s "looker_repos_secret_git_ssh_key_b64" "looker_api_client_id_staging"
+    airflow variable -s "looker_repos_secret_git_ssh_key_b64" "looker_repos_secret_git_ssh_key_b64"
     airflow variable -s "looker_api_client_id_staging" "looker_api_client_id_staging"
     airflow variable -s "looker_api_client_secret_staging" "looker_api_client_secret_staging"
 }

--- a/bin/test-parse
+++ b/bin/test-parse
@@ -28,6 +28,7 @@ EOF
 
 
 function get_errors_in_listing {
+    set -x
     # spawn in the background
     docker-compose up --detach
 

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -1,4 +1,5 @@
 from airflow import DAG
+from airflow.models import Variable
 from datetime import timedelta, datetime
 from operators.gcp_container_operator import GKEPodOperator
 from airflow.operators.python_operator import PythonOperator
@@ -95,7 +96,7 @@ with DAG('probe_scraper',
     delay_python_task = PythonOperator(
         task_id="wait_for_30_minutes",
         dag=dag,
-        python_callable=lambda: time.sleep(60 * 1))
+        python_callable=lambda: time.sleep(60 * 30))
 
     gcp_gke_conn_id = "google_cloud_airflow_gke"
     lookml_generator = GKEPodOperator(
@@ -109,15 +110,15 @@ with DAG('probe_scraper',
         location="us-west1",
         dag=dag,
         env_vars={
-            "GIT_SSH_KEY_BASE64": "{{ var.values.looker_repos_secret_git_ssh_key_b64 }}",
+            "GIT_SSH_KEY_BASE64": Variable.get("looker_repos_secret_git_ssh_key_b64"),
             "HUB_REPO_URL": "git@github.com:mozilla/looker-hub.git",
             "HUB_BRANCH_SOURCE": "base",
             "HUB_BRANCH_PUBLISH": "main-stage",
             "SPOKE_REPO_URL": "git@github.com:mozilla/looker-spoke-default.git",
             "SPOKE_BRANCH_PUBLISH": "main-stage",
             "LOOKER_INSTANCE_URI": "https://mozillastaging.cloud.looker.com",
-            "LOOKER_API_CLIENT_ID": "{{ var.values.looker_api_client_id_staging }}",
-            "LOOKER_API_CLIENT_SECRET": "{{ var.values.looker_api_client_secret_staging }}",
+            "LOOKER_API_CLIENT_ID": Variable.get("looker_api_client_id_staging"),
+            "LOOKER_API_CLIENT_SECRET": Variable.get("looker_api_client_secret_staging"),
         }
     )
 


### PR DESCRIPTION
There don't seem to be values for the env vars from the Airflow variables. Hoping this fixes that issue. (The env vars are present, but empty; other env vars (e.g. looker_hub_url) are present and valid.)