### PR TITLE
lookml-generator UPDATE_SPOKE_BRANCHES as string

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -126,7 +126,7 @@ with DAG('probe_scraper',
             "LOOKER_API_CLIENT_ID": Variable.get("looker_api_client_id_prod"),
             "LOOKER_API_CLIENT_SECRET": Variable.get("looker_api_client_secret_prod"),
             "GITHUB_ACCESS_TOKEN": Variable.get("dataops_looker_github_secret_access_token"),
-            "UPDATE_SPOKE_BRANCHES": True,
+            "UPDATE_SPOKE_BRANCHES": "true",
         }
     )
 
@@ -153,7 +153,7 @@ with DAG('probe_scraper',
             "LOOKER_API_CLIENT_ID": Variable.get("looker_api_client_id_staging"),
             "LOOKER_API_CLIENT_SECRET": Variable.get("looker_api_client_secret_staging"),
             "GITHUB_ACCESS_TOKEN": Variable.get("dataops_looker_github_secret_access_token"),
-            "UPDATE_SPOKE_BRANCHES": True,
+            "UPDATE_SPOKE_BRANCHES": "true",
         }
     )
 


### PR DESCRIPTION
The Airflow tasks failed last night since they expect string values for env variables.