### PR TITLE
[DSRE-9] - Upgrade Airflow wtmo to 1.10.15 bridge release prior to 2.0

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -156,11 +156,11 @@ init_variables() {
 
 case $1 in
   flower)
-    exec airflow flower
+    exec airflow celery flower
     ;;
   web)
-    airflow initdb
-    airflow upgradedb
+    airflow db init
+    airflow db upgrade
 
     # Only init connections in dev
     [ ! -z ${DEVELOPMENT+check} ] && init_connections && init_variables
@@ -169,7 +169,7 @@ case $1 in
     exec airflow webserver -p ${PORT} --workers 4
     ;;
   worker)
-    exec airflow worker
+    exec airflow celery worker
     ;;
   scheduler)
     exec airflow scheduler

--- a/bin/test-parse
+++ b/bin/test-parse
@@ -44,7 +44,7 @@ function get_errors_in_listing {
     # Parse the logs for ERROR messages, these typically correspond to python
     # exceptions in the DAG. In general, there should NOT be any errors when
     # runnning the local environment.
-    docker-compose exec web airflow list_dags | grep "ERROR"
+    docker-compose exec web airflow dags list | grep "ERROR"
 }
 
 

--- a/plugins/backfill/main.py
+++ b/plugins/backfill/main.py
@@ -162,9 +162,9 @@ class Backfill(get_baseview()):
         # Prepare the command and execute in background
         background_cmd = "screen -dmS {} ".format(screen_id)
         if clear == 'true':
-            background_cmd = background_cmd + 'airflow clear -c '
+            background_cmd = background_cmd + 'airflow tasks clear -c '
         elif clear == 'false':
-            background_cmd = background_cmd + 'airflow backfill '
+            background_cmd = background_cmd + 'airflow dags backfill '
 
         if use_task_regex == 'true':
             background_cmd = background_cmd + "-t {} ".format(task_regex)

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,16 @@
-boto3
-kombu==4.6.3 # CeleryExecutor issues with 1.10.2 supposedly fixed in 1.10.5 airflow, but still observed issues on 1.10.7
+boto3==1.15.18
+botocore<1.19.0,>=1.18.0
+kombu==4.6.10 # CeleryExecutor issues with 1.10.2 supposedly fixed in 1.10.5 airflow, but still observed issues on 1.10.7
+importlib-metadata==2.1.0
+argcomplete==1.12.2
+pandas-gbq==0.14.1
 # removed hdfs
-apache-airflow[celery,postgres,hive,jdbc,async,password,crypto,github_enterprise,datadog,statsd,s3,mysql,google_auth,gcp_api,kubernetes]==1.10.12
+apache-airflow[celery,postgres,hive,jdbc,async,password,crypto,github_enterprise,datadog,statsd,s3,mysql,google_auth,gcp_api,kubernetes]==1.10.15
+apache-airflow-upgrade-check
+# Airflow 2.0 backported providers
+apache-airflow-backport-providers-google
+apache-airflow-backport-providers-amazon
+apache-airflow-backport-providers-http
 cryptography>=3.2
 mozlogging
 retrying

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,171 +4,202 @@
 #
 #    pip-compile
 #
-alembic==1.4.2            # via apache-airflow
-amqp==2.6.0               # via kombu
-apache-airflow[async,celery,crypto,datadog,gcp_api,github_enterprise,google_auth,hive,jdbc,kubernetes,mysql,password,postgres,s3,statsd]==1.10.12  # via -r requirements.in
+alembic==1.6.5            # via apache-airflow
+amqp==2.6.1               # via kombu
+apache-airflow-backport-providers-amazon==2021.3.3  # via -r requirements.in
+apache-airflow-backport-providers-google==2021.3.3  # via -r requirements.in
+apache-airflow-backport-providers-http==2021.4.10  # via -r requirements.in
+apache-airflow-upgrade-check==1.4.0  # via -r requirements.in
+apache-airflow[async,celery,crypto,datadog,gcp_api,github_enterprise,google_auth,hive,jdbc,kubernetes,mysql,password,postgres,s3,statsd]==1.10.15  # via -r requirements.in, apache-airflow-backport-providers-amazon, apache-airflow-backport-providers-google, apache-airflow-upgrade-check
 apispec[yaml]==1.3.3      # via flask-appbuilder
