### PR TITLE
Bug 1774415: upgrade instance type for crash_symbolication dag

### DIFF
--- a/dags/crash_symbolication.py
+++ b/dags/crash_symbolication.py
@@ -132,7 +132,7 @@ with DAG(
             ],
             idle_delete_ttl=14400,
             num_workers=2,
-            worker_machine_type="n1-standard-4",
+            worker_machine_type="n1-standard-8",
             gcp_conn_id=params.conn_id,
             service_account=params.client_email,
             storage_bucket=params.storage_bucket,


### PR DESCRIPTION
The crash_symbolication.top_signatures_correlations task is running out
of memory. This upgrades the instance type to make more available.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1774415