### PR TITLE
Bug 1712696 Run baseline_clients_first_seen with --no-partition

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -170,6 +170,7 @@ with models.DAG(
             "query",
             "backfill",
             "*.baseline_clients_first_seen_v1",
+            "--no-partition",
         ] + baseline_args,
         docker_image="mozilla/bigquery-etl:latest",
     )


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1712696

I introduced this regression in
https://github.com/mozilla/telemetry-airflow/pull/1317
which @scholtzan had previously fixed in
https://github.com/mozilla/telemetry-airflow/pull/1313