-argcomplete==1.11.1       # via apache-airflow
-attrs==19.3.0             # via apache-airflow, cattrs, jsonschema
-babel==2.8.0              # via flask-babel
-bcrypt==3.1.7             # via apache-airflow, flask-bcrypt
-billiard==3.6.3.0         # via celery
-boto3==1.13.20            # via -r requirements.in, apache-airflow
-botocore==1.16.20         # via boto3, s3transfer
-cached-property==1.5.1    # via apache-airflow
-cachetools==4.1.0         # via google-auth
-cattrs==1.0.0             # via apache-airflow
-celery==4.3.0             # via apache-airflow, flower
-certifi==2020.4.5.1       # via kubernetes, requests
-cffi==1.14.0              # via bcrypt, cryptography
+argcomplete==1.12.2       # via -r requirements.in, apache-airflow
+attrs==20.3.0             # via apache-airflow, cattrs, jsonschema
+babel==2.9.1              # via flask-babel
+bcrypt==3.2.0             # via apache-airflow, flask-bcrypt
+billiard==3.6.4.0         # via celery
+boto3==1.15.18            # via -r requirements.in, apache-airflow, apache-airflow-backport-providers-amazon, watchtower
+botocore==1.18.18         # via -r requirements.in, apache-airflow-backport-providers-amazon, boto3, s3transfer
+cached-property==1.5.2    # via apache-airflow
+cachetools==4.2.2         # via google-auth
+cattrs==1.7.1             # via apache-airflow
+celery==4.4.7             # via apache-airflow, flower
+certifi==2021.5.30        # via kubernetes, requests
+cffi==1.14.6              # via bcrypt, cryptography, google-crc32c
 chardet==3.0.4            # via requests
 click==7.1.2              # via flask, flask-appbuilder, hmsclient
-colorama==0.4.3           # via flask-appbuilder
+colorama==0.4.4           # via flask-appbuilder
 colorlog==4.0.2           # via apache-airflow
 configparser==3.5.3       # via apache-airflow
-croniter==0.3.32          # via apache-airflow
-cryptography==3.2.1       # via -r requirements.in, apache-airflow, pyopenssl
-datadog==0.36.0           # via apache-airflow
-decorator==4.4.2          # via datadog
-defusedxml==0.6.0         # via python3-openid
-dill==0.3.1.1             # via apache-airflow
+croniter==0.3.37          # via apache-airflow
+cryptography==3.4.7       # via -r requirements.in, apache-airflow, pyopenssl
+datadog==0.42.0           # via apache-airflow
+defusedxml==0.7.1         # via python3-openid
+dill==0.3.4               # via apache-airflow
 dnspython==1.16.0         # via email-validator, eventlet
-docutils==0.15.2          # via botocore, python-daemon
-email-validator==1.1.1    # via apache-airflow, flask-appbuilder
-eventlet==0.25.2          # via apache-airflow
+docutils==0.17.1          # via python-daemon
+email-validator==1.1.3    # via apache-airflow, flask-appbuilder
+eventlet==0.31.1          # via apache-airflow
 flask-admin==1.5.4        # via apache-airflow
 flask-appbuilder==2.3.4   # via apache-airflow
 flask-babel==1.0.0        # via flask-appbuilder
 flask-bcrypt==0.7.1       # via apache-airflow
 flask-caching==1.3.3      # via apache-airflow
-flask-jwt-extended==3.24.1  # via flask-appbuilder
+flask-jwt-extended==3.25.1  # via flask-appbuilder
 flask-login==0.4.1        # via apache-airflow, flask-appbuilder
 flask-oauthlib==0.9.5     # via -r requirements.in, apache-airflow
 flask-openid==1.2.5       # via flask-appbuilder
