### PR TITLE
 Remove extracting sample counts to csv in glam dags

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -295,20 +295,6 @@ extract_counts = SubDagOperator(
     dag=dag
 )
 
-extract_sample_counts = SubDagOperator(
-    subdag=extract_user_counts(
-        GLAM_DAG,
-        "extract_sample_counts",
-        default_args,
-        dag.schedule_interval,
-        dataset_id,
-        "sample_counts",
-        "sample-counts"
-    ),
-    task_id="extract_sample_counts",
-    dag=dag
-)
-
 extracts_per_channel = SubDagOperator(
     subdag=extracts_subdag(
         GLAM_DAG,
@@ -406,10 +392,9 @@ clients_histogram_probe_counts >> histogram_percentiles
 
 clients_scalar_aggregates >> glam_user_counts
 glam_user_counts >> extract_counts
-glam_sample_counts >> extract_sample_counts
+
 
 extract_counts >> extracts_per_channel
-extract_sample_counts >> extracts_per_channel
 client_scalar_probe_counts >> extracts_per_channel
 scalar_percentiles >> extracts_per_channel
 histogram_percentiles >> extracts_per_channel

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -159,7 +159,6 @@ for product in final_products:
     extract_user_counts = query(task_name=f"{product}__extract_user_counts_v1")
 
     sample_counts = view(task_name=f"{product}__view_sample_counts_v1")
-    extract_sample_counts = query(task_name=f"{product}__extract_sample_counts_v1")
 
     export = gke_command(
         task_id=f"export_{product}",
@@ -216,4 +215,4 @@ for product in final_products:
     )
     probe_counts >> extract_probe_counts >> export >> pre_import
     clients_scalar_aggregate >> user_counts >> extract_user_counts >> export >> pre_import
-    clients_histogram_aggregate >> sample_counts >> extract_sample_counts >> export >> pre_import
+    clients_histogram_aggregate >> sample_counts >> export >> pre_import

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -142,7 +142,6 @@ for product in final_products:
     extract_user_counts = query(task_name=f"{product}__extract_user_counts_v1")
 
     sample_counts = view(task_name=f"{product}__view_sample_counts_v1")
-    extract_sample_counts = query(task_name=f"{product}__extract_sample_counts_v1")
 
     export = gke_command(
         task_id=f"export_{product}",
@@ -199,4 +198,4 @@ for product in final_products:
     )
     probe_counts >> extract_probe_counts >> export >> pre_import
     clients_scalar_aggregate >> user_counts >> extract_user_counts >> export >> pre_import
-    clients_histogram_aggregate >> sample_counts >> extract_sample_counts >> export >> pre_import
+    clients_histogram_aggregate >> sample_counts >> export >> pre_import


### PR DESCRIPTION
As per the discussion in [this link](https://github.com/mozilla/glam/pull/1853) we no longer need to extract the sample counts separately and can be part of the `client_probes_extract` sql part