### PR TITLE
[DSRE-258] Add default_pool_task_slot_count = 50

### DIFF
--- a/airflow.cfg
+++ b/airflow.cfg
@@ -5,7 +5,7 @@ hide_sensitive_var_conn_fields = True
 sensitive_var_conn_names = 'cred,CRED,secret,SECRET,pass,PASS,password,PASSWORD,private,PRIVATE,key,KEY,cert,CERT,token,TOKEN,AKIA'
 
 # This setting would not have any effect in an existing deployment where the default_pool already exists.
-# default_pool_task_slot_count = 50
+default_pool_task_slot_count = 50
 
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository


### PR DESCRIPTION
For some reason the statsd metrics are reverting to 128 even though the pool size is set to 50 in the UI. Setting this config value may fix