-flask-sqlalchemy==2.4.3   # via flask-appbuilder
-flask-swagger==0.2.13     # via apache-airflow
+flask-sqlalchemy==2.5.1   # via flask-appbuilder
+flask-swagger==0.2.14     # via apache-airflow
 flask-wtf==0.14.3         # via apache-airflow, flask-appbuilder
-flask==1.1.2              # via apache-airflow, flask-admin, flask-appbuilder, flask-babel, flask-bcrypt, flask-caching, flask-jwt-extended, flask-login, flask-oauthlib, flask-openid, flask-sqlalchemy, flask-swagger, flask-wtf
-flower==0.9.4             # via apache-airflow
+flask==1.1.4              # via apache-airflow, flask-admin, flask-appbuilder, flask-babel, flask-bcrypt, flask-caching, flask-jwt-extended, flask-login, flask-oauthlib, flask-openid, flask-sqlalchemy, flask-swagger, flask-wtf
+flower==0.9.7             # via apache-airflow
 funcsigs==1.0.2           # via apache-airflow
 future==0.18.2            # via apache-airflow, pyhive
-gevent==20.5.2            # via apache-airflow
-google-api-core[grpc,grpcgcp]==1.17.0  # via google-api-python-client, google-cloud-bigquery, google-cloud-bigtable, google-cloud-container, google-cloud-core, google-cloud-dlp, google-cloud-language, google-cloud-secret-manager, google-cloud-spanner, google-cloud-speech, google-cloud-texttospeech, google-cloud-translate, google-cloud-videointelligence, google-cloud-vision
-google-api-python-client==1.8.4  # via apache-airflow
-google-auth-httplib2==0.0.3  # via apache-airflow, google-api-python-client
-google-auth-oauthlib==0.4.1  # via pandas-gbq, pydata-google-auth
-google-auth==1.16.0       # via apache-airflow, google-api-core, google-api-python-client, google-auth-httplib2, google-auth-oauthlib, google-cloud-bigquery, google-cloud-storage, kubernetes, pandas-gbq, pydata-google-auth
-google-cloud-bigquery==1.24.0  # via pandas-gbq
-google-cloud-bigtable==1.2.1  # via apache-airflow
-google-cloud-container==0.5.0  # via apache-airflow
-google-cloud-core==1.3.0  # via google-cloud-bigquery, google-cloud-bigtable, google-cloud-spanner, google-cloud-storage, google-cloud-translate
-google-cloud-dlp==0.15.0  # via apache-airflow
-google-cloud-language==1.3.0  # via apache-airflow
-google-cloud-secret-manager==1.0.0  # via apache-airflow
-google-cloud-spanner==1.17.0  # via apache-airflow
-google-cloud-speech==1.3.2  # via apache-airflow
-google-cloud-storage==1.28.1  # via apache-airflow
-google-cloud-texttospeech==1.0.1  # via apache-airflow
-google-cloud-translate==1.7.0  # via apache-airflow
-google-cloud-videointelligence==1.14.0  # via apache-airflow
-google-cloud-vision==1.0.0  # via apache-airflow
-google-resumable-media==0.5.0  # via google-cloud-bigquery, google-cloud-storage
-googleapis-common-protos[grpc]==1.51.0  # via google-api-core, grpc-google-iam-v1
-graphviz==0.14            # via apache-airflow
-greenlet==0.4.15          # via apache-airflow, eventlet, gevent
-grpc-google-iam-v1==0.12.3  # via google-cloud-bigtable, google-cloud-container, google-cloud-secret-manager, google-cloud-spanner
-grpcio-gcp==0.2.2         # via apache-airflow, google-api-core
-grpcio==1.29.0            # via google-api-core, googleapis-common-protos, grpc-google-iam-v1, grpcio-gcp
-gunicorn==19.10.0         # via apache-airflow
-hiredis==1.0.1            # via -r requirements.in
+gevent==21.1.2            # via apache-airflow
+google-ads==7.0.0         # via apache-airflow-backport-providers-google
+google-api-core[grpc,grpcgcp]==1.31.0  # via apache-airflow-backport-providers-google, google-ads, google-api-python-client, google-cloud-appengine-logging, google-cloud-automl, google-cloud-bigquery, google-cloud-bigquery-datatransfer, google-cloud-bigquery-storage, google-cloud-bigtable, google-cloud-container, google-cloud-core, google-cloud-datacatalog, google-cloud-dataproc, google-cloud-dlp, google-cloud-kms, google-cloud-language, google-cloud-logging, google-cloud-memcache, google-cloud-monitoring, google-cloud-os-login, google-cloud-pubsub, google-cloud-redis, google-cloud-secret-manager, google-cloud-spanner, google-cloud-speech, google-cloud-tasks, google-cloud-texttospeech, google-cloud-translate, google-cloud-videointelligence, google-cloud-vision, google-cloud-workflows
+google-api-python-client==1.12.8  # via apache-airflow, apache-airflow-backport-providers-google
+google-auth-httplib2==0.1.0  # via apache-airflow, apache-airflow-backport-providers-google, google-api-python-client
+google-auth-oauthlib==0.4.4  # via google-ads, pandas-gbq, pydata-google-auth
+google-auth==1.32.1       # via apache-airflow, apache-airflow-backport-providers-google, google-api-core, google-api-python-client, google-auth-httplib2, google-auth-oauthlib, google-cloud-core, google-cloud-storage, kubernetes, pandas-gbq, pydata-google-auth
+google-cloud-appengine-logging==0.1.1  # via google-cloud-logging
+google-cloud-audit-log==0.1.0  # via google-cloud-logging
+google-cloud-automl==2.4.0  # via apache-airflow-backport-providers-google
+google-cloud-bigquery-datatransfer==3.3.0  # via apache-airflow-backport-providers-google
+google-cloud-bigquery-storage==2.6.0  # via google-cloud-bigquery
+google-cloud-bigquery[bqstorage,pandas]==2.20.0  # via pandas-gbq
+google-cloud-bigtable==1.7.0  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-container==1.0.1  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-core==1.7.1  # via google-cloud-bigquery, google-cloud-bigtable, google-cloud-logging, google-cloud-spanner, google-cloud-storage, google-cloud-translate
+google-cloud-datacatalog==3.3.0  # via apache-airflow-backport-providers-google
+google-cloud-dataproc==2.4.0  # via apache-airflow-backport-providers-google
+google-cloud-dlp==1.0.0   # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-kms==2.4.0   # via apache-airflow-backport-providers-google
+google-cloud-language==1.3.0  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-logging==2.5.0  # via apache-airflow-backport-providers-google
+google-cloud-memcache==1.1.0  # via apache-airflow-backport-providers-google
+google-cloud-monitoring==2.4.0  # via apache-airflow-backport-providers-google
+google-cloud-os-login==2.2.1  # via apache-airflow-backport-providers-google
+google-cloud-pubsub==2.6.1  # via apache-airflow-backport-providers-google
+google-cloud-redis==2.2.0  # via apache-airflow-backport-providers-google
+google-cloud-secret-manager==1.0.0  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-spanner==1.19.1  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-speech==1.3.2  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-storage==1.40.0  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-tasks==2.4.0  # via apache-airflow-backport-providers-google
+google-cloud-texttospeech==1.0.1  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-translate==1.7.0  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-videointelligence==1.16.1  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-vision==1.0.0  # via apache-airflow, apache-airflow-backport-providers-google
+google-cloud-workflows==1.1.0  # via apache-airflow-backport-providers-google
+google-crc32c==1.1.2      # via google-resumable-media
+google-resumable-media==1.3.1  # via google-cloud-bigquery, google-cloud-storage
+googleapis-common-protos[grpc]==1.53.0  # via google-ads, google-api-core, google-cloud-audit-log, grpc-google-iam-v1
+graphviz==0.16            # via apache-airflow
+greenlet==1.1.0           # via apache-airflow, eventlet, gevent
+grpc-google-iam-v1==0.12.3  # via google-cloud-bigtable, google-cloud-container, google-cloud-datacatalog, google-cloud-kms, google-cloud-pubsub, google-cloud-secret-manager, google-cloud-spanner, google-cloud-tasks
+grpcio-gcp==0.2.2         # via apache-airflow, apache-airflow-backport-providers-google, google-api-core
+grpcio==1.38.1            # via google-ads, google-api-core, google-cloud-bigquery, google-cloud-pubsub, googleapis-common-protos, grpc-google-iam-v1, grpcio-gcp
+gunicorn==20.1.0          # via apache-airflow
+hiredis==2.0.0            # via -r requirements.in
 hmsclient==0.1.1          # via apache-airflow
