### PR TITLE
Update operational monitoring DAG

### DIFF
--- a/dags/jetstream.py
+++ b/dags/jetstream.py
@@ -56,7 +56,7 @@ with DAG(
         task_id="jetstream_run_config_changed",
         name="jetstream_run_config_changed",
         image=jetstream_image,
-        email=["ascholtz@mozilla.com", "tdsmith@mozilla.com",],
+        email=["ascholtz@mozilla.com", "kignasiak@mozilla.com",],
         arguments=[
             "--log_to_bigquery",
             "rerun-config-changed",

--- a/dags/operational_monitoring.py
+++ b/dags/operational_monitoring.py
@@ -2,6 +2,7 @@ from airflow import DAG
 from datetime import timedelta, datetime
 from utils.gcp import gke_command
 from utils.tags import Tag
+from operators.gcp_container_operator import GKEPodOperator
 
 from operators.task_sensor import ExternalTaskCompletedSensor
 
@@ -9,23 +10,20 @@ from operators.task_sensor import ExternalTaskCompletedSensor
 docs = """
 ### operational_monitoring
 
-This DAG is currently under development. Failures can be ignored during Airflow triage.
-
-#### Description
 
 This DAG schedules queries for populating datasets used for operational monitoring.
-The queries are generated via [`operational_monitoring` in bigquery-etl](https://github.com/mozilla/bigquery-etl/tree/main/bigquery_etl/operational_monitoring). 
+The queries are generated via [`opmon`](https://github.com/mozilla/opmon). 
 
 #### Owner
 
-msamuel@mozilla.com
+ascholtz@mozilla.com
 """
 
 default_args = {
-    "owner": "msamuel@mozilla.com",
+    "owner": "ascholtz@mozilla.com",
     "email": [
         "telemetry-alerts@mozilla.com",
-        "msamuel@mozilla.com",
+        "ascholtz@mozilla.com",
     ],
     "depends_on_past": False,
     "start_date": datetime(2021, 6, 3),
@@ -41,14 +39,52 @@ tags = [Tag.ImpactTier.tier_3]
 with DAG(
     DAG_NAME,
     default_args=default_args,
-    schedule_interval="0 3 * * *",
+    schedule_interval="0 4 * * *",
     doc_md=docs,
     tags=tags,
 ) as dag:
-    wait_for_main_nightly = ExternalTaskCompletedSensor(
-        task_id="wait_for_main_nightly",
+    # Built from repo https://github.com/mozilla/opmon
+    opmon_image = "gcr.io/moz-fx-data-experiments/opmon:latest"
+
+    opmon_run = GKEPodOperator(
+        task_id="opmon_run",
+        name="opmon_run",
+        image=opmon_image,
+        email=["ascholtz@mozilla.com"],
+        arguments=[
+            "--log_to_bigquery",
+            "run", 
+            "--date={{ ds }}",
+        ],
+        dag=dag,
+    )
+
+    wait_for_clients_daily_export = ExternalTaskCompletedSensor(
+        task_id="wait_for_clients_daily",
         external_dag_id="bqetl_main_summary",
-        external_task_id="telemetry_derived__main_nightly__v1",
+        external_task_id="telemetry_derived__clients_daily__v6",
+        execution_delta=timedelta(hours=2),
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
+        dag=dag,
+    )
+
+    wait_for_main_summary_export = ExternalTaskCompletedSensor(
+        task_id="wait_for_main_summary",
+        external_dag_id="bqetl_main_summary",
+        external_task_id="telemetry_derived__main_summary__v4",
+        execution_delta=timedelta(hours=2),
+        mode="reschedule",
+        pool="DATA_ENG_EXTERNALTASKSENSOR",
+        email_on_retry=False,
+        dag=dag,
+    )
+
+    wait_for_search_clients_daily = ExternalTaskCompletedSensor(
+        task_id="wait_for_search_clients_daily",
+        external_dag_id="bqetl_search",
+        external_task_id="search_derived__search_clients_daily__v8",
         execution_delta=timedelta(hours=1),
         mode="reschedule",
         pool="DATA_ENG_EXTERNALTASKSENSOR",
@@ -56,16 +92,10 @@ with DAG(
         dag=dag,
     )
 
-    operational_monitoring = gke_command(
-        task_id="run_operational_monitoring",
-        command=[
-            "./script/bqetl",
-            "opmon",
-            "run",
-            "--submission-date={{ ds }}",
-        ],
-        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
-        dag=dag,
+    opmon_run.set_upstream(
+        [
+            wait_for_clients_daily_export,
+            wait_for_main_summary_export,
+            wait_for_search_clients_daily,
+        ]
     )
-
-    wait_for_main_nightly >> operational_monitoring


### PR DESCRIPTION
This updates the DAG to use the new opmon container instead (https://github.com/mozilla/opmon)

Once approved, but before merging we'll need to backfill the existing projects.