### PR TITLE
Adding sleep op fenix

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.models import Variable
-
+from operators.sleep_operator import SleepOperator
 from operators.gcp_container_operator import GKENatPodOperator
 from operators.task_sensor import ExternalTaskCompletedSensor
 from glam_subdags.generate_query import (
@@ -225,6 +225,12 @@ env_vars = dict(
     GOOGLE_CLOUD_PROJECT = "moz-fx-data-glam-prod-fca7"
 )
 
+sleep_for_5_mins =  SleepOperator(
+    task_id='sleep_for_5_mins',
+    sleep_time=300,
+    dag=dag)
+
+
 glam_fenix_import_glean_aggs_beta = GKENatPodOperator(
     task_id = 'glam_fenix_import_glean_aggs_beta',
     name = 'glam_fenix_import_glean_aggs_beta',
@@ -258,7 +264,7 @@ glam_fenix_import_glean_counts = GKENatPodOperator(
     dag=dag)
 
 
-export >> glam_fenix_import_glean_aggs_beta
-export >> glam_fenix_import_glean_aggs_nightly
-export >> glam_fenix_import_glean_aggs_release
-export >> glam_fenix_import_glean_counts
+export >> sleep_for_5_mins >> glam_fenix_import_glean_aggs_beta
+export >> sleep_for_5_mins >> glam_fenix_import_glean_aggs_nightly
+export >> sleep_for_5_mins >> glam_fenix_import_glean_aggs_release
+export >> sleep_for_5_mins >> glam_fenix_import_glean_counts

--- a/dags/glam_firefox_desktop.py
+++ b/dags/glam_firefox_desktop.py
@@ -1,0 +1,190 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from operators.task_sensor import ExternalTaskCompletedSensor
+from glam_subdags.generate_query import (
+    generate_and_run_glean_queries,
+    generate_and_run_glean_task,
+)
+from utils.gcp import gke_command
+from functools import partial
+
+default_args = {
+    "owner": "akommasani@mozilla.com",
+    "depends_on_past": False,
+    "start_date": datetime(2020, 2, 19),
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "akommasani@mozilla.com",
+    ],
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=30),
+}
+
+PROJECT = "moz-fx-data-glam-prod-fca7"
+BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
+
+# Fenix as a product has a convoluted app_id history. The comments note the
+# start and end dates of the id in the app store.
+# https://docs.google.com/spreadsheets/d/18PzkzZxdpFl23__-CIO735NumYDqu7jHpqllo0sBbPA
+PRODUCTS = [
+    "firefox_desktop",
+]
+
+# This is only required if there is a logical mapping defined within the
+# bigquery-etl module within the templates/logical_app_id folder. This builds
+# the dependency graph such that the view with the logical clients daily table
+# is always pointing to a concrete partition in BigQuery.
+LOGICAL_MAPPING = {
+    "firefox_desktop_glam_nightly": ["firefox_desktop"],
+    "firefox_desktop_glam_beta": ["firefox_desktop"],
+    "firefox_desktop_glam_release": ["firefox_desktop"],
+   
+}
+
+dag = DAG(
+    "glam_firefox_desktop",
+    default_args=default_args,
+    max_active_runs=1,
+    schedule_interval="0 2 * * *",
+)
+
+wait_for_copy_deduplicate = ExternalTaskCompletedSensor(
+    task_id="wait_for_copy_deduplicate",
+    external_dag_id="copy_deduplicate",
+    external_task_id="copy_deduplicate_all",
+    execution_delta=timedelta(hours=1),
+    check_existence=True,
+    mode="reschedule",
+    pool="DATA_ENG_EXTERNALTASKSENSOR",
+    email_on_retry=False,
+    dag=dag,
+)
+
+mapping = {}
+for product in PRODUCTS:
+    query = generate_and_run_glean_queries(
+        task_id=f"daily_{product}",
+        product=product,
+        destination_project_id=PROJECT,
+        env_vars=dict(STAGE="daily"),
+        dag=dag,
+    )
+    mapping[product] = query
+    wait_for_copy_deduplicate >> query
+
+# the set of logical ids and the set of ids that are not mapped to logical ids
+final_products = set(LOGICAL_MAPPING.keys()) | set(PRODUCTS) - set(
+    sum(LOGICAL_MAPPING.values(), [])
+)
+for product in final_products:
+    func = partial(
+        generate_and_run_glean_task,
+        product=product,
+        destination_project_id=PROJECT,
+        env_vars=dict(STAGE="incremental"),
+        dag=dag,
+    )
+    view, init, query = [
+        partial(func, task_type=task_type) for task_type in ["view", "init", "query"]
+    ]
+
+    # stage 1 - incremental
+    clients_daily_histogram_aggregates = view(
+        task_name=f"{product}__view_clients_daily_histogram_aggregates_v1"
+    )
+    clients_daily_scalar_aggregates = view(
+        task_name=f"{product}__view_clients_daily_scalar_aggregates_v1"
+    )
+    latest_versions = query(task_name=f"{product}__latest_versions_v1")
+
+    clients_scalar_aggregate_init = init(
+        task_name=f"{product}__clients_scalar_aggregates_v1"
+    )
+    clients_scalar_aggregate = query(
+        task_name=f"{product}__clients_scalar_aggregates_v1"
+    )
+
+    clients_histogram_aggregate_init = init(
+        task_name=f"{product}__clients_histogram_aggregates_v1"
+    )
+    clients_histogram_aggregate = query(
+        task_name=f"{product}__clients_histogram_aggregates_v1"
+    )
+
+    # stage 2 - downstream for export
+    scalar_bucket_counts = query(task_name=f"{product}__scalar_bucket_counts_v1")
+    scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")
+    scalar_percentile = query(task_name=f"{product}__scalar_percentiles_v1")
+
+    histogram_bucket_counts = query(task_name=f"{product}__histogram_bucket_counts_v1")
+    histogram_probe_counts = query(task_name=f"{product}__histogram_probe_counts_v1")
+    histogram_percentiles = query(task_name=f"{product}__histogram_percentiles_v1")
+
+    probe_counts = view(task_name=f"{product}__view_probe_counts_v1")
+    extract_probe_counts = query(task_name=f"{product}__extract_probe_counts_v1")
+
+    user_counts = view(task_name=f"{product}__view_user_counts_v1")
+    extract_user_counts = query(task_name=f"{product}__extract_user_counts_v1")
+
+    sample_counts = view(task_name=f"{product}__view_sample_counts_v1")
+    extract_sample_counts = query(task_name=f"{product}__extract_sample_counts_v1")
+
+    export = gke_command(
+        task_id=f"export_{product}",
+        cmds=["bash"],
+        env_vars={
+            "SRC_PROJECT": PROJECT,
+            "DATASET": "glam_etl",
+            "PRODUCT": product,
+            "BUCKET": BUCKET,
+        },
+        command=["script/glam/export_csv"],
+        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
+        gcp_conn_id="google_cloud_derived_datasets",
+        dag=dag,
+    )
+
+    # set all of the dependencies for all of the tasks
+
+    # get the dependencies for the logical mapping, or just pass through the
+    # daily query unmodified
+    for dependency in LOGICAL_MAPPING.get(product, [product]):
+        mapping[dependency] >> clients_daily_scalar_aggregates
+        mapping[dependency] >> clients_daily_histogram_aggregates
+
+    # only the scalar aggregates are upstream of latest versions
+    clients_daily_scalar_aggregates >> latest_versions
+    latest_versions >> clients_scalar_aggregate_init
+    latest_versions >> clients_histogram_aggregate_init
+
+    (
+        clients_daily_scalar_aggregates
+        >> clients_scalar_aggregate_init
+        >> clients_scalar_aggregate
+    )
+    (
+        clients_daily_histogram_aggregates
+        >> clients_histogram_aggregate_init
+        >> clients_histogram_aggregate
+    )
+
+    (
+        clients_scalar_aggregate
+        >> scalar_bucket_counts
+        >> scalar_probe_counts
+        >> scalar_percentile
+        >> probe_counts
+    )
+    (
+        clients_histogram_aggregate
+        >> histogram_bucket_counts
+        >> histogram_probe_counts
+        >> histogram_percentiles
+        >> probe_counts
+    )
+    probe_counts >> extract_probe_counts >> export
+    clients_scalar_aggregate >> user_counts >> extract_user_counts >> export
+    clients_histogram_aggregate >> sample_counts >> extract_sample_counts >> export


### PR DESCRIPTION
The glam fenix imports are failing with error  'Dependencies not met' 

https://workflow.telemetry.mozilla.org/log?dag_id=glam_fenix&task_id=glam_fenix_import_glean_counts&execution_date=2021-12-10T02%3A00%3A00%2B00%3A00

The error is complaining about the upstream task 'export_org_mozilla_fenix_glam_beta' 

Example: 
The task starts at time 2021-12-11 02:18:35,380,

But the dependent task finishes afterward: at the time [2021-12-11 02:19:24,249]

