### PR TITLE
Changed timeout for Acoustic report generation from 1 to 2 hours

### DIFF
--- a/dags/fivetran_acoustic.py
+++ b/dags/fivetran_acoustic.py
@@ -184,7 +184,7 @@ for report_type, _config in REPORTS_CONFIG.items():
             task_id="generate_acoustic_report",
             python_callable=_generate_acoustic_report,
             op_args=[ACOUSTIC_CONNECTION_ID, report_type, _config],
-            execution_timeout=timedelta(hours=1),
+            execution_timeout=timedelta(hours=2),
         )
 
         sync_trigger = FivetranOperator(


### PR DESCRIPTION
# Changed timeout for Acoustic report generation from 1 to 2 hours

It seems like sometimes waiting for the report to be generated can take a while, 2 hours should be enough hence the change.