### PR TITLE
Mark baseline_clients_first_seen as depends_on_past

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -172,6 +172,7 @@ with models.DAG(
             "*.baseline_clients_first_seen_v1",
             "--no-partition",
         ] + baseline_args,
+        depends_on_past=True,
         docker_image="mozilla/bigquery-etl:latest",
     )
     baseline_clients_daily = gke_command(


### PR DESCRIPTION
Noticed this while rerunning two days while addressing https://bugzilla.mozilla.org/show_bug.cgi?id=1712696 and realizing that output will not be correct if both days run concurrently.