-httplib2==0.18.1          # via google-api-python-client, google-auth-httplib2
-humanize==0.5.1           # via flower
-idna==2.9                 # via email-validator, requests
-importlib-metadata==1.6.0  # via argcomplete, jsonschema
-iso8601==0.1.12           # via apache-airflow
+httplib2==0.19.1          # via google-api-python-client, google-auth-httplib2
+humanize==3.10.0          # via flower
+idna==2.10                # via email-validator, requests
+importlib-metadata==2.1.0  # via -r requirements.in, apache-airflow, apache-airflow-upgrade-check, argcomplete, importlib-resources, jsonschema, kombu
+importlib-resources==1.5.0  # via apache-airflow
+iso8601==0.1.14           # via apache-airflow
 itsdangerous==1.1.0       # via flask, flask-wtf
-jaydebeapi==1.2.1         # via apache-airflow
-jinja2==2.10.3            # via apache-airflow, flask, flask-babel, python-nvd3
+jaydebeapi==1.2.3         # via apache-airflow
+jinja2==2.11.3            # via apache-airflow, flask, flask-babel, python-nvd3
 jmespath==0.10.0          # via boto3, botocore
 jpype1==0.7.1             # via -r requirements.in, apache-airflow, jaydebeapi
-json-merge-patch==0.2     # via apache-airflow
+json-merge-patch==0.2     # via apache-airflow, apache-airflow-backport-providers-google
 jsonschema==3.2.0         # via -r requirements.in, apache-airflow, flask-appbuilder
