### PR TITLE
Directly reference bqetl script for running operational monitoring.

### DIFF
--- a/dags/operational_monitoring.py
+++ b/dags/operational_monitoring.py
@@ -39,7 +39,7 @@ with DAG(
     operational_monitoring = gke_command(
         task_id="run_operational_monitoring",
         command=[
-            "bqetl",
+            "./script/bqetl",
             "opmon",
             "run",
             "--submission-date={{ ds }}",


### PR DESCRIPTION
I spoke to Anthony about how jinja generates sql from airflow in other locations. He mentioned that it's done with entrypoint scripts: https://github.com/mozilla/bigquery-etl/blob/2f29f6ed9007f9516fe6881a775ff8ae3ee06b65/script/generate_sql#L44

One thing to try is invoking bqetl with `./script/bqetl` since `bqetl` might be aliased from $pwd which may affect where `PackageLoader` is looking.

Giving this a shot