### PR TITLE
Update burnham DAG dependencies.

### DIFF
--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -371,7 +371,7 @@ DEFAULT_GKE_NAMESPACE = "default"
 BURNHAM_PLATFORM_URL = "https://incoming.telemetry.mozilla.org"
 
 BURNHAM_DISTRIBUTIONS = {
-    "21.0.0": BurnhamDistribution(
+    "22.0.0": BurnhamDistribution(
         burnham_version="22.0.0",
         glean_sdk_version="43.0.2",
         glean_parser_version="4.4.0",
@@ -646,7 +646,7 @@ with DAG(
 
     client5 = burnham_run(
         task_id="client5",
-        burnham_distribution=BURNHAM_DISTRIBUTIONS["21.0.0"],
+        burnham_distribution=BURNHAM_DISTRIBUTIONS["22.0.0"],
         burnham_test_run=burnham_test_run,
         burnham_test_name=DEFAULT_TEST_NAME,
         burnham_missions=["MISSION G: FIVE WARPS, FOUR JUMPS", "MISSION C: ONE JUMP"],
@@ -659,7 +659,7 @@ with DAG(
 
     client6 = burnham_run(
         task_id="client6",
-        burnham_distribution=BURNHAM_DISTRIBUTIONS["21.0.0"],
+        burnham_distribution=BURNHAM_DISTRIBUTIONS["22.0.0"],
         burnham_test_run=burnham_test_run,
         burnham_test_name=DEFAULT_TEST_NAME,
         burnham_missions=[
@@ -679,7 +679,7 @@ with DAG(
 
     client7 = burnham_run(
         task_id="client7",
-        burnham_distribution=BURNHAM_DISTRIBUTIONS["21.0.0"],
+        burnham_distribution=BURNHAM_DISTRIBUTIONS["22.0.0"],
         burnham_test_run=burnham_test_run,
         burnham_test_name=DEFAULT_TEST_NAME,
         burnham_missions=["MISSION A: ONE WARP", "MISSION B: TWO WARPS"],
@@ -692,7 +692,7 @@ with DAG(
 
     client8 = burnham_run(
         task_id="client8",
-        burnham_distribution=BURNHAM_DISTRIBUTIONS["21.0.0"],
+        burnham_distribution=BURNHAM_DISTRIBUTIONS["22.0.0"],
         burnham_test_run=burnham_test_run,
         burnham_test_name="test_disable_upload",
         burnham_missions=[

--- a/dags/burnham.py
+++ b/dags/burnham.py
@@ -372,9 +372,9 @@ BURNHAM_PLATFORM_URL = "https://incoming.telemetry.mozilla.org"
 
 BURNHAM_DISTRIBUTIONS = {
     "21.0.0": BurnhamDistribution(
-        burnham_version="21.0.0",
-        glean_sdk_version="41.1.1",
-        glean_parser_version="4.0.0",
+        burnham_version="22.0.0",
+        glean_sdk_version="43.0.2",
+        glean_parser_version="4.4.0",
     )
 }
 


### PR DESCRIPTION
Updates burnham version to 22.0.0, glean-sdk version to 43.0.2 and glean-parser version to 4.4.0.