### PR TITLE
Remove --only parameter from baseline tasks

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -159,7 +159,6 @@ with models.DAG(
 
     baseline_args = [
         "--project-id=moz-fx-data-shared-prod",
-        "--only=*_stable.baseline_v1",
         "--start_date={{ ds }}",
         "--end_date={{ ds }}"
     ]


### PR DESCRIPTION
`--only` is not a backfill option, it was used in the old scripts