-kombu==4.6.3              # via -r requirements.in, celery
+kombu==4.6.10             # via -r requirements.in, celery
 kubernetes==11.0.0        # via apache-airflow
 lazy-object-proxy==1.4.3  # via apache-airflow
+libcst==0.3.19            # via google-cloud-bigquery-storage, google-cloud-datacatalog, google-cloud-os-login, google-cloud-pubsub, google-cloud-workflows
 lockfile==0.12.2          # via python-daemon
-mako==1.1.3               # via alembic
+mako==1.1.4               # via alembic
 markdown==2.6.11          # via apache-airflow
-markupsafe==1.1.1         # via jinja2, mako, wtforms
+markupsafe==2.0.1         # via jinja2, mako, wtforms
 marshmallow-enum==1.5.1   # via flask-appbuilder
-marshmallow-sqlalchemy==0.23.1  # via flask-appbuilder
+marshmallow-sqlalchemy==0.23.1  # via apache-airflow, flask-appbuilder
 marshmallow==2.21.0       # via flask-appbuilder, marshmallow-enum, marshmallow-sqlalchemy
-monotonic==1.5            # via eventlet
 mozlogging==0.1.0         # via -r requirements.in
+mypy-extensions==0.4.3    # via typing-inspect
 mysqlclient==1.3.14       # via apache-airflow
