### PR TITLE
Step to validate airflow dags as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,9 @@ jobs:
             docker-compose build
             # now take ownership of the folder
             sudo chown -R 10001:10001 .
+
       - run:
-          name: Test if dag scripts can be parsed
+          name: Test if dag scripts can be parsed by Airflow and that tags have been correctly set
           command: bash bin/test-parse
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
 
       - run:
           name: Test if dag scripts can be parsed by Airflow and that tags have been correctly set
+          #  Valid DAG tags are defined in: `bin/test-dag-tags.py`
           command: bash bin/test-parse
 
   deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,10 @@ unittests.cfg
 airflow-webserver.pid
 airflow-worker.pid
 .config
+.viminfo
 .credentials
+.bash_history
+.mysql_history
 
 /dags/bigquery-etl-dags
 /dags/bigquery-etl-dags/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         apt-transport-https build-essential curl git libpq-dev python-dev \
         default-libmysqlclient-dev gettext sqlite3 libffi-dev libsasl2-dev \
-        lsb-release gnupg vim screen procps && \
+        lsb-release gnupg vim screen procps default-mysql-client && \
     CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \

--- a/bin/test-dag-tags.py
+++ b/bin/test-dag-tags.py
@@ -33,6 +33,7 @@ def _execute_shell_cmd(cmd: str, cmd_params: Dict[str, dict] = dict()) -> str:
         capture_output=True,
         text=True,
     )
+
     try:
         cmd_output.check_returncode()
     except subprocess.CalledProcessError as _err:
@@ -45,7 +46,7 @@ def _execute_shell_cmd(cmd: str, cmd_params: Dict[str, dict] = dict()) -> str:
     return cmd_output.stdout.strip().replace("\r", "").split("\n")
 
 
