### PR TITLE
Shift taar addons ranking date 1 day back

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -240,7 +240,7 @@ with DAG("taar_daily", default_args=default_args, schedule_interval="0 4 * * *",
         # This uses a circleci built docker image from github.com/mozilla/taar_gcp_etl
         image=TAAR_ETL_CONTAINER_IMAGE,
         arguments=["-m", "taar_etl.taar_lite_guid_ranking",
-                "--date", "{{ ds }}",
+                "--date", "{{ macros.ds_add(ds, -1) }}",
                 "--prefix", "taar/lite",
                 "--bucket", TAAR_ETL_MODEL_STORAGE_BUCKET],
     )


### PR DESCRIPTION
It turned out the TAAR lite API has been returning an empty recommendations list for a while. The issue is that [this job](https://github.com/mozilla/taar_gcp_etl/blob/master/taar_etl/taar_lite_guid_ranking.py) writes an empty file to GCS even though it works on testing. I think it's because there is no data in `telemetry.addons` when it's being executed. A shift 1 day back should help. It is not critical to have a number of installations super precise.