### PR TITLE
[Bug 1765180] Timeout for intacct historical wait tasks

### DIFF
--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -75,7 +75,8 @@ with DAG(
                 task_id='intacct-sensor-{}'.format(location),
                 fivetran_conn_id='fivetran',
                 connector_id='{}'.format(connector_id),
-                poke_interval=5
+                poke_interval=5,
+                timeout=3*60*60,  # Timeout of 3 hours
         )
 
         fivetran_sync_start >> fivetran_sync_wait >> fivetran_sensors_complete


### PR DESCRIPTION
It looks like sometimes the wait tasks lose connection to the Fivetran API, we should shut them down after a while