### PR TITLE
Increase `copy_deduplicate` DAG task retries from 1 to 2

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -47,8 +47,8 @@ default_args = {
     "email_on_failure": True,
     "email_on_retry": True,
     "depends_on_past": False,
-    # If a task fails, retry it once after waiting at least 5 minutes
-    "retries": 1,
+    # If a task fails, retry it twice after waiting at least 5 minutes
+    "retries": 2,
     "retry_delay": datetime.timedelta(minutes=5),
 }
 


### PR DESCRIPTION
To better tolerate transient GCP issues, like how the `copy_deduplicate_main_ping` task failed twice and stopped on [2022-04-30](https://workflow.telemetry.mozilla.org/log?dag_id=copy_deduplicate&task_id=copy_deduplicate_main_ping&execution_date=2022-04-29T01%3A00%3A00%2B00%3A00).