### PR TITLE
Add note to operational_monitoring DAG

### DIFF
--- a/dags/operational_monitoring.py
+++ b/dags/operational_monitoring.py
@@ -5,6 +5,21 @@ from utils.gcp import gke_command
 from operators.task_sensor import ExternalTaskCompletedSensor
 
 
+docs = """
+### operational_monitoring
+
+This DAG is currently under development. Failures can be ignored during Airflow triage.
+
+#### Description
+
+This DAG schedules queries for populating datasets used for operational monitoring.
+The queries are generated via [`operational_monitoring` in bigquery-etl](https://github.com/mozilla/bigquery-etl/tree/main/bigquery_etl/operational_monitoring). 
+
+#### Owner
+
+msamuel@mozilla.com
+"""
+
 default_args = {
     "owner": "msamuel@mozilla.com",
     "email": [
@@ -24,6 +39,7 @@ with DAG(
     DAG_NAME,
     default_args=default_args,
     schedule_interval="0 3 * * *",
+    doc_md=docs,
 ) as dag:
     wait_for_main_nightly = ExternalTaskCompletedSensor(
         task_id="wait_for_main_nightly",


### PR DESCRIPTION
The `operational_monitoring` DAG is currently still under heavy development and frequently failing. To prevent constantly bugs being filed during Airflow triage, I added a note to the DAG description that failures can be ignored for now. Once it's production ready we can update the docs there. 