### PR TITLE
 Increase number of tasks for bucket counts to 25

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -13,7 +13,7 @@ from utils.gcp import bigquery_etl_query, gke_command
 
 project_id = "moz-fx-data-shared-prod"
 dataset_id = "telemetry_derived"
-tmp_project = "mozdata"  # for temporary tables in analysis dataset
+tmp_project = "moz-fx-data-shared-prod"  # for temporary tables in analysis dataset
 default_args = {
     "owner": "msamuel@mozilla.com",
     "depends_on_past": False,


### PR DESCRIPTION


This increases the number of tasks from 20 to 25 due to: [link](https://workflow.telemetry.mozilla.org/log?dag_id=glam.clients_histogram_bucket_counts&task_id=clients_histogram_bucket_counts_16&execution_date=2021-10-18T02%3A00%3A00%2B00%3A00)