### PR TITLE
change the order for the sample counts to be calculated before extract

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -213,6 +213,6 @@ for product in final_products:
         >> histogram_percentiles
         >> probe_counts
     )
-    probe_counts >> extract_probe_counts >> export >> pre_import
+    probe_counts >> sample_counts >> extract_probe_counts >> export >> pre_import
     clients_scalar_aggregate >> user_counts >> extract_user_counts >> export >> pre_import
-    clients_histogram_aggregate >> sample_counts >> export >> pre_import
+    clients_histogram_aggregate >> export >> pre_import

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -196,6 +196,6 @@ for product in final_products:
         >> histogram_percentiles
         >> probe_counts
     )
-    probe_counts >> extract_probe_counts >> export >> pre_import
+    probe_counts >> sample_counts >> extract_probe_counts >> export >> pre_import
     clients_scalar_aggregate >> user_counts >> extract_user_counts >> export >> pre_import
-    clients_histogram_aggregate >> sample_counts >> export >> pre_import
+    clients_histogram_aggregate >> export >> pre_import


### PR DESCRIPTION
Rearrange the tasks for the sample counts to be calculated before the extract probe counts task. 