### PR TITLE
changed the mozdata project to mox-fx-data-shared-prod

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -13,7 +13,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 
 project_id = "moz-fx-data-shared-prod"
 dataset_id = "telemetry_derived"
-tmp_project = "mozdata"  # for temporary tables in analysis dataset
+tmp_project = "moz-fx-data-shared-prod"  # for temporary tables in analysis dataset
 default_args = {
     "owner": "msamuel@mozilla.com",
     "depends_on_past": False,


### PR DESCRIPTION
The glam etl has been failing with the below error :`[2021-10-19 05:55:11,534] {{pod_launcher.py:149}} INFO - google.api_core.exceptions.BadRequest: 400 Resources exceeded during query execution: Your project or organization exceeded the maximum disk and memory limit available for shuffle operations. Consider provisioning more slots, reducing query concurrency, or using more efficient logic in this job.`

This PR is an attempt to resolve the issue by changing `mozdata` to `moz-fx-data-shared-prod` as mozdata doesn't have a high limit for shuffle 