### PR TITLE
Fix failing parquet export

### DIFF
--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -116,7 +116,7 @@ def export_to_parquet(
             task_id="run_dataproc_pyspark",
             cluster_name=cluster_name,
             dataproc_jars=[
-                "gs://spark-lib/bigquery/spark-bigquery-latest.jar"
+                "gs://spark-lib/bigquery/spark-2.4-bigquery-latest.jar"
             ],
             dataproc_properties={
                 "spark.jars.packages": "org.apache.spark:spark-avro_2.11:2.4.4",


### PR DESCRIPTION
as of 2022-07-18T18:17:56Z `gs://spark-lib/bigquery/spark-bigquery-latest.jar` contains a jar for spark 3.1, but the parquet export job uses spark 2.4