### PR TITLE
Start Intacct Fivetran sensors before Fivetran syncs start (bug 1765180)

### DIFF
--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -67,18 +67,18 @@ with DAG(
     for location, connector_id in list_of_connectors.items():
         with TaskGroup(f'intacct-{location}', prefix_group_id=False):
             fivetran_sync_start = FivetranOperator(
-                task_id='intacct-task-{}'.format(location),
+                task_id=f'intacct-task-{location}',
                 fivetran_conn_id='fivetran',
-                connector_id='{}'.format(connector_id)
+                connector_id=connector_id,
             )
 
             # It's best if the sensor starts before the Fivetran sync is triggered to avoid any
             # chance of it missing the Fivetran sync happening, so we give it a higher priority and
             # don't set it as downstream of the sync start operator.
             fivetran_sync_wait = FivetranSensor(
-                task_id='intacct-sensor-{}'.format(location),
+                task_id=f'intacct-sensor-{location}',
                 fivetran_conn_id='fivetran',
-                connector_id='{}'.format(connector_id),
+                connector_id=connector_id,
                 poke_interval=5,
                 timeout=3*60*60,  # Timeout of 3 hours
                 priority_weight=fivetran_sync_start.priority_weight + 1,

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -83,6 +83,7 @@ with DAG(
             connector_id=connector_id,
             poke_interval=5,
             execution_timeout=timedelta(hours=3),
+            retries=0,
             priority_weight=fivetran_sync_start.priority_weight + 1,
         )
         fivetran_sync >> fivetran_sync_wait >> fivetran_sensors_complete

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -80,7 +80,7 @@ with DAG(
                 fivetran_conn_id='fivetran',
                 connector_id=connector_id,
                 poke_interval=5,
-                timeout=3*60*60,  # Timeout of 3 hours
+                execution_timeout=timedelta(hours=3),
                 priority_weight=fivetran_sync_start.priority_weight + 1,
             )
 

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
-from airflow.utils.task_group import TaskGroup
 from operators.backport.fivetran.operator import FivetranOperator
 from operators.backport.fivetran.sensor import FivetranSensor
 from utils.tags import Tag
@@ -65,23 +64,25 @@ with DAG(
     )
 
     for location, connector_id in list_of_connectors.items():
-        with TaskGroup(f'intacct-{location}', prefix_group_id=False):
-            fivetran_sync_start = FivetranOperator(
-                task_id=f'intacct-task-{location}',
-                fivetran_conn_id='fivetran',
-                connector_id=connector_id,
-            )
 
-            # It's best if the sensor starts before the Fivetran sync is triggered to avoid any
-            # chance of it missing the Fivetran sync happening, so we give it a higher priority and
-            # don't set it as downstream of the sync start operator.
-            fivetran_sync_wait = FivetranSensor(
-                task_id=f'intacct-sensor-{location}',
-                fivetran_conn_id='fivetran',
-                connector_id=connector_id,
-                poke_interval=5,
-                execution_timeout=timedelta(hours=3),
-                priority_weight=fivetran_sync_start.priority_weight + 1,
-            )
+        fivetran_sync = DummyOperator(task_id=f'intacct-{location}')
 
-            fivetran_sync_wait >> fivetran_sensors_complete
+        fivetran_sync_start = FivetranOperator(
+            task_id=f'intacct-task-{location}',
+            fivetran_conn_id='fivetran',
+            connector_id=connector_id,
+        )
+        fivetran_sync >> fivetran_sync_start
+
+        # It's best if the sensor starts before the Fivetran sync is triggered to avoid any
+        # chance of it missing the Fivetran sync happening, so we give it a higher priority and
+        # don't set it as downstream of the sync start operator.
+        fivetran_sync_wait = FivetranSensor(
+            task_id=f'intacct-sensor-{location}',
+            fivetran_conn_id='fivetran',
+            connector_id=connector_id,
+            poke_interval=5,
+            execution_timeout=timedelta(hours=3),
+            priority_weight=fivetran_sync_start.priority_weight + 1,
+        )
+        fivetran_sync >> fivetran_sync_wait >> fivetran_sensors_complete

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
+from airflow.operators.dummy import DummyOperator
 from airflow.utils.task_group import TaskGroup
 from operators.backport.fivetran.operator import FivetranOperator
 from operators.backport.fivetran.sensor import FivetranSensor
-from airflow.operators.dummy import DummyOperator
 from utils.tags import Tag
 
 docs = """


### PR DESCRIPTION
When investigating [bug 1765180](https://bugzilla.mozilla.org/show_bug.cgi?id=1765180) I discovered a race condition with how `FivetranSensor` was set as downstream of the associated `FivetranOperator`:
> The [Fivetran sensor](https://github.com/mozilla/telemetry-airflow/blob/main/dags/operators/backport/fivetran/sensor.py) appears to work by reading the last connector run timestamp when it starts and then looking for a change in that. However, if the sensor task is delayed for some reason it might start after the Fivetran sync already completed, in which case it will end up waiting for the next sync, which will be the next daily sync triggered by Airflow.
> 
> That appears to have been the case here where the `intacct-sensor-china_vie` task didn't start until 2022-04-19 02:05:34, while the associated `sage_intacct_china_vie` Fivetran connector sync had already completed at 2022-04-19 02:05:27.

This PR attempts to avoid those race conditions by having the sensors start _before_ their associated Fivetran syncs.  Unfortunately there's no straightforward way to do that in Airflow using normal task dependencies, so it removes the dependency between the `FivetranSensor` and `FivetranOperator` tasks, and uses a parent DummyOperator to still group the tasks together.

This also fixes the timeout for `FivetranSensor`s (which run in `poke` mode by default and thus wouldn't respect the `timeout` argument which apparently only applies in `reschedule` mode), and sets the sensors to not retry (otherwise the retried sensors would just wait indefinitely for another sync to happen because the sync doesn't get retried).