### PR TITLE
Fixup quicksuggest2bq image url

### DIFF
--- a/dags/contextual_services_import.py
+++ b/dags/contextual_services_import.py
@@ -36,7 +36,7 @@ with DAG("contextual_services_import",
             "--destination-project", project_id,
             "--destination-table-id", table_id,
         ],
-        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/quicksuggest2bq:latest",
+        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/quicksuggest2bq_docker_etl:latest",
         gcp_conn_id="google_cloud_derived_datasets",
         dag=dag,
         email=[


### PR DESCRIPTION
Based on failure in https://workflow.telemetry.mozilla.org/log?dag_id=contextual_services_import&task_id=quicksuggest2bq&execution_date=2021-11-18T17%3A13%3A28.682138%2B00%3A00 and [kube logs](https://console.cloud.google.com/logs/query;query=quicksuggest2bq.d9badb30c934490cb50eaf05b7ed42db;cursorTimestamp=2021-11-18T17:16:46Z?project=moz-fx-data-derived-datasets)