### PR TITLE
bug 1696907 - Give probe_scraper.runner a copy of the BMO API key

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -71,6 +71,7 @@ with DAG('probe_scraper',
         '--output-bucket', 'net-mozaws-prod-us-west-2-data-pitmo',
         '--cache-bucket', 'telemetry-airflow-cache',
         '--env', 'prod'
+        "--bugzilla-api-key", "{{ var.value.bugzilla_probe_expiry_bot_api_key }}"
     ]
 
     # Cluster autoscaling works on pod resource requests, instead of usage


### PR DESCRIPTION
The FOG checks that the runner kicks off may need it to file bugs for expiring
metrics.