-natsort==7.0.1            # via croniter
-newrelic==5.14.0.142      # via -r requirements.in
-numpy==1.18.4             # via pandas
+natsort==7.1.1            # via croniter
+newrelic==6.4.4.161       # via -r requirements.in
+numpy==1.21.0             # via pandas, pyarrow
 oauthlib==2.1.0           # via apache-airflow, flask-oauthlib, requests-oauthlib
-pandas-gbq==0.13.2        # via apache-airflow
-pandas==0.25.3            # via apache-airflow, pandas-gbq
+packaging==21.0           # via apache-airflow, apache-airflow-upgrade-check, google-api-core, google-cloud-appengine-logging, google-cloud-automl, google-cloud-bigquery, google-cloud-bigquery-datatransfer, google-cloud-bigquery-storage, google-cloud-datacatalog, google-cloud-dataproc, google-cloud-kms, google-cloud-logging, google-cloud-memcache, google-cloud-monitoring, google-cloud-os-login, google-cloud-redis, google-cloud-tasks, google-cloud-workflows
+pandas-gbq==0.14.1        # via -r requirements.in, apache-airflow, apache-airflow-backport-providers-google
+pandas==1.3.0             # via apache-airflow, google-cloud-bigquery, pandas-gbq
 pendulum==1.4.4           # via apache-airflow
 prison==0.1.3             # via flask-appbuilder
-protobuf==3.12.2          # via google-api-core, google-cloud-bigquery, googleapis-common-protos
-psutil==5.7.0             # via apache-airflow
-psycopg2-binary==2.8.5    # via apache-airflow
+prometheus-client==0.8.0  # via flower
+proto-plus==1.19.0        # via google-cloud-appengine-logging, google-cloud-automl, google-cloud-bigquery, google-cloud-bigquery-datatransfer, google-cloud-bigquery-storage, google-cloud-datacatalog, google-cloud-dataproc, google-cloud-kms, google-cloud-logging, google-cloud-memcache, google-cloud-monitoring, google-cloud-os-login, google-cloud-pubsub, google-cloud-redis, google-cloud-tasks, google-cloud-workflows
+protobuf==3.17.3          # via google-ads, google-api-core, google-cloud-audit-log, google-cloud-bigquery, googleapis-common-protos, proto-plus
+psutil==5.8.0             # via apache-airflow
+psycopg2-binary==2.9.1    # via apache-airflow
+pure-sasl==0.6.2          # via thrift-sasl
+pyarrow==4.0.1            # via google-cloud-bigquery
 pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pycparser==2.20           # via cffi
-pydata-google-auth==1.1.0  # via pandas-gbq
-pygments==2.6.1           # via apache-airflow
-pyhive[hive]==0.6.2       # via apache-airflow
+pydata-google-auth==1.2.0  # via pandas-gbq
+pygments==2.9.0           # via apache-airflow
+pyhive[hive]==0.6.4       # via apache-airflow
 pyjwt==1.7.1              # via flask-appbuilder, flask-jwt-extended
-pyopenssl==19.1.0         # via apache-airflow
-pyrsistent==0.16.0        # via jsonschema
-python-daemon==2.1.2      # via apache-airflow
+pyopenssl==20.0.1         # via apache-airflow, apache-airflow-backport-providers-google
+pyparsing==2.4.7          # via httplib2, packaging
+pyrsistent==0.18.0        # via jsonschema
+python-daemon==2.3.0      # via apache-airflow
 python-dateutil==2.8.1    # via alembic, apache-airflow, botocore, croniter, flask-appbuilder, kubernetes, pandas, pendulum, pyhive
 python-editor==1.0.4      # via alembic
 python-nvd3==0.15.0       # via apache-airflow
 python-slugify==4.0.1     # via apache-airflow, python-nvd3
