### PR TITLE
Fix destination_table_no_partition when no destination table is set

### DIFF
--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -221,7 +221,7 @@ def bigquery_etl_query(
     kwargs["name"] = kwargs.get("name", kwargs["task_id"].replace("_", "-"))
     if not project_id:
         project_id = "moz-fx-data-shared-prod"
-    destination_table_no_partition = destination_table.split("$")[0]
+    destination_table_no_partition = destination_table.split("$")[0] if destination_table is not None else None
     sql_file_path = sql_file_path or "sql/{}/{}/{}/query.sql".format(project_id, dataset_id, destination_table_no_partition)
     if destination_table is not None and date_partition_parameter is not None:
         destination_table = destination_table + "${{ds_nodash}}"


### PR DESCRIPTION
Currently some DAGs are failing to import with
```
Broken DAG: [/app/pvmount/telemetry-airflow/dags/bigquery-etl-dags/bqetl_google_analytics_derived.py] Traceback (most recent call last):
  File "/app/pvmount/telemetry-airflow/dags/bigquery-etl-dags/bqetl_google_analytics_derived.py", line 72, in <module>
    sql_file_path="sql/moz-fx-data-marketing-prod/ga_derived/blogs_empty_check_v1/query.sql",
  File "/app/pvmount/telemetry-airflow/dags/utils/gcp.py", line 224, in bigquery_etl_query
    destination_table_no_partition = destination_table.split("$")[0]
AttributeError: 'NoneType' object has no attribute 'split'
```