### PR TITLE
Bug 1714471 - Set partitioning parameters in ltv_revenue_join

### DIFF
--- a/dags/ltv.py
+++ b/dags/ltv.py
@@ -113,8 +113,9 @@ ltv_revenue_join = bigquery_etl_query(
     destination_table="client_ltv_v1",
     dataset_id="revenue_derived",
     project_id="moz-fx-data-shared-prod",
-    arguments=("--clustering_fields=engine,country", "--schema_update_option=ALLOW_FIELD_ADDITION",
-               "--schema_update_option=ALLOW_FIELD_RELAXATION"),
+    arguments=("--clustering_fields=engine,country",
+               "--schema_update_option=ALLOW_FIELD_ADDITION", "--schema_update_option=ALLOW_FIELD_RELAXATION",
+               "--time_partitioning_type=DAY", "--time_partitioning_field=submission_date"),
     dag=dag,
 )
 


### PR DESCRIPTION
This makes ltv_revenue_join query equivalent to the old one based on BigQueryExecuteQueryOperator (rewritten in https://github.com/mozilla/telemetry-airflow/pull/1388). Explicitly setting time partitioning is required here due to clustering - I have validated this by running `bq query` locally to a data-partitioned, clustered table.