### PR TITLE
Backport airbyte sync operator

### DIFF
--- a/dags/airbyte_github_test.py
+++ b/dags/airbyte_github_test.py
@@ -1,0 +1,19 @@
+from airflow import DAG
+from airflow.utils.dates import days_ago
+from operators.airbyte_operator import AirbyteTriggerSyncOperator
+
+with DAG(
+    dag_id="airbyte_github_test",
+    default_args={"owner": "bwubbo@mozilla.com"},
+    schedule_interval="@daily",
+    start_date=days_ago(1),
+) as dag:
+
+    airflow_test = AirbyteTriggerSyncOperator(
+        task_id="airbyte_github_test",
+        airbyte_conn_id="airbyte_conn_test",
+        connection_id="05b03d15-3928-4dbe-83f1-aa070eeebc9f",
+        asynchronous=False,
+        timeout=3600,
+        wait_seconds=3,
+    )

--- a/dags/operators/airbyte_hook.py
+++ b/dags/operators/airbyte_hook.py
@@ -1,0 +1,124 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import time
+from typing import Any, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.http_hook import HttpHook
+
+
+class AirbyteHook(HttpHook):
+    """
+    Hook for Airbyte API
+
+    :param airbyte_conn_id: Required. The name of the Airflow connection to get
+        connection information for Airbyte.
+    :type airbyte_conn_id: str
+    :param api_version: Optional. Airbyte API version.
+    :type api_version: str
+    """
+
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    CANCELLED = "cancelled"
+    PENDING = "pending"
+    FAILED = "failed"
+    ERROR = "error"
+
+    def __init__(
+        self,
+        airbyte_conn_id: str = "airbyte_default",
+        api_version: Optional[str] = "v1",
+    ) -> None:
+        super().__init__(http_conn_id=airbyte_conn_id)
+        self.api_version: str = api_version
+
+    def wait_for_job(
+        self,
+        job_id: str,
+        wait_seconds: Optional[float] = 3,
+        timeout: Optional[float] = 3600,
+    ) -> None:
+        """
+        Helper method which polls a job to check if it finishes.
+
+        :param job_id: Required. Id of the Airbyte job
+        :type job_id: str
+        :param wait_seconds: Optional. Number of seconds between checks.
+        :type wait_seconds: float
+        :param timeout: Optional. How many seconds wait for job to be ready.
+            Used only if ``asynchronous`` is False.
+        :type timeout: float
+        """
+        state = None
+        start = time.monotonic()
+        while True:
+            if timeout and start + timeout < time.monotonic():
+                raise AirflowException(
+                    f"Timeout: Airbyte job {job_id} is not ready after {timeout}s"
+                )
+            time.sleep(wait_seconds)
+            try:
+                job = self.get_job(job_id=job_id)
+                state = job.json()["job"]["status"]
+            except AirflowException as err:
+                self.log.info(
+                    "Retrying. Airbyte API returned server error when waiting for job: %s",
+                    err,
+                )
+                continue
+
+            if state in (self.RUNNING, self.PENDING):
+                continue
+            if state == self.SUCCEEDED:
+                break
+            if state == self.ERROR:
+                raise AirflowException(f"Job failed:\n{job}")
+            elif state == self.CANCELLED:
+                raise AirflowException(f"Job was cancelled:\n{job}")
+            else:
+                raise Exception(
+                    f"Encountered unexpected state `{state}` for job_id `{job_id}`"
+                )
+
+    def submit_sync_connection(self, connection_id: str) -> Any:
+        """
+        Submits a job to a Airbyte server.
+
+        :param connection_id: Required. The ConnectionId of the Airbyte Connection.
+        :type connection_id: str
+        """
+        return self.run(
+            endpoint=f"api/{self.api_version}/connections/sync",
+            data=json.dumps({"connectionId": connection_id}),
+            headers={"Content-type": "application/json", "accept": "application/json"},
+        )
+
+    def get_job(self, job_id: int) -> Any:
+        """
+        Gets the resource representation for a job in Airbyte.
+
+        :param job_id: Required. Id of the Airbyte job
+        :type job_id: int
+        """
+        return self.run(
+            endpoint=f"api/{self.api_version}/jobs/get",
+            data=json.dumps({"id": job_id}),
+            headers={"Content-type": "application/json", "accept": "application/json"},
+        )

