### PR TITLE
Add missing docs to DAGs

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -1,3 +1,14 @@
+"""
+This is a processing job on top of BHR pings, migrated from Databricks and now running
+as a scheduled Dataproc task.
+
+BHR is related to the Background Hang Monitor in desktop Firefox.
+See [bug 1675103](https://bugzilla.mozilla.org/show_bug.cgi?id=1675103)
+
+The [job source](https://github.com/mozilla/python_mozetl/blob/main/mozetl/bhr_collection)
+is maintained in the mozetl repository.
+"""
+
 import datetime
 
 from airflow import DAG
@@ -26,6 +37,7 @@ with DAG(
         "bhr_collection",
         default_args=default_args,
         schedule_interval="0 5 * * *",
+        doc_md=__doc__,
 ) as dag:
     # Jobs read from/write to s3://telemetry-public-analysis-2/bhr/data/hang_aggregates/
     write_aws_conn_id = 'aws_dev_telemetry_public_analysis_2_rw'

--- a/dags/etl_graph.py
+++ b/dags/etl_graph.py
@@ -1,3 +1,11 @@
+"""
+See [etl-graph in the docker-etl repository]
+(https://github.com/mozilla/docker-etl/blob/main/jobs/etl-graph).
+
+This DAG is low priority, as it powers a stand-alone visualization internal
+to the data platform.
+"""
+
 from datetime import datetime, timedelta
 
 from airflow import DAG