-python3-openid==3.1.0     # via flask-openid
-pytz==2020.1              # via -r requirements.in, babel, celery, flask-babel, flower, google-api-core, pandas, tzlocal
-pytzdata==2019.3          # via pendulum
-pyyaml==5.3.1             # via apispec, flask-swagger, kubernetes
+python3-openid==3.2.0     # via flask-openid
+pytz==2021.1              # via -r requirements.in, babel, celery, flask-babel, flower, google-api-core, pandas, tzlocal
+pytzdata==2020.1          # via pendulum
+pyyaml==5.4.1             # via apispec, flask-swagger, google-ads, kubernetes, libcst
 redis==3.5.3              # via -r requirements.in
 requests-oauthlib==1.1.0  # via apache-airflow, flask-oauthlib, google-auth-oauthlib, kubernetes
-requests==2.23.0          # via -r requirements.in, apache-airflow, datadog, google-api-core, kubernetes, requests-oauthlib
+requests==2.23.0          # via -r requirements.in, apache-airflow, datadog, google-api-core, google-cloud-bigquery, google-cloud-storage, kubernetes, requests-oauthlib
 retrying==1.3.3           # via -r requirements.in
-rsa==4.0                  # via google-auth
-s3transfer==0.3.3         # via boto3
-sasl==0.2.1               # via pyhive, thrift-sasl
-setproctitle==1.1.10      # via apache-airflow
+rsa==4.7.2                # via google-auth
+s3transfer==0.3.7         # via boto3
+sasl==0.3.1               # via pyhive
+setproctitle==1.2.2       # via apache-airflow
 shelljob==0.5.6           # via -r requirements.in
-six==1.15.0               # via bcrypt, cryptography, eventlet, flask-jwt-extended, google-api-core, google-api-python-client, google-auth, google-cloud-bigquery, google-resumable-media, grpcio, jsonschema, kubernetes, prison, protobuf, pyopenssl, pyrsistent, python-dateutil, retrying, sasl, sqlalchemy-utils, tenacity, thrift, thrift-sasl, websocket-client
+six==1.16.0               # via bcrypt, eventlet, flask-jwt-extended, google-api-core, google-api-python-client, google-auth, google-auth-httplib2, google-cloud-core, google-resumable-media, grpcio, jsonschema, kubernetes, prison, protobuf, pyopenssl, python-dateutil, retrying, sasl, sqlalchemy-utils, tenacity, thrift, thrift-sasl
 sqlalchemy-jsonfield==0.9.0  # via apache-airflow
-sqlalchemy-utils==0.36.6  # via flask-appbuilder
+sqlalchemy-utils==0.37.8  # via flask-appbuilder
 sqlalchemy==1.3.15        # via -r requirements.in, alembic, apache-airflow, flask-sqlalchemy, marshmallow-sqlalchemy, sqlalchemy-jsonfield, sqlalchemy-utils
 statsd==3.3.0             # via apache-airflow
-tabulate==0.8.7           # via apache-airflow
+tabulate==0.8.9           # via apache-airflow
 tenacity==4.12.0          # via apache-airflow
 text-unidecode==1.3       # via python-slugify
-thrift-sasl==0.4.2        # via pyhive
+thrift-sasl==0.4.3        # via pyhive
 thrift==0.13.0            # via apache-airflow, hmsclient, pyhive, thrift-sasl
 tornado==5.1.1            # via apache-airflow, flower
-typing-extensions==3.7.4.2  # via apache-airflow
+typing-extensions==3.10.0.0  # via apache-airflow, libcst, typing-inspect
+typing-inspect==0.7.1     # via libcst
 tzlocal==1.5.1            # via apache-airflow, pendulum
 unicodecsv==0.14.1        # via apache-airflow
 uritemplate==3.0.1        # via google-api-python-client
-urllib3==1.25.9           # via -r requirements.in, botocore, kubernetes, requests
-vine==1.3.0               # via amqp, celery
-websocket-client==0.57.0  # via -r requirements.in, kubernetes
+urllib3==1.25.11          # via -r requirements.in, botocore, kubernetes, requests
+vine==1.3.0               # via amqp, apache-airflow, celery, flower
+watchtower==0.7.3         # via apache-airflow-backport-providers-amazon
+websocket-client==1.1.0   # via -r requirements.in, kubernetes
 werkzeug==0.16.0          # via -r requirements.in, apache-airflow, flask, flask-caching, flask-jwt-extended
