### PR TITLE
Bug 1774028 - Make repeated subdags in GLAM ETL explicitly sequential

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -249,12 +249,6 @@ client_scalar_probe_counts = gke_command(
     dag=dag,
 )
 
-# SubdagOperator uses a SequentialExecutor by default
-# so its tasks will run sequentially.
-# Note: In 2.0, SubDagOperator is changed to use airflow scheduler instead of
-# backfill to schedule tasks in the subdag. User no longer need to specify
-# the executor in SubDagOperator. (We don't but the assumption that Sequential
-# Executor is used is now wrong)
 clients_histogram_bucket_counts = SubDagOperator(
     subdag=repeated_subdag(
         GLAM_DAG,

--- a/dags/glam_subdags/general.py
+++ b/dags/glam_subdags/general.py
@@ -29,7 +29,6 @@ def repeated_subdag(
         f"{parent_dag_name}.{child_dag_name}",
         default_args=default_args,
         schedule_interval=schedule_interval,
-        concurrency=1,
     )
 
     # This task runs first and replaces the relevant partition, followed
@@ -53,6 +52,8 @@ def repeated_subdag(
         dag=dag,
     )
 
+    upstream_task = task_0
+
     for partition in range(1, num_partitions):
         min_param = partition * PARTITION_SIZE
         max_param = min_param + PARTITION_SIZE - 1
@@ -68,6 +69,7 @@ def repeated_subdag(
             arguments=("--append_table", "--noreplace",),
             dag=dag,
         )
-        task_0 >> task
+        upstream_task >> task
+        upstream_task = task
 
     return dag

--- a/dags/glam_subdags/histograms.py
+++ b/dags/glam_subdags/histograms.py
@@ -17,7 +17,6 @@ def histogram_aggregates_subdag(
         GLAM_HISTOGRAM_AGGREGATES_SUBDAG,
         default_args=default_args,
         schedule_interval=schedule_interval,
-        concurrency=1,
     )
 
     clients_histogram_aggregates_new = bigquery_etl_query(


### PR DESCRIPTION
This is an attempt to fix subtasks that became stuck in Airflow. Tasks in these subdags need to run sequentially because they write to a single partition. Currently this is achieved by setting `concurrency=1` on a SubDAG level. This change makes tasks explicitly sequential and removes the concurrency setting.