@@ -14,7 +22,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-with DAG("etl_graph", default_args=default_args, schedule_interval="0 2 * * *") as dag:
+with DAG("etl_graph", default_args=default_args, schedule_interval="0 2 * * *", doc_md=__doc__) as dag:
     etl_graph = GKEPodOperator(
         task_id="etl_graph",
         name="etl_graph",

--- a/dags/experiments_live.py
+++ b/dags/experiments_live.py
@@ -1,3 +1,11 @@
+"""
+See [experiments-monitoring-data-export in the docker-etl repository]
+(https://github.com/mozilla/docker-etl/tree/main/jobs/experiments-monitoring-data-export).
+
+This DAG exports views related to experiment monitoring to GCS as JSON
+every 5 minutes to power the Experimenter console.
+"""
+
 from airflow import DAG
 from datetime import datetime, timedelta
 
@@ -21,7 +29,9 @@ with DAG('experiments_live',
          # max_active_tasks=4,
          concurrency=4,
          max_active_runs=1,
-         schedule_interval="*/5 * * * *") as dag:
+         schedule_interval="*/5 * * * *",
+         doc_md=__doc__,
+) as dag:
 
     # list of datasets to export data to GCS
     experiment_datasets = [

--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -1,3 +1,10 @@
+"""
+Powers the public https://data.firefox.com/ dashboard.
+
+Source code is in the [firefox-public-data-report-etl repository]
+(https://github.com/mozilla/firefox-public-data-report-etl).
+"""
+
 from airflow import DAG
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from operators.task_sensor import ExternalTaskCompletedSensor
@@ -31,7 +38,11 @@ default_args = {
     "retry_delay": timedelta(minutes=10),
 }
 
-dag = DAG("firefox_public_data_report", default_args=default_args, schedule_interval="0 1 * * MON")
+dag = DAG(
+    "firefox_public_data_report",
+    default_args=default_args,
+    schedule_interval="0 1 * * MON",
+    doc_md=__doc__)
 
 # Required to write json output to s3://telemetry-public-analysis-2/public-data-report/hardware/
 write_aws_conn_id='aws_dev_telemetry_public_analysis_2_rw'

--- a/dags/glam.py
+++ b/dags/glam.py
@@ -1,3 +1,13 @@
+"""
+Desktop ETL for https://glam.telemetry.mozilla.org/
+
+Generates and runs a series of BQ queries, see
+[bigquery_etl/glam](https://github.com/mozilla/bigquery-etl/tree/main/bigquery_etl/glam)
+in bigquery-etl and the
+[glam_subdags](https://github.com/mozilla/telemetry-airflow/tree/main/dags/glam_subdags)
+in telemetry-airflow.
+"""
+
 from datetime import datetime, timedelta
 
 from airflow import DAG
@@ -34,7 +44,11 @@ GLAM_DAG = "glam"
 GLAM_CLIENTS_HISTOGRAM_AGGREGATES_SUBDAG = "clients_histogram_aggregates"
 PERCENT_RELEASE_WINDOWS_SAMPLING = "10"
 
-dag = DAG(GLAM_DAG, default_args=default_args, schedule_interval="0 2 * * *")
+dag = DAG(
+    GLAM_DAG,
+    default_args=default_args,
+    schedule_interval="0 2 * * *",
+    doc_md=__doc__)
 
 
 # Make sure all the data for the given day has arrived before running.

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -1,3 +1,13 @@
+"""
+Firefox for Android ETL for https://glam.telemetry.mozilla.org/
+
+Generates and runs a series of BQ queries, see
+[bigquery_etl/glam](https://github.com/mozilla/bigquery-etl/tree/main/bigquery_etl/glam)
+in bigquery-etl and the
+[glam_subdags](https://github.com/mozilla/telemetry-airflow/tree/main/dags/glam_subdags)
+in telemetry-airflow.
+"""
+
 from datetime import datetime, timedelta
 
 from airflow import DAG
@@ -57,6 +67,7 @@ dag = DAG(
     default_args=default_args,
     max_active_runs=1,
     schedule_interval="0 2 * * *",
+    doc_md=__doc__,
 )
 
 wait_for_copy_deduplicate = ExternalTaskCompletedSensor(

--- a/dags/graphics_telemetry.py
+++ b/dags/graphics_telemetry.py
@@ -1,3 +1,13 @@
+"""
+Processes main ping data and exports to S3 to power a graphics dashboard at
+https://firefoxgraphics.github.io/telemetry/
+
+This was originally a Databricks notebook that was migrated to a scheduled
+Dataproc task. Source code lives in the
+[FirefoxGraphics/telemetry](https://github.com/FirefoxGraphics/telemetry)
+repository.
+"""
+
 import datetime
 import os
 
@@ -37,6 +47,7 @@ with DAG(
         "graphics_telemetry",
         default_args=default_args,
         schedule_interval="0 3 * * *",
+        doc_md=__doc__,
 ) as dag:
     # Jobs read from/write to s3://telemetry-public-analysis-2/gfx/telemetry-data/
     write_aws_conn_id = 'aws_dev_telemetry_public_analysis_2_rw'

--- a/dags/jetstream.py
+++ b/dags/jetstream.py
@@ -1,3 +1,10 @@
+"""
+Powers the [jetstream](https://experimenter.info/jetstream/jetstream/)
+analysis framework for experiments.
+
+See the [jetstream repository](https://github.com/mozilla/jetstream).
+"""
+
 from airflow import DAG
 from operators.task_sensor import ExternalTaskCompletedSensor
 from datetime import timedelta, datetime
@@ -14,7 +21,12 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-with DAG("jetstream", default_args=default_args, schedule_interval="0 4 * * *") as dag:
+with DAG(
+        "jetstream",
+        default_args=default_args,
+        schedule_interval="0 4 * * *",
+        doc_md=__doc__,
+) as dag:
 
     # Built from repo https://github.com/mozilla/jetstream
     jetstream_image = "gcr.io/moz-fx-data-experiments/jetstream:latest"

--- a/dags/kpi_forecasts.py
+++ b/dags/kpi_forecasts.py
@@ -1,3 +1,11 @@
+"""
+Runs simpleprophet forecasting for corporate KPIs, dumping results to BQ tables
+which are then visualized in Looker dashboards.
+
+Source code is in
+[mozilla/forecasting](https://github.com/mozilla/forecasting/tree/main/simpleprophet).
+"""
+
 import datetime
 
 from airflow import models
@@ -23,6 +31,7 @@ dag_name = 'kpi_forecasts'
 with models.DAG(
         dag_name,
         schedule_interval='0 4 * * *',
+        doc_md=__doc__,
         default_args=default_args) as dag:
 
     simpleprophet_forecasts_mobile = simpleprophet_forecast(

--- a/dags/ltv.py
+++ b/dags/ltv.py
@@ -1,3 +1,12 @@
+"""
+Client Lifetime Value.
+
+Kicks off jobs to run on a Dataproc cluster. The job code lives in
+[jobs/ltv_daily.py](https://github.com/mozilla/telemetry-airflow/blob/main/jobs/ltv_daily.py).
+
+See [client_ltv docs on DTMO](https://docs.telemetry.mozilla.org/datasets/search/client_ltv/reference.html).
+"""
+
 import json
 import os
 

--- a/dags/ltv.py
+++ b/dags/ltv.py
@@ -41,7 +41,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-dag = DAG("ltv_daily", default_args=default_args, schedule_interval="0 4 * * *")
+dag = DAG("ltv_daily", default_args=default_args, schedule_interval="0 4 * * *", doc_md=__doc__)
 
 params = get_dataproc_parameters("google_cloud_airflow_dataproc")
 

--- a/dags/mad_server.py
+++ b/dags/mad_server.py
@@ -1,3 +1,11 @@
+"""
+Malicious Addons Detection
+
+This runs once a week to emit a trained model to GCS.
+
+Source code is in the private [mad-server repository](https://github.com/mozilla/mad-server/).
+"""
+
 import os
 from airflow import DAG
 from datetime import datetime, timedelta
@@ -17,7 +25,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-with DAG("mad_server", default_args=default_args, schedule_interval="@weekly") as dag:
+with DAG("mad_server", default_args=default_args, schedule_interval="@weekly", doc_md=__doc__) as dag:
     is_dev = os.environ.get("DEPLOY_ENVIRONMENT") == "dev"
     aws_conn_id="aws_dev_mad_resources_training"
     # mad-server expects AWS creds in some custom env vars.

--- a/dags/mozaggregator_mobile.py
+++ b/dags/mozaggregator_mobile.py
@@ -1,3 +1,10 @@
+"""
+Aggregates that power the legacy telemetry
+[Measurement Dashboard](https://telemetry.mozilla.org/new-pipeline/dist.html).
+
+See [python_mozaggregator](https://github.com/mozilla/python_mozaggregator).
+"""
+
 import json
 import os
 from datetime import datetime, timedelta
@@ -27,7 +34,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-dag = DAG("mobile_aggregates", default_args=default_args, schedule_interval="@daily")
+dag = DAG("mobile_aggregates", default_args=default_args, schedule_interval="@daily", doc_md=__doc__)
 
 subdag_args = default_args.copy()
 subdag_args["retries"] = 0

--- a/dags/mozaggregator_prerelease.py
+++ b/dags/mozaggregator_prerelease.py
@@ -1,3 +1,10 @@
+"""
+Aggregates that power the legacy telemetry
+[Measurement Dashboard](https://telemetry.mozilla.org/new-pipeline/dist.html).
+
+See [python_mozaggregator](https://github.com/mozilla/python_mozaggregator).
+"""
+
 import json
 import os
 from datetime import datetime, timedelta
@@ -29,6 +36,7 @@ dag = DAG(
     "prerelease_telemetry_aggregates",
     default_args=default_args,
     schedule_interval="@daily",
+    doc_md=__doc__,
 )
 
 

--- a/dags/mozfun.py
+++ b/dags/mozfun.py
@@ -1,3 +1,12 @@
+"""
+Nightly deploy of `mozfun` UDFs.
+
+This job has elevated permissions to be able to create new datasets in the mozfun
+project when new logical namespaces are created in the mozfun directory of bigquery-etl.
+This is the reason that individual data engineers cannot deploy UDFs to the mozfun project
+on their own, hence the need for this nightly task.
+"""
+
 from airflow import DAG
 from datetime import timedelta, datetime
 from utils.gcp import gke_command
@@ -13,7 +22,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-with DAG("mozfun", default_args=default_args, schedule_interval="@daily") as dag:
+with DAG("mozfun", default_args=default_args, schedule_interval="@daily", doc_md=__doc__) as dag:
     docker_image = "gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest"
 
     publish_public_udfs = gke_command(

--- a/dags/parquet_export.py
+++ b/dags/parquet_export.py
@@ -1,3 +1,11 @@
+"""
+Export of a few BigQuery datasets to Parquet files on GCS.
+
+The only consumer of these datasets is the taar DAGs.
+We should eventually update the TAAR logic to use BigQuery directly,
+which would allow us to tear down this DAG.
+"""
+
 from airflow import DAG
 from datetime import datetime, timedelta
 from airflow.operators.subdag_operator import SubDagOperator
@@ -24,7 +32,7 @@ default_args = {
 
 # Make sure all the data for the given day has arrived before running.
 # Running at 1am should suffice.
-dag = DAG('parquet_export', default_args=default_args, schedule_interval='0 3 * * *')
+dag = DAG('parquet_export', default_args=default_args, schedule_interval='0 3 * * *', doc_md=__doc__)
 
 main_summary_bigint_columns = [
     # bigquery does not have 32-bit int, and int->bigint is not a

--- a/dags/partybal.py
+++ b/dags/partybal.py
@@ -1,3 +1,9 @@
+"""
+See https://github.com/mozilla/partybal
+
+This is currently only experimental.
+"""
+
 from airflow import DAG
 from datetime import timedelta, datetime
 from operators.gcp_container_operator import GKEPodOperator
@@ -13,7 +19,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-with DAG("partybal", default_args=default_args, schedule_interval="0 */3 * * *") as dag:
+with DAG("partybal", default_args=default_args, schedule_interval="0 */3 * * *", doc_md=__doc__) as dag:
 
     # Built from repo https://github.com/mozilla/partybal
     partybal_image = "gcr.io/partybal/partybal:latest"
@@ -25,4 +31,3 @@ with DAG("partybal", default_args=default_args, schedule_interval="0 */3 * * *")
         email=["ascholtz@mozilla.com", "msamuel@mozilla.com",],
         dag=dag,
     )
-

--- a/dags/play_store_export.py
+++ b/dags/play_store_export.py
@@ -1,3 +1,10 @@
+"""
+Runs a Docker image that backfills data from the Google Play store to BigQuery.
+
+The container is defined in
+[docker-etl](https://github.com/mozilla/docker-etl/tree/main/jobs/play-store-export)
+"""
+
 from airflow import DAG
 from datetime import datetime, timedelta
 from utils.gcp import gke_command
@@ -17,6 +24,7 @@ project_id = "moz-fx-data-marketing-prod"
 
 with DAG("play_store_export",
          default_args=default_args,
+         doc_md=__doc__,
          schedule_interval="@daily") as dag:
 
     play_store_export = gke_command(

--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -1,3 +1,12 @@
+"""
+Daily data exports used by TAAR.
+
+Source code is in [mozilla/telemetry-batch-view](https://github.com/mozilla/telemetry-batch-view/blob/main/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala).
+
+For context, see https://github.com/mozilla/taar
+"""
+
+
 from datetime import datetime, timedelta
 
 from airflow import DAG
@@ -44,7 +53,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-dag = DAG("taar_daily", default_args=default_args, schedule_interval="0 4 * * *")
+dag = DAG("taar_daily", default_args=default_args, schedule_interval="0 4 * * *", doc_md=__doc__)
 
 amodump = GKEPodOperator(
     task_id="taar_amodump",

--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -1,6 +1,9 @@
 """
 This configures a weekly DAG to run the TAAR Ensemble job off.
+
+For context, see https://github.com/mozilla/taar
 """
+
 from airflow import DAG
 from datetime import datetime, timedelta
 from airflow.operators.subdag_operator import SubDagOperator
@@ -47,7 +50,8 @@ default_args_weekly = {
 
 
 taar_weekly = DAG(
-    "taar_weekly", default_args=default_args_weekly, schedule_interval="@weekly"
+    "taar_weekly", default_args=default_args_weekly, schedule_interval="@weekly",
+    doc_md=__doc__,
 )
 
 

--- a/dags/update_orphaning_dashboard_etl.py
+++ b/dags/update_orphaning_dashboard_etl.py
@@ -1,3 +1,9 @@
+"""
+Powers https://telemetry.mozilla.org/update-orphaning/
+
+See [jobs/update_orphaning_dashboard_etl.py](https://github.com/mozilla/telemetry-airflow/blob/main/jobs/update_orphaning_dashboard_etl.py).
+"""
+
 from airflow import DAG
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.operators.subdag_operator import SubDagOperator
@@ -25,7 +31,12 @@ default_args = {
 }
 
 # run every Monday to maintain compatibility with legacy ATMO schedule
-dag = DAG("update_orphaning_dashboard_etl", default_args=default_args, schedule_interval="0 2 * * MON")
+dag = DAG(
+    "update_orphaning_dashboard_etl",
+    default_args=default_args,
+    schedule_interval="0 2 * * MON",
+    doc_md=__doc__,
+)
 
 # Unsalted cluster name so subsequent runs fail if the cluster name exists
 cluster_name = 'app-update-out-of-date-dataproc-cluster'


### PR DESCRIPTION
Inspired by discussion early today of nostalgia for docs days,
I wanted to add basic docs to all the bespoke DAGs in this repo
to help with giving basic context in the Airflow UI that should help with
onboarding folks to the Airflow triage process.