### PR TITLE
Fix socorro import dag again

### DIFF
--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -144,8 +144,8 @@ gke_args = [
 remove_bq_table_partition = BigQueryDeleteTableOperator(
     task_id="remove_bq_table_partition",
     gcp_conn_id=bq_gcp_conn_id,
-    deletion_dataset_table="{{ var.value.gcp_shared_prod_project }}.{}.{}${{{{ds_nodash}}}}".format(
-        bq_dataset, bq_table_name
+    deletion_dataset_table="{}.{}.{}${{{{ds_nodash}}}}".format(
+        "{{ var.value.gcp_shared_prod_project }}", bq_dataset, bq_table_name
     ),
     ignore_if_missing=True,
     dag=dag,


### PR DESCRIPTION
`ValueError: table_id must be a fully-qualified ID in standard SQL format, e.g., "project.dataset.table_id", got { var.value.gcp_shared_prod_project }.telemetry_derived.socorro_crash_v2$20211018` so I guess it was double formatted.