### PR TITLE
[DSRE-1056] Explicitly set service account for dataproc jobs running via export_to_parquet

### DIFF
--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -17,6 +17,8 @@ from airflow.providers.google.cloud.transfers.bigquery_to_gcs import BigQueryToG
 
 from airflow.providers.google.cloud.operators.gcs import GCSDeleteObjectsOperator
 
+from utils.dataproc import get_dataproc_parameters
+
 import json
 import re
 
@@ -89,6 +91,8 @@ def export_to_parquet(
         avro_prefix += "partition_id=" + partition_id + "/"
     avro_path = "gs://" + gcs_output_bucket + "/" + avro_prefix + "*.avro"
 
+    params = get_dataproc_parameters("google_cloud_airflow_dataproc")
+
     with models.DAG(dag_id=dag_prefix + dag_name, default_args=default_args) as dag:
 
         create_dataproc_cluster = DataprocCreateClusterOperator(
@@ -99,6 +103,7 @@ def export_to_parquet(
             region=region,
             cluster_config=ClusterGenerator(
                 project_id=project_id,
+                service_account=params.client_email,
                 num_workers=num_workers,
                 storage_bucket=dataproc_storage_bucket,
                 init_actions_uris=[


### PR DESCRIPTION
if this fails ill have to test it locally until it doesnt. but lets just quick try pushing this change

After the migration of WTMO jobs from the derived-datasets to airflow-gke/airflow-dataproc projects the parquet export dag's spark portion is failing with:

ERROR: Access Denied: Table moz-fx-data-shared-prod:telemetry_derived.clients_daily_v6$20221012: Permission bigquery.tables.get denied on table moz-fx-data-shared-prod:telemetry_derived.clients_daily_v6$20221012 (or it may not exist).

This is bc the export_to_parquet codepath in dags/utils/gcp.py created spark clusters without overriding the SA so the default compute SA is used and doesnt have read permisisons to shared-prod.telemetry_derived