### PR TITLE
Revert celery config change.

### DIFF
--- a/airflow.cfg
+++ b/airflow.cfg
@@ -497,8 +497,7 @@ flower_port = $AIRFLOW_FLOWER_PORT
 sync_parallelism = 0
 
 # Import path for celery configuration options
-# celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
-celery_config_options = moz_celery_config.CELERY_CONFIG
+celery_config_options = airflow.config_templates.default_celery.DEFAULT_CELERY_CONFIG
 ssl_active = False
 # ssl_key =
 # ssl_cert =

--- a/dags/moz_celery_config.py
+++ b/dags/moz_celery_config.py
@@ -1,6 +1,0 @@
-from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
-
-CELERY_CONFIG = dict(DEFAULT_CELERY_CONFIG,
-                     **{"worker_log_format": "[%(asctime)s] %(levelname)s - %(processName)s - %(message)s",
-                        "worker_redirect_stdouts_level": "INFO"
-                     })


### PR DESCRIPTION
Worked locally, not on stage.

Either way the stackdriver alert needs to be modified to exclude the statefulset workers, and then have a custom log based metric for error counts and a separate alert on that