### PR TITLE
Fix glam clients bucket counts

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -34,7 +34,7 @@ GLAM_DAG = "glam"
 GLAM_CLIENTS_HISTOGRAM_AGGREGATES_SUBDAG = "clients_histogram_aggregates"
 PERCENT_RELEASE_WINDOWS_SAMPLING = "10"
 
-dag = DAG(GLAM_DAG, default_args=default_args, schedule_interval="0 2 * * *")
+dag = DAG(GLAM_DAG, default_args=default_args, schedule_interval="0 9 * * *")
 
 # Make sure all the data for the given day has arrived before running.
 wait_for_main_ping = ExternalTaskCompletedSensor(
@@ -330,7 +330,7 @@ clients_histogram_bucket_counts >> clients_histogram_probe_counts
 clients_histogram_probe_counts >> histogram_percentiles
 
 clients_scalar_aggregates >> glam_user_counts
-
+histogram_percentiles >> client_scalar_probe_counts
 glam_user_counts >> extract_counts
 glam_sample_counts >> extract_sample_counts
 


### PR DESCRIPTION
This is to resolve issue with couple of tasks : 
Failure in `clients_histogram_bucket_counts` : [link](https://workflow.telemetry.mozilla.org/log?dag_id=glam.clients_histogram_bucket_counts&task_id=clients_histogram_bucket_counts_7&execution_date=2021-10-23T02%3A00%3A00%2B00%3A00)
`021-10-24T08:35:50.041620706Z BigQuery error in query operation: Error processing job 'moz-fx-data-shared-
[2021-10-24 08:35:50,071] {{pod_launcher.py:149}} INFO - prod:bqjob_r31a166944e02f7ca_0000017cb149d5d2_1': Resources exceeded during
[2021-10-24 08:35:50,071] {{pod_launcher.py:149}} INFO - query execution: Your project or organization exceeded the maximum disk and
[2021-10-24 08:35:50,071] {{pod_launcher.py:149}} INFO - memory limit available for shuffle operations. Consider provisioning more slots,
[2021-10-24 08:35:50,072] {{pod_launcher.py:149}} INFO - reducing query concurrency, or using more efficient logic in this job.`

Failure in `clients_scalar_probe_counts` : [link](https://workflow.telemetry.mozilla.org/log?dag_id=glam&task_id=client_scalar_probe_counts&execution_date=2021-10-24T02%3A00%3A00%2B00%3A00)

`google.api_core.exceptions.BadRequest: 400 Resources exceeded during query execution: Your project or organization exceeded the maximum disk and memory limit available for shuffle operations. Consider provisioning more slots, reducing query concurrency, or using more efficient logic in this job.`


As part of the solution, 3 changes have been made
1. Moved the dag execution time from 2 am UTC to 9 am UTC  to avoid contention issues 
2. Increased `clients_histogram_bucket_counts` partitions to 50
3. Moved the `client_scalar_probe_counts` to later in the dag