### PR TITLE
Remove allow_field_addition_on_date support

### DIFF
--- a/dags/fxa_export_to_amplitude.py
+++ b/dags/fxa_export_to_amplitude.py
@@ -49,8 +49,7 @@ with models.DAG(
         project_id='moz-fx-data-shared-prod',
         destination_table='fxa_amplitude_export_v1',
         dataset_id='firefox_accounts_derived',
-        depends_on_past=True,
-        allow_field_addition_on_date="2020-09-09"
+        depends_on_past=True
     )
 
     task_id = 'fxa_amplitude_export_task'


### PR DESCRIPTION
Depends on https://github.com/mozilla/bigquery-etl/pull/2011

This removes support for `allow_field_addition_on_date`, instead table schemas should be updated via `schema.yaml` files in bigquery-etl. 

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1706683