### PR TITLE
Change location from which to run data validation job

### DIFF
--- a/dags/search_term_data_validation.py
+++ b/dags/search_term_data_validation.py
@@ -35,7 +35,7 @@ with DAG("search_term_data_validation", default_args=default_args, schedule_inte
     search_term_data_validation = gke_command(
         task_id="search_term_data_validation",
         command=[
-            "python", "data_validation_job.py",
+            "python", "src/data_validation_job.py",
             "--data_validation_origin",
             "moz-fx-data-shared-prod.search_terms.sanitization_job_data_validation_metrics",
             "--data_validation_reporting_destination",


### PR DESCRIPTION
Here is my thinking:

- No matter where we cd into, for some reason CI seems to want the root directory to be usr/app
- That's really fine, because pytest will run properly from there anyway
- I don't want to flatten the file structure artificially to get our scheduling tools to work properly
- So I am now running the job in airflow from outside the src location