-def retrieve_existing_airflow_dags_from_db(pswd: str) -> Dict[str, str]:
+def get_loaded_airflow_dag_tags_from_db(pswd: str) -> Dict[str, str]:
     shell_cmd = "docker-compose exec web mysql -Ns -h db -u root -p{pswd} airflow -e 'SELECT dag_id, name FROM dag_tag;'"
     cmd_params = {
         "pswd": {
@@ -67,7 +68,7 @@ def retrieve_existing_airflow_dags_from_db(pswd: str) -> Dict[str, str]:
     return dags
 
 
-def get_number_of_dags_loaded(pswd) -> int:
+def get_loaded_dags_from_db(pswd) -> int:
     cmd_params = {
         "pswd": {
             "value": pswd,
@@ -82,10 +83,10 @@ if __name__ == "__main__":
     # Assumes the web and db containers are already running
     tag_errors = 0
 
-    dags = get_number_of_dags_loaded(db_pass)
+    dags = get_loaded_dags_from_db(db_pass)
     num_of_dags = len(dags)
 
-    dags_with_tags = retrieve_existing_airflow_dags_from_db(db_pass)
+    dags_with_tags = get_loaded_airflow_dag_tags_from_db(db_pass)
     num_of_dags_with_tags = len(dags_with_tags)
 
     if num_of_dags != num_of_dags_with_tags:

--- a/bin/test-dag-tags.py
+++ b/bin/test-dag-tags.py
@@ -11,71 +11,46 @@ class DagValidationError(Exception):
     pass
 
 
-def retrieve_existing_airflow_dags():
-    output = subprocess.run(
-        "docker-compose exec web mysql -Ns -h db -u root -psecret airflow -e 'SELECT dag_id, name FROM dag_tag;'",
+def retrieve_existing_airflow_dags_from_db(pswd):
+    mask_string = "###"
+    shell_cmd = "docker-compose exec web mysql -Ns -h db -u root -p{pswd} airflow -e 'SELECT dag_id, name FROM dag_tag;'"
+
+    print("Executing command: %s" % (shell_cmd.format(pswd=mask_string)))
+    cmd_output = subprocess.run(
+        shell_cmd.format(pswd=pswd),
         shell=True,
-        capture_output=True
-    ).stdout.decode('ascii').strip()
+        capture_output=True,
+        text=True,
+    )
+    try:
+        cmd_output.check_returncode()
+    except subprocess.CalledProcessError as _err:
+        print(cmd_output.stdout)
+        print(cmd_output.stderr)
+        raise _err
+
+    print("Command executed successfully, processing output...")
+    processed_cmd_output = cmd_output.stdout.strip().replace("\r", "").split("\n")
 
     dags = defaultdict(list)
 
-    for dag in output.replace("\r", "").split("\n"):
+    for dag in processed_cmd_output:
         dag_name, tag_name = dag.split("\t")
-
         dags[dag_name] = dags[dag_name] + [tag_name]
 
-    return dags
-
-
-import glob, os
-import re
-
-# for file in glob.glob("*.txt"):
-#     print(file)
-
-def get_dag_tags(dag_dir: str):
-    tag_mapping = {
-        "Tag.ImpactTier.tier_1": "impact/tier_1",
-        "Tag.ImpactTier.tier_2": "impact/tier_2",
-        "Tag.ImpactTier.tier_3": "impact/tier_3",
-        "repo/telemetry-airflow": "impact/tier_3",
-        "repo/bigquery-etl": "repo/bigquery-etl",
-    }
-
-
-    dags = defaultdict(list)
-
-    for file in glob.glob("dag_dir/*.py"):
-        if "init" in file:
-            continue
-
-        with open(file) as _dag:
-            try:
-                match = re.search("tags\s=\s\[(.+)]", _dag.read()).group(1)
-                tags = match.strip().translate({44: "", 34: "",}).split(" ")
-
-            except AttributeError:
-                print("DAG file: %s appears to be missing tags.")
-                tags = list()
-
-            dags[file.split("/")[-1]] = [tag_mapping[tag] for tag in tags]
+    print("Number of DAGs found: %s" % (len(dags)))
 
     return dags
-
 
 
 if __name__ == "__main__":
+    # Assumes the web and db containers are already running
     tag_errors = 0
 
-    # bin/run script waits for db and reddis to be up before interacting with webserver container in test-parse script
-    # dags = retrieve_existing_airflow_dags()
-    dag_directory = "dags"
-    dags = get_dag_tags(dag_directory)
+    dags = retrieve_existing_airflow_dags_from_db("secret")
 
     for file_name, tags in dags.items():
         tag_categories = [category.split("/")[0] for category in tags]
-
 
         if not all(req_tag in tag_categories for req_tag in REQUIRED_TAG_TYPES):
             tag_errors += 1
@@ -88,4 +63,4 @@ if __name__ == "__main__":
     if tag_errors:
         raise DagValidationError("DAG tags validation failed.")
 
-    print("DAG tags validation successful.")
+    print("DAG tags validation for %s DAGs successful." % (len(dags)))

--- a/bin/test-dag-tags.py
+++ b/bin/test-dag-tags.py
@@ -1,0 +1,52 @@
+#!/bin/python3
+from collections import defaultdict
+import subprocess
+
+
+VALID_TAGS = ("impact/tier_1", "impact/tier_2", "impact/tier_3", "repo/bigquery-etl", "repo/telemetry-airflow",)
+REQUIRED_TAG_TYPES = ("impact",)
+
+
+class DagValidationError(Exception):
+    pass
+
+
+def retrieve_existing_airflow_dags():
+    output = subprocess.run(
+        "docker-compose exec web mysql -Ns -h db -u root -psecret airflow -e 'SELECT dag_id, name FROM dag_tag;'",
+        shell=True,
+        capture_output=True
+    ).stdout.decode('ascii').strip()
+
+    dags = defaultdict(list)
+
+    for dag in output.replace("\r", "").split("\n"):
+        dag_name, tag_name = dag.split("\t")
+
+        dags[dag_name] = dags[dag_name] + [tag_name]
+
+    return dags
+
+
+
+if __name__ == "__main__":
+    tag_errors = 0
+
+    # bin/run script waits for db and reddis to be up before interacting with webserver container in test-parse script
+    dags = retrieve_existing_airflow_dags()
+
+    for dag_id, tags in dags.items():
+        tag_categories = [category.split("/")[0] for category in tags]
+
+        if not all(req_tag in tag_categories for req_tag in REQUIRED_TAG_TYPES):
+            tag_errors += 1
+            print('%s is missing a required tag. Required tags include: %s. Please refer to: https://mozilla.github.io/bigquery-etl/reference/airflow_tags/ for more information.' % (dag_id, REQUIRED_TAG_TYPES))
+
+        if any(tag not in VALID_TAGS for tag in tags):
+            tag_errors += 1
+            print('DAG: %s contains an invalid tag. Tags specified: %s, valid tags: %s.' % (dag_id, tags, VALID_TAGS))
+
+    if tag_errors:
+        raise DagValidationError("DAG tags validation failed.")
+
+    print("DAG tags validation successful.")

--- a/bin/test-dag-tags.py
+++ b/bin/test-dag-tags.py
@@ -1,7 +1,7 @@
 #!/bin/python3
 from collections import defaultdict
 import subprocess
-from typing import Dict, Iterable
+from typing import Dict
 
 
 VALID_TAGS = ("impact/tier_1", "impact/tier_2", "impact/tier_3", "repo/bigquery-etl", "repo/telemetry-airflow",)
@@ -43,8 +43,6 @@ def _execute_shell_cmd(cmd: str, cmd_params: Dict[str, dict] = dict()) -> str:
     print("Command executed successfully, processing output...")
 
     return cmd_output.stdout.strip().replace("\r", "").split("\n")
-
-
 
 
 def retrieve_existing_airflow_dags_from_db(pswd: str) -> Dict[str, str]:

--- a/bin/test-dag-tags.py
+++ b/bin/test-dag-tags.py
@@ -28,23 +28,62 @@ def retrieve_existing_airflow_dags():
     return dags
 
 
+import glob, os
+import re
+
+# for file in glob.glob("*.txt"):
+#     print(file)
+
+def get_dag_tags(dag_dir: str):
+    tag_mapping = {
+        "Tag.ImpactTier.tier_1": "impact/tier_1",
+        "Tag.ImpactTier.tier_2": "impact/tier_2",
+        "Tag.ImpactTier.tier_3": "impact/tier_3",
+        "repo/telemetry-airflow": "impact/tier_3",
+        "repo/bigquery-etl": "repo/bigquery-etl",
+    }
+
+
+    dags = defaultdict(list)
+
+    for file in glob.glob("dag_dir/*.py"):
+        if "init" in file:
+            continue
+
+        with open(file) as _dag:
+            try:
+                match = re.search("tags\s=\s\[(.+)]", _dag.read()).group(1)
+                tags = match.strip().translate({44: "", 34: "",}).split(" ")
+
+            except AttributeError:
+                print("DAG file: %s appears to be missing tags.")
+                tags = list()
+
+            dags[file.split("/")[-1]] = [tag_mapping[tag] for tag in tags]
+
+    return dags
+
+
 
 if __name__ == "__main__":
     tag_errors = 0
 
     # bin/run script waits for db and reddis to be up before interacting with webserver container in test-parse script
-    dags = retrieve_existing_airflow_dags()
+    # dags = retrieve_existing_airflow_dags()
+    dag_directory = "dags"
+    dags = get_dag_tags(dag_directory)
 
-    for dag_id, tags in dags.items():
+    for file_name, tags in dags.items():
         tag_categories = [category.split("/")[0] for category in tags]
+
 
         if not all(req_tag in tag_categories for req_tag in REQUIRED_TAG_TYPES):
             tag_errors += 1
-            print('%s is missing a required tag. Required tags include: %s. Please refer to: https://mozilla.github.io/bigquery-etl/reference/airflow_tags/ for more information.' % (dag_id, REQUIRED_TAG_TYPES))
+            print('%s is missing a required tag. Required tags include: %s. Please refer to: https://mozilla.github.io/bigquery-etl/reference/airflow_tags/ for more information.' % (file_name, REQUIRED_TAG_TYPES))
 
         if any(tag not in VALID_TAGS for tag in tags):
             tag_errors += 1
-            print('DAG: %s contains an invalid tag. Tags specified: %s, valid tags: %s.' % (dag_id, tags, VALID_TAGS))
+            print('DAG file: %s contains an invalid tag. Tags specified: %s, valid tags: %s.' % (file_name, tags, VALID_TAGS))
 
     if tag_errors:
         raise DagValidationError("DAG tags validation failed.")

--- a/bin/test-parse
+++ b/bin/test-parse
@@ -53,7 +53,7 @@ function main() {
         echo "Existing container is up, please bring it down and re-run."
         exit 1
     fi
-    
+
     # Register the cleanup function, note that the testing function may override
     # the trap on the exit signal.
     function cleanup {
@@ -87,6 +87,15 @@ function main() {
         fi
         echo "Unit tests passed!"
     fi
+
+    # Validate Airflow tags
+    # see Github Issue: https://github.com/mozilla/telemetry-airflow/issues/1443
+    python3 bin/test-dag-tags.py
+    if [[ $? -ne 0 ]]; then
+        echo "Invalid tag configuration detected."
+        exit 1
+    fi
+    # END Validate Airflow tags
 
     echo "All checks passed, the dags can be parsed locally."
 }

--- a/dags/casa.py
+++ b/dags/casa.py
@@ -36,6 +36,7 @@ with DAG(
     default_args=default_args,
     doc_md=DOCS,
     schedule_interval="0 5 * * *",
+    tags=tags,
 ) as dag:
 
     casa_sync_start = FivetranOperator(

--- a/dags/crash_symbolication.py
+++ b/dags/crash_symbolication.py
@@ -43,6 +43,7 @@ with DAG(
     default_args=default_args,
     # dag runs daily but tasks only run on certain days
     schedule_interval="0 5 * * *",
+    tags=tags,
     doc_md=__doc__,
 ) as dag:
     # top_signatures_correlations uploads results to public analysis bucket

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -51,10 +51,13 @@ list_of_connectors ={
   "uk": "toy_tribute"
 }
 
-with DAG('fivetran_intacct_historical',
-         default_args=default_args,
-         doc_md=docs,
-         schedule_interval="0 5 * * *") as dag:
+with DAG(
+    'fivetran_intacct_historical',
+    default_args=default_args,
+    doc_md=docs,
+    schedule_interval="0 5 * * *",
+    tags=tags,
+) as dag:
 
     fivetran_sensors_complete = DummyOperator(
         task_id='intacct-fivetran-sensors-complete',

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -4,6 +4,7 @@ from airflow import DAG
 from operators.backport.fivetran.operator import FivetranOperator
 from operators.backport.fivetran.sensor import FivetranSensor
 from airflow.operators.dummy import DummyOperator
+from utils.tags import Tag
 
 docs = """
 ### fivetran_intacct
@@ -27,6 +28,9 @@ default_args = {
     "retries": 2,
     "retry_delay": timedelta(minutes=30),
 }
+
+tags = [Tag.ImpactTier.tier_1, "repo/telemetry-airflow", ]
+
 list_of_connectors ={
   "moz": "decently_wouldst",
   "germany": "backslid_mumps",


### PR DESCRIPTION
# Step to validate airflow dags as part of CI

## Description
- `bin/test-dag-tags.py` script introduced to query `dag_tag` Airflow table to retrieve a list of all DAGs along with their tags and ensure they are correct.
- `test-environment` check now includes a command for executing a python script validating Airflow DAGs (part of `test-parse` script).
- installing mysql-client on airflow image to be able to query the DB for tag validation
- Added tag assignment to DAGs that were missing them


## Next step
- Integrate this check with `bigquery-etl` repos



resolves #1443 