### PR TITLE
add sample counts to glam desktop dag

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -6,7 +6,7 @@ from airflow.executors import get_default_executor
 from operators.task_sensor import ExternalTaskCompletedSensor
 from airflow.operators.subdag_operator import SubDagOperator
 
-from glam_subdags.extract import extracts_subdag, extract_user_counts
+from glam_subdags.extract import extracts_subdag, extract_user_counts, extract_sample_counts
 from glam_subdags.histograms import histogram_aggregates_subdag
 from glam_subdags.general import repeated_subdag
 from glam_subdags.generate_query import generate_and_run_desktop_query
@@ -208,6 +208,18 @@ glam_user_counts = bigquery_etl_query(
     dag=dag,
 )
 
+glam_sample_counts = bigquery_etl_query(
+    task_id="glam_sample_counts",
+    destination_table="glam_sample_counts_v1",
+    dataset_id=dataset_id,
+    project_id=project_id,
+    owner="akommasani@mozilla.com",
+    date_partition_parameter=None,
+    parameters=("submission_date:DATE:{{ds}}",),
+    arguments=("--replace",),
+    dag=dag,
+
+)
 client_scalar_probe_counts = gke_command(
     task_id="client_scalar_probe_counts",
     command=[
@@ -263,6 +275,18 @@ extract_counts = SubDagOperator(
     dag=dag
 )
 
+extract_sample_counts = SubDagOperator(
+    subdag=extract_sample_counts(
+        GLAM_DAG,
+        "extract_sample_counts",
+        default_args,
+        dag.schedule_interval,
+        dataset_id
+    ),
+    task_id="extract_sample_counts",
+    executor=get_default_executor(),
+    dag=dag
+)
 
 extracts_per_channel = SubDagOperator(
     subdag=extracts_subdag(
@@ -300,6 +324,8 @@ clients_daily_keyed_histogram_aggregates >> clients_histogram_aggregates
 
 clients_histogram_aggregates >> clients_histogram_bucket_counts
 clients_histogram_aggregates >> glam_user_counts
+clients_histogram_aggregates >> glam_sample_counts
+
 
 clients_histogram_bucket_counts >> clients_histogram_probe_counts
 clients_histogram_probe_counts >> histogram_percentiles
@@ -307,8 +333,10 @@ clients_histogram_probe_counts >> histogram_percentiles
 clients_scalar_aggregates >> glam_user_counts
 
 glam_user_counts >> extract_counts
+glam_sample_counts >> extract_sample_counts
 
 extract_counts >> extracts_per_channel
+extract_sample_counts >> extracts_per_channel
 client_scalar_probe_counts >> extracts_per_channel
 scalar_percentiles >> extracts_per_channel
 histogram_percentiles >> extracts_per_channel

--- a/dags/glam.py
+++ b/dags/glam.py
@@ -6,7 +6,7 @@ from airflow.executors import get_default_executor
 from operators.task_sensor import ExternalTaskCompletedSensor
 from airflow.operators.subdag_operator import SubDagOperator
 
-from glam_subdags.extract import extracts_subdag, extract_user_counts, extract_sample_counts
+from glam_subdags.extract import extracts_subdag, extract_user_counts
 from glam_subdags.histograms import histogram_aggregates_subdag
 from glam_subdags.general import repeated_subdag
 from glam_subdags.generate_query import generate_and_run_desktop_query
@@ -268,7 +268,9 @@ extract_counts = SubDagOperator(
         "extract_user_counts",
         default_args,
         dag.schedule_interval,
-        dataset_id
+        dataset_id,
+        "user_counts",
+        "counts"
     ),
     task_id="extract_user_counts",
     executor=get_default_executor(),
@@ -276,12 +278,14 @@ extract_counts = SubDagOperator(
 )
 
 extract_sample_counts = SubDagOperator(
-    subdag=extract_sample_counts(
+    subdag=extract_user_counts(
         GLAM_DAG,
         "extract_sample_counts",
         default_args,
         dag.schedule_interval,
-        dataset_id
+        dataset_id,
+        "sample_counts",
+        "sample-counts"
     ),
     task_id="extract_sample_counts",
     executor=get_default_executor(),

--- a/dags/glam_subdags/extract.py
+++ b/dags/glam_subdags/extract.py
@@ -147,7 +147,7 @@ def extract_user_counts(
         glam_bucket, file_prefix
     )
     bq2gcs = BigQueryToCloudStorageOperator(
-        task_id="glam_extract_user_{}_to_csv".format(task_prefix),
+        task_id="glam_extract_{}_to_csv".format(task_prefix),
         source_project_dataset_table="{}.{}.{}".format(
             project_id, dataset_id, bq_extract_table
         ),

--- a/dags/glam_subdags/extract.py
+++ b/dags/glam_subdags/extract.py
@@ -108,18 +108,19 @@ def extract_user_counts(
     child_dag_name,
     default_args,
     schedule_interval,
-    dataset_id
+    dataset_id,
+    task_prefix,
+    file_prefix
 ):
-
+    bq_extract_table="glam_{}_extract_v1".format(task_prefix)
     dag = DAG(
         dag_id="{}.{}".format(parent_dag_name, child_dag_name),
         default_args=default_args,
         schedule_interval=schedule_interval,
     )
-
-    bq_extract_table = "glam_user_counts_extract_v1"
+    
     etl_query = bigquery_etl_query(
-        task_id="glam_user_counts_extract",
+        task_id="glam_{}_extract".format(task_prefix),
         destination_table=bq_extract_table,
         dataset_id=dataset_id,
         project_id=project_id,
@@ -135,18 +136,18 @@ def extract_user_counts(
     )
 
     gcs_delete = GoogleCloudStorageDeleteOperator(
-        task_id="glam_gcs_delete_count_extracts",
+        task_id="glam_gcs_delete_{}_extracts".format(task_prefix),
         bucket_name=glam_bucket,
-        prefix="glam-extract-firefox-counts",
+        prefix="glam-extract-firefox-{}".format(file_prefix),
         google_cloud_storage_conn_id=gcp_conn.gcp_conn_id,
         dag=dag,
     )
 
-    gcs_destination = "gs://{}/glam-extract-firefox-counts.csv".format(
-        glam_bucket
+    gcs_destination = "gs://{}/glam-extract-firefox-{}.csv".format(
+        glam_bucket, file_prefix
     )
     bq2gcs = BigQueryToCloudStorageOperator(
-        task_id="glam_extract_user_counts_to_csv",
+        task_id="glam_extract_user_{}_to_csv".format(task_prefix),
         source_project_dataset_table="{}.{}.{}".format(
             project_id, dataset_id, bq_extract_table
         ),
@@ -160,63 +161,3 @@ def extract_user_counts(
     etl_query >> gcs_delete >> bq2gcs
 
     return dag
-
-def extract_sample_counts(
-    parent_dag_name,
-    child_dag_name,
-    default_args,
-    schedule_interval,
-    dataset_id
-):
-
-    dag = DAG(
-        dag_id="{}.{}".format(parent_dag_name, child_dag_name),
-        default_args=default_args,
-        schedule_interval=schedule_interval,
-    )
-
-    bq_extract_table = "glam_sample_counts_extract_v1"
-    etl_query = bigquery_etl_query(
-        task_id="glam_sample_counts_extract",
-        destination_table=bq_extract_table,
-        dataset_id=dataset_id,
-        project_id=project_id,
-        owner="akommasani@mozilla.com",
-        email=[
-            "telemetry-alerts@mozilla.com",
-            "msamuel@mozilla.com",
-            "robhudson@mozilla.com",
-            "akommasani@mozilla.com"
-        ],
-        date_partition_parameter=None,
-        arguments=("--replace",),
-        dag=dag,
-    )
-
-    gcs_delete = GoogleCloudStorageDeleteOperator(
-        task_id="glam_gcs_delete_sample_count_extracts",
-        bucket_name=glam_bucket,
-        prefix="glam-extract-firefox-sample-counts",
-        google_cloud_storage_conn_id=gcp_conn.gcp_conn_id,
-        dag=dag,
-    )
-
-    gcs_destination = "gs://{}/glam-extract-firefox-sample-counts.csv".format(
-        glam_bucket
-    )
-    bq2gcs = BigQueryToCloudStorageOperator(
-        task_id="glam_extract_sample_counts_to_csv",
-        source_project_dataset_table="{}.{}.{}".format(
-            project_id, dataset_id, bq_extract_table
-        ),
-        destination_cloud_storage_uris=gcs_destination,
-        bigquery_conn_id=gcp_conn.gcp_conn_id,
-        export_format="CSV",
-        print_header=False,
-        dag=dag,
-    )
-
-    etl_query >> gcs_delete >> bq2gcs
-
-    return dag
-


### PR DESCRIPTION
The PR is to resolve the issue [#1240](https://github.com/mozilla/glam/issues/1240). 
As part of this change, I have added two tasks 
1. glam_sample_counts: This task aggregates (sums) on the histogram values [query](https://gist.github.com/alekhyamoz/031fd954469acd6020d844202c5f8ce4)
2. extract_sample_counts: This task extracts the data from bigquery table and pushed the data to GCS in csv format

The below is how the dag looks including the above two tasks:
<img width="1629" alt="Screen Shot 2021-09-09 at 11 43 36 AM" src="https://user-images.githubusercontent.com/88394696/132718373-0f51c61d-eb73-47f5-8ae9-ea5a75a5d85d.png">
