### PR TITLE
 updated the gcr image for glam with latest version

### DIFF
--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -71,7 +71,7 @@ wait_for_fog = ExternalTaskCompletedSensor(
 )
 
 # Move logic from Glam deployment's GKE Cronjob to this dag for better dependency timing
-glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2021.8.1-10'
+glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.02.0-15'
 
 base_docker_args = ['/venv/bin/python', 'manage.py']
 


### PR DESCRIPTION
The recent deployment of glam created a latest version : [gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.02.0-15](http://gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.02.0-15)

Updated the airflow dag with the latest version