-wtforms==2.3.1            # via flask-admin, flask-wtf
-zipp==3.1.0               # via importlib-metadata
+wtforms==2.3.3            # via flask-admin, flask-wtf
+zipp==3.5.0               # via importlib-metadata, importlib-resources
 zope.deprecation==4.4.0   # via apache-airflow
-zope.event==4.4           # via gevent
-zope.interface==5.1.0     # via gevent
+zope.event==4.5.0         # via gevent
+zope.interface==5.4.0     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
Why 1.10.15 initially?

https://airflow.apache.org/docs/apache-airflow/2.1.0/upgrading-to-2.html#step-2-upgrade-to-airflow-1-10-15-a-k-a-our-bridge-release


Changelogs of potential note to review (from 1.10.13 -> 1.10.15):
- https://github.com/apache/airflow/pull/10666
- https://github.com/apache/airflow/pull/10963
- https://github.com/apache/airflow/pull/12419
- https://github.com/apache/airflow/pull/10850
- https://github.com/apache/airflow/pull/12328
- https://github.com/apache/airflow/pull/12311
- https://github.com/apache/airflow/pull/12003
- https://github.com/apache/airflow/pull/11480
- https://github.com/apache/airflow/pull/11191
- https://github.com/apache/airflow/pull/11095
- https://github.com/apache/airflow/pull/11468
- https://github.com/apache/airflow/pull/12069
- https://github.com/apache/airflow/pull/12133
- https://github.com/apache/airflow/pull/12663
- https://github.com/apache/airflow/pull/3651
- https://github.com/apache/airflow/pull/3729
- https://github.com/apache/airflow/pull/3738
- https://github.com/apache/airflow/pull/12605
- https://github.com/apache/airflow/pull/9544
- https://github.com/apache/airflow/pull/12725
- https://github.com/apache/airflow/pull/12747
- https://github.com/apache/airflow/pull/11802
- https://github.com/apache/airflow/pull/13074
- https://github.com/apache/airflow/pull/13803
- https://github.com/apache/airflow/pull/13816
- https://github.com/apache/airflow/pull/14188
- https://github.com/apache/airflow/pull/14090
- https://github.com/apache/airflow/pull/13470
- https://github.com/apache/airflow/pull/8571
- https://github.com/apache/airflow/pull/11368
- https://github.com/apache/airflow/pull/10677

full list (https://airflow.apache.org/docs/apache-airflow/stable/changelog.html#airflow-1-10-15-2021-03-17)

TODO:
- [x] resolve pip dependencies
- [x] review changelogs
- [x] resolve - Broken DAG: [/app/dags/mozfun.py] cannot import name '_check_google_client_version' from 'pandas_gbq.gbq' (/usr/local/lib/python3.7/site-packages/pandas_gbq/gbq.py) 
- [x] Test containers
- [x] Diff 1.10.15 and 1.10.12 code for dags/operators/gcp_container_operator, and dataproc operators for moz_dataproc_operator usage. Also s3_to_gcs_transfer_operator

Test jobs
- [x] GKEPodOperator
- [x] Dataproc (taar_lite standalone, use {{yesterday_ds}} as date)

Test plugins
- [x] backfill plugin
- [x] Mozilla docs

Addl note:
In 1.10.15,  Adding Operators, Hooks and Sensors via Airflow Plugins is deprecated
	The ability to import Operators, Hooks and Sensors via the plugin mechanism has been deprecated and will raise warnings in Airflow 1.10.13 and will be removed completely in Airflow 2.0.
	Check https://airflow.apache.org/docs/1.10.13/howto/custom-operator.html to see how you can create and import Custom Hooks, Operators and Sensors.
In the plugins folder these may be effected?
- log_email_backend.py
- celery_visibility_timeout_fix.py
