### PR TITLE
Bump taar image version

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -28,7 +28,7 @@ TAAR_ETL_STORAGE_BUCKET = Variable.get("taar_etl_storage_bucket")
 TAAR_ETL_MODEL_STORAGE_BUCKET = Variable.get("taar_etl_model_storage_bucket")
 
 # This uses a circleci built docker image from github.com/mozilla/taar_gcp_etl
-TAAR_ETL_CONTAINER_IMAGE = "gcr.io/moz-fx-data-airflow-prod-88e0/taar_gcp_etl:0.6.1"
+TAAR_ETL_CONTAINER_IMAGE = "gcr.io/moz-fx-data-airflow-prod-88e0/taar_gcp_etl:0.6.5"
 
 
 # Dataproc connection to GCP

--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -27,7 +27,7 @@ TAAR_DATAFLOW_SERVICE_ACCOUNT = Variable.get("taar_dataflow_service_account_emai
 
 # This uses a circleci built docker image from github.com/mozilla/taar_gcp_etl
 TAAR_ETL_CONTAINER_IMAGE = (
-    "gcr.io/moz-fx-data-airflow-prod-88e0/taar_gcp_etl:0.6.4"
+    "gcr.io/moz-fx-data-airflow-prod-88e0/taar_gcp_etl:0.6.5"
 )
 DELETE_DAYS = 29
 


### PR DESCRIPTION
It updates the usage of addons API `https://addons.mozilla.org/api` from v3 to v4.