### PR TITLE
[DSRE-882] Create dev GLAM ETL Pipeline via WTMO

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -171,15 +171,19 @@ init_variables() {
     airflow variables set "glean_dictionary_netlify_build_webhook_id" "status/200"
     airflow variables set "lookml_generator_release_str" "v0.0.0"
 
-    airflow variables set "glam_secret__database_url" "glam_secret__database_url"
-    airflow variables set "glam_secret__django_secret_key" "glam_secret__django_secret_key"
-
     airflow variables set "fivetran_acoustic_raw_recipient_export_connector_id" "dummy_connector_id"
 
     airflow variables set "fivetran_acoustic_contact_export_connector_id" "dummy_connector_id"
     airflow variables set "fivetran_acoustic_contact_export_list_id" "00000"
 
     airflow variables set "slack_secret_token" "slack_secret_token"
+
+    airflow variables set "Dev_glam_secret__database_url" "Dev_glam_secret__database_url"
+    airflow variables set "Prod_glam_secret__database_url" "Prod_glam_secret__database_url"
+    airflow variables set "Dev_glam_secret__django_secret_key" "Dev_glam_secret__django_secret_key"
+    airflow variables set "Prod_glam_secret__django_secret_key" "Prod_glam_secret__django_secret_key"
+    airflow variables set "Dev_glam_project" "Dev_glam_project"
+    airflow variables set "Prod_glam_project" "Prod_glam_project"
 }
 
 [ $# -lt 1 ] && usage

--- a/dags/glam.py
+++ b/dags/glam.py
@@ -14,7 +14,9 @@ from airflow import DAG
 from operators.gcp_container_operator import GKENatPodOperator
 from airflow.models import Variable
 from airflow.operators.subdag_operator import SubDagOperator
+from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.sensors.external_task import ExternalTaskSensor
+from airflow.utils.task_group import TaskGroup
 
 from glam_subdags.extract import extracts_subdag, extract_user_counts
 from glam_subdags.histograms import histogram_aggregates_subdag
@@ -288,71 +290,27 @@ extract_counts = SubDagOperator(
     dag=dag
 )
 
-extracts_per_channel = SubDagOperator(
-    subdag=extracts_subdag(
-        GLAM_DAG,
-        "extracts",
-        default_args,
-        dag.schedule_interval,
-        dataset_id
-    ),
-    task_id="extracts",
-    dag=dag,
-)
+with dag as dag:
+    extracts_per_channel = SubDagOperator(
+        subdag=extracts_subdag(
+            GLAM_DAG,
+            "extracts",
+            default_args,
+            dag.schedule_interval,
+            dataset_id
+        ),
+        task_id="extracts",
+    )
 
-# Move logic from Glam deployment's GKE Cronjob to this dag for better dependency timing
-glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.03.0-17'
+    with TaskGroup('glam_external') as glam_external:
+        ExternalTaskMarker(
+            task_id="glam_glean_imports__wait_for_glam",
+            external_dag_id="glam_glean_imports",
+            external_task_id="wait_for_glam",
+            execution_date="{{ execution_date.replace(hour=5, minute=0).isoformat() }}",
+        )
 
-base_docker_args = ['/venv/bin/python', 'manage.py']
-
-env_vars = dict(
-    DATABASE_URL = Variable.get("glam_secret__database_url"),
-    DJANGO_SECRET_KEY = Variable.get("glam_secret__django_secret_key"),
-    DJANGO_CONFIGURATION = "Prod",
-    DJANGO_DEBUG = "False",
-    DJANGO_SETTINGS_MODULE = "glam.settings",
-    GOOGLE_CLOUD_PROJECT = "moz-fx-data-glam-prod-fca7"
-)
-
-glam_import_desktop_aggs_beta = GKENatPodOperator(
-    task_id = 'glam_import_desktop_aggs_beta',
-    name = 'glam_import_desktop_aggs_beta',
-    image = glam_import_image,
-    arguments = base_docker_args + ['import_desktop_aggs', 'beta'],
-    env_vars = env_vars,
-    dag=dag)
-
-glam_import_desktop_aggs_nightly = GKENatPodOperator(
-    task_id = 'glam_import_desktop_aggs_nightly',
-    name = 'glam_import_desktop_aggs_nightly',
-    image = glam_import_image,
-    arguments = base_docker_args + ['import_desktop_aggs', 'nightly'],
-    env_vars = env_vars,
-    dag=dag)
-
-glam_import_desktop_aggs_release = GKENatPodOperator(
-    task_id = 'glam_import_desktop_aggs_release',
-    name = 'glam_import_desktop_aggs_release',
-    image = glam_import_image,
-    arguments = base_docker_args + ['import_desktop_aggs', 'release'],
-    env_vars = env_vars,
-    dag=dag)
-
-glam_import_user_counts = GKENatPodOperator(
-    task_id = 'glam_import_user_counts',
-    name = 'glam_import_user_counts',
-    image = glam_import_image,
-    arguments = base_docker_args + ['import_user_counts'],
-    env_vars = env_vars,
-    dag=dag)
-
-glam_import_probes = GKENatPodOperator(
-    task_id = 'glam_import_probes',
-    name = 'glam_import_probes',
-    image = glam_import_image,
-    arguments = base_docker_args + ['import_probes'],
-    env_vars = env_vars,
-    dag=dag)
+        extracts_per_channel >> glam_external
 
 
 wait_for_main_ping >> latest_versions
@@ -392,9 +350,3 @@ client_scalar_probe_counts >> extracts_per_channel
 scalar_percentiles >> extracts_per_channel
 histogram_percentiles >> extracts_per_channel
 glam_sample_counts >> extracts_per_channel
-
-extracts_per_channel >> glam_import_desktop_aggs_beta
-extracts_per_channel >> glam_import_desktop_aggs_nightly
-extracts_per_channel >> glam_import_user_counts
-extracts_per_channel >> glam_import_probes
-glam_import_desktop_aggs_release

--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -157,16 +157,12 @@ for env in ['Dev','Prod']:
         glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.03.0-17'
 
     env_vars = dict(
-        # Todo - make secrets in wtmo
         DATABASE_URL = Variable.get(env + "_glam_secret__database_url"),
         DJANGO_SECRET_KEY = Variable.get(env + "_glam_secret__django_secret_key"),
-        # Todo - What does this do?
         DJANGO_CONFIGURATION = env,
         DJANGO_DEBUG = "False",
         DJANGO_SETTINGS_MODULE= "glam.settings",
-        # Todo add the project ids to WTMO UI
         GOOGLE_CLOUD_PROJECT = Variable.get(env + "_glam_project"),
-        #GOOGLE_CLOUD_PROJECT = "moz-fx-data-glam-prod-fca7"
     )
 
     with dag as dag:


### PR DESCRIPTION
Do not commit until:
- [x] whitelisting NAT IP to dev cluster
- [x] add secrets to sops/wtmo

- Moves all of the glam/glean import jobs into one file, for easier updating.
- Uses TaskGroups to group Dev and Prod tasks into separate groups (viewable from Graph view)

Before:
![Screen Shot 2022-07-26 at 5 26 00 PM](https://user-images.githubusercontent.com/12399756/181134616-4c1b4e50-96fe-4c6e-a426-6f6849cd50c6.png)
After:
![Screen Shot 2022-07-26 at 5 26 57 PM](https://user-images.githubusercontent.com/12399756/181134695-5ff2a99d-69fd-40b7-b9e3-b48553f66173.png)

Note that the graph view isn't perfect, and doesn't display the fan in nature of the glean imports until you click on a taskgroup to expand it:
 
![Screen Shot 2022-07-26 at 5 28 07 PM](https://user-images.githubusercontent.com/12399756/181134791-b5ef75a8-ca60-46de-be1a-2b989201fd9a.png)


- Allows devs to change the image version for Dev only, so they can test changes to ETL without hitting prod
- This was set up in a way that adding a Stage env taskgroup is trivial (for the dag code at least, but requires infra changes another db, ip whitelist, sops secrets, etc.)

Open to any suggestions on how to do this differently