### PR TITLE
Remove duplicate email address from socorro_import DAG

### DIFF
--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -37,7 +37,6 @@ default_args = {
     "email": [
         "telemetry-alerts@mozilla.com",
         "wkahngreene@mozilla.com",
-        "willkg@mozilla.com",
     ],
     "email_on_failure": True,
     "email_on_retry": True,


### PR DESCRIPTION
I'm wkahngreene and one of my aliases is willkg. This removes one of them from the email list.