--- a/dags/operators/airbyte_operator.py
+++ b/dags/operators/airbyte_operator.py
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional
+
+from airflow.models import BaseOperator
+from operators.airbyte_hook import AirbyteHook
+from airflow.utils.decorators import apply_defaults
+
+
+class AirbyteTriggerSyncOperator(BaseOperator):
+    """
+    This operator allows you to submit a job to an Airbyte server to run a integration
+    process between your source and destination.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:AirbyteTriggerSyncOperator`
+
+    :param airbyte_conn_id: Required. The name of the Airflow connection to get connection
+        information for Airbyte.
+    :type airbyte_conn_id: str
+    :param connection_id: Required. The Airbyte ConnectionId UUID between a source and destination.
+    :type connection_id: str
+    :param asynchronous: Optional. Flag to get job_id after submitting the job to the Airbyte API.
+        This is useful for submitting long running jobs and
+        waiting on them asynchronously using the AirbyteJobSensor.
+    :type asynchronous: bool
+    :param api_version: Optional. Airbyte API version.
+    :type api_version: str
+    :param wait_seconds: Optional. Number of seconds between checks. Only used when ``asynchronous`` is False.
+    :type wait_seconds: float
+    :param timeout: Optional. The amount of time, in seconds, to wait for the request to complete.
+        Only used when ``asynchronous`` is False.
+    :type timeout: float
+    """
+
+    template_fields = ("connection_id",)
+
+    @apply_defaults
+    def __init__(
+        self,
+        connection_id: str,
+        airbyte_conn_id: str = "airbyte_default",
+        asynchronous: Optional[bool] = False,
+        api_version: Optional[str] = "v1",
+        wait_seconds: Optional[float] = 3,
+        timeout: Optional[float] = 3600,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.airbyte_conn_id = airbyte_conn_id
+        self.connection_id = connection_id
+        self.timeout = timeout
+        self.api_version = api_version
+        self.wait_seconds = wait_seconds
+        self.asynchronous = asynchronous
+
+    def execute(self, context) -> None:
+        """Create Airbyte Job and wait to finish"""
+        hook = AirbyteHook(
+            airbyte_conn_id=self.airbyte_conn_id, api_version=self.api_version
+        )
+        job_object = hook.submit_sync_connection(connection_id=self.connection_id)
+        job_id = job_object.json()["job"]["id"]
+
+        self.log.info("Job %s was submitted to Airbyte Server", job_id)
+        if not self.asynchronous:
+            self.log.info("Waiting for job %s to complete", job_id)
+            hook.wait_for_job(
+                job_id=job_id, wait_seconds=self.wait_seconds, timeout=self.timeout
+            )
+            self.log.info("Job %s completed successfully", job_id)
+
+        return job_id


### PR DESCRIPTION
This is a port of the airbyte operator into airflow 1.10 from here: https://airflow.apache.org/docs/apache-airflow-providers-airbyte/1.0.0/_modules/index.html

I think the only change was to use `HttpHook` from `airflow.hooks.http_hook` instead of `airflow.providers.http.hooks.http` in `airbyte_hook.py` which just required updating the headers and using the `requests` data param instead of json.

Tested locally and it seems to work fine:
![Screen Shot 2021-07-30 at 6 36 45 PM](https://user-images.githubusercontent.com/12437227/127718589-19820007-97b9-4079-96b9-096606e0a971.png)

Cancelling a running job also fails the airflow task.

