### PR TITLE
[DSRE-1056] Fix airflow dags after GKE migration

### DIFF
--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -21,6 +21,7 @@ import json
 import re
 
 GCP_PROJECT_ID = "moz-fx-data-airflow-gke-prod"
+DATAPROC_PROJECT_ID = "airflow-dataproc"
 
 def export_to_parquet(
     table,
@@ -75,7 +76,7 @@ def export_to_parquet(
     cluster_name += "-export-{{ ds_nodash }}"
 
     dag_prefix = parent_dag_name + "." if parent_dag_name else ""
-    project_id = GCP_PROJECT_ID
+    project_id = DATAPROC_PROJECT_ID
 
     if destination_table is None:
         destination_table = unqualified_table


### PR DESCRIPTION
This PR fixes the dags:
1. parquet_export - by fixing the project_id references in dags/utils/gcp.py for dataprocOperators to change from derived-datasets to airflow-dataproc
2. socorro_import - by changing usage of BigQueryDeleteTableOperator to GKEPodOperator so that we can piggyback on existing permissions. Previously the airflow-access@derived-datasets SA had broader shared-prod permissions, so that workloads happening on the airflow worker pod could do things like BigQueryDeleteTableOperator to delete a socorro_crash partition. Now that we've switched to GKEPodOperator and the newer GKE airflow-gke cluster, the worker pod will use the airflow-gke-access SA to init a Pod on the airflow-gke cluster, and that Pod's container will have access defined by the default-workloads SA (which can perform shared-prod ops)
