### PR TITLE
[DSRE-658] Add publish to pubsub for glam import migration.

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -8,7 +8,8 @@ in bigquery-etl and the
 in telemetry-airflow.
 """
 
-from datetime import datetime, timedelta
+import datetime
+from datetime import timedelta
 
 from airflow import DAG
 from operators.gcp_container_operator import GKENatPodOperator
@@ -31,7 +32,7 @@ tmp_project = "moz-fx-data-shared-prod"  # for temporary tables in analysis data
 default_args = {
     "owner": "msamuel@mozilla.com",
     "depends_on_past": False,
-    "start_date": datetime(2019, 10, 22),
+    "start_date": datetime.datetime(2019, 10, 22),
     "email": [
         "telemetry-alerts@mozilla.com",
         "msamuel@mozilla.com",

--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -2,7 +2,8 @@
 Desktop ETL for importing glean data into GLAM app
 """
 
-from datetime import datetime, timedelta
+import datetime
+from datetime import timedelta
 
 from airflow import DAG
 from operators.gcp_container_operator import GKENatPodOperator
@@ -21,7 +22,7 @@ from utils.tags import Tag
 default_args = {
     "owner": "akommasani@mozilla.com",
     "depends_on_past": False,
-    "start_date": datetime(2019, 10, 22),
+    "start_date": datetime.datetime(2019, 10, 22),
     "email": [
         "telemetry-alerts@mozilla.com",
         "akommasani@mozilla.com",

--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -9,6 +9,7 @@ from operators.gcp_container_operator import GKENatPodOperator
 from operators.task_sensor import ExternalTaskCompletedSensor
 from airflow.models import Variable
 from airflow.operators.subdag_operator import SubDagOperator
+from airflow.providers.google.cloud.operators.pubsub import PubSubPublishMessageOperator
 
 from glam_subdags.extract import extracts_subdag, extract_user_counts
 from glam_subdags.histograms import histogram_aggregates_subdag
@@ -116,7 +117,23 @@ glam_import_glean_counts = GKENatPodOperator(
     env_vars = env_vars,
     dag=dag)
 
+m1 = {'data': b'Pubsub message from Airflow',
+      'attributes': {'date': datetime.date.today().strftime('%Y%m%d'),
+                     'dag': 'glam_glean_imports.py',
+      }
+}
+
+publish_to_pubsub = PubSubPublishMessageOperator(
+    task_id="publish_to_pubsub",
+    project_id="moz-fx-data-airflow-prod-88e0",
+    topic="airflow-glam-triggers",
+    gcp_conn_id="google_cloud_airflow_pubsub",
+    messages=[m1],
+    dag=dag)
+
 [wait_for_fenix, wait_for_fog] >> glam_import_glean_aggs_beta
 [wait_for_fenix, wait_for_fog] >> glam_import_glean_aggs_nightly
 [wait_for_fenix, wait_for_fog] >> glam_import_glean_aggs_release
 [wait_for_fenix, wait_for_fog] >> glam_import_glean_counts
+
+[wait_for_fenix, wait_for_fog] >> publish_to_pubsub


### PR DESCRIPTION
 Next step is to modify the import job container to subscribe to the topic and verify msgs prior to importing.

This should be done in dev/stage first with separate subscriptions. Once this is working, we can replace the Airflow GkePodOperators that run the migrate.py <args> with the new GkeCronJob||GkeDeployment in Glam