### PR TITLE
Revert "Adding sleep op fenix"

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.models import Variable
-from operators.sleep_operator import SleepOperator
+
 from operators.gcp_container_operator import GKENatPodOperator
 from operators.task_sensor import ExternalTaskCompletedSensor
 from glam_subdags.generate_query import (
@@ -225,12 +225,6 @@ env_vars = dict(
     GOOGLE_CLOUD_PROJECT = "moz-fx-data-glam-prod-fca7"
 )
 
-sleep_for_5_mins =  SleepOperator(
-    task_id='sleep_for_5_mins',
-    sleep_time=300,
-    dag=dag)
-
-
 glam_fenix_import_glean_aggs_beta = GKENatPodOperator(
     task_id = 'glam_fenix_import_glean_aggs_beta',
     name = 'glam_fenix_import_glean_aggs_beta',
@@ -264,7 +258,7 @@ glam_fenix_import_glean_counts = GKENatPodOperator(
     dag=dag)
 
 
-export >> sleep_for_5_mins >> glam_fenix_import_glean_aggs_beta
-export >> sleep_for_5_mins >> glam_fenix_import_glean_aggs_nightly
-export >> sleep_for_5_mins >> glam_fenix_import_glean_aggs_release
-export >> sleep_for_5_mins >> glam_fenix_import_glean_counts
+export >> glam_fenix_import_glean_aggs_beta
+export >> glam_fenix_import_glean_aggs_nightly
+export >> glam_fenix_import_glean_aggs_release
+export >> glam_fenix_import_glean_counts


### PR DESCRIPTION
Reverts mozilla/telemetry-airflow#1431. 
Adding the sleep task is not quite helpful for this issue. 
Will create another PR to add the sleep at [this](https://github.com/mozilla/telemetry-airflow/blob/7a195415de77d7bdb4651406f50df96005960bb8/dags/glam_fenix.py#L166) point in the code. 