### PR TITLE
Bug 1720157 - Increase number of tasks for bucket counts

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -232,7 +232,7 @@ clients_histogram_bucket_counts = SubDagOperator(
         dag.schedule_interval,
         dataset_id,
         ("submission_date:DATE:{{ds}}",),
-        10,
+        20,
         None,
     ),
     task_id="clients_histogram_bucket_counts",


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1720157#c1)

This increases the number of tasks from 10 to 20 due to:

```
[2021-07-14 21:42:54,520] {pod_launcher.py:156} INFO - b'query execution: Your project or organization exceeded the maximum disk and\n'
[2021-07-14 21:42:54,521] {pod_launcher.py:156} INFO - b'memory limit available for shuffle operations. Consider provisioning more slots,\n'
```