### PR TITLE
Bug 1747068 - Revert dml and parallelism for shredder-on-demand

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -75,9 +75,7 @@ on_demand = gke_command(
         # temporarily cover 4 intervals instead of 2, to process backlog
         # per https://bugzilla.mozilla.org/show_bug.cgi?id=1747068
         "--start-date={{macros.ds_add(ds, 27-28*4)}}",
-        # avoid dml to increase parallelism
-        "--no-use-dml",
-        "--parallelism=4",
+        "--parallelism=2",
         "--billing-project=moz-fx-data-shredder",
         "--only=telemetry_stable.main_v4",
     ],


### PR DESCRIPTION
see [Bug 1747068](https://bugzilla.mozilla.org/show_bug.cgi?id=1747068) for explanation