### PR TITLE
Updated owner of socorro_import DAG as per tags google sheet

### DIFF
--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -31,12 +31,12 @@ conn - aws_socorro_readonly_s3
 """
 
 default_args = {
-    "owner": "amiyaguchi@mozilla.com",
+    "owner": "wkahngreene@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 9, 10),
     "email": [
         "telemetry-alerts@mozilla.com",
-        "amiyaguchi@mozilla.com",
+        "wkahngreene@mozilla.com",
         "willkg@mozilla.com",
     ],
     "email_on_failure": True,


### PR DESCRIPTION
# Updated owner of socorro_import DAG as per tags google sheet

When collecting a list of Airflow tags we identified that some DAG owners were no longer at Mozilla. This PR updates out of date owners.

Airflow Tags Google Sheet: https://docs.google.com/spreadsheets/d/1WXo5_d8j_KfGzT07ay3gC2zAfnhRHzxoZDlwcThNvf0/edit#gid=0