### PR TITLE
Run baseline backfill without generating queries

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -157,43 +157,40 @@ with models.DAG(
 
     copy_deduplicate_all >> telemetry_derived__core_clients_first_seen__v1
 
+    baseline_args = [
+        "--project-id=moz-fx-data-shared-prod",
+        "--start_date={{ ds }}",
+        "--end_date={{ ds }}"
+    ]
+
     baseline_clients_first_seen = gke_command(
         task_id="baseline_clients_first_seen",
-        command = [
-            "/bin/bash",
-            "-c",
-            "./script/generate_sql " + 
-            "--target-project moz-fx-data-shared-prod " + 
-            "&& bqetl query backfill *.baseline_clients_first_seen_v1 " +
-            "--project-id=moz-fx-data-shared-prod " + 
-            "--start_date={{ ds }} --end_date={{ ds }} --no-partition"
-        ],
+        command=[
+            "bqetl",
+            "query",
+            "backfill",
+            "*.baseline_clients_first_seen_v1",
+        ] + baseline_args,
         docker_image="mozilla/bigquery-etl:latest",
     )
     baseline_clients_daily = gke_command(
         task_id="baseline_clients_daily",
-        command = [
-            "/bin/bash",
-            "-c",
-            "./script/generate_sql " + 
-            "--target-project moz-fx-data-shared-prod " + 
-            "&& bqetl query backfill *.baseline_clients_daily_v1 " +
-            "--project-id=moz-fx-data-shared-prod " + 
-            "--start_date={{ ds }} --end_date={{ ds }}"
-        ],
+        command=[
+            "bqetl",
+            "query",
+            "backfill",
+            "*.baseline_clients_daily_v1",
+        ] + baseline_args,
         docker_image="mozilla/bigquery-etl:latest",
     )
     baseline_clients_last_seen = gke_command(
         task_id="baseline_clients_last_seen",
-        command = [
-            "/bin/bash",
-            "-c",
-            "./script/generate_sql " + 
-            "--target-project moz-fx-data-shared-prod " + 
-            "&& bqetl query backfill *.baseline_clients_last_seen_v1 " +
-            "--project-id=moz-fx-data-shared-prod " + 
-            "--start_date={{ ds }} --end_date={{ ds }}"
-        ],
+        command=[
+            "bqetl",
+            "query",
+            "backfill",
+            "*.baseline_clients_last_seen_v1",
+        ] + baseline_args,
         depends_on_past=True,
         docker_image="mozilla/bigquery-etl:latest",
     )


### PR DESCRIPTION
Reverts https://github.com/mozilla/telemetry-airflow/pull/1312

Relies on https://github.com/mozilla/bigquery-etl/pull/2062