### PR TITLE
Upgrade backported fivetran connector to v1.1.2

### DIFF
--- a/dags/operators/backport/fivetran/hook.py
+++ b/dags/operators/backport/fivetran/hook.py
@@ -1,4 +1,4 @@
-# Ported from https://github.com/fivetran/airflow-provider-fivetran/blob/main/fivetran_provider/hooks/fivetran.py
+# Ported from fivetran provider v1.1.2 https://github.com/fivetran/airflow-provider-fivetran/blob/be5ab77defbbffe6000202fc5fc37b6e27c07a54/fivetran_provider/hooks/fivetran.py
 
 import json
 from typing import Any, Dict
@@ -29,39 +29,39 @@ class FivetranHook(BaseHook):
     :type retry_delay: float
     """
 
-    conn_name_attr = 'fivetran_conn_id'
-    default_conn_name = 'fivetran_default'
-    conn_type = 'fivetran'
-    hook_name = 'Fivetran'
-    api_user_agent = 'airflow_provider_fivetran/1.0.1'
-    api_protocol = 'https'
-    api_host = 'api.fivetran.com'
-    api_path_connectors = 'v1/connectors/'
+    conn_name_attr = "fivetran_conn_id"
+    default_conn_name = "fivetran_default"
+    conn_type = "fivetran"
+    hook_name = "Fivetran"
+    api_user_agent = "airflow_provider_fivetran/1.1.2"
+    api_protocol = "https"
+    api_host = "api.fivetran.com"
+    api_path_connectors = "v1/connectors/"
 
     @staticmethod
     def get_ui_field_behaviour() -> Dict:
         """Returns custom field behaviour"""
         return {
-            "hidden_fields": ['schema', 'port', 'extra', 'host'],
+            "hidden_fields": ["schema", "port", "extra", "host"],
             "relabeling": {
-                'login': 'Fivetran API Key',
-                'password': 'Fivetran API Secret',
+                "login": "Fivetran API Key",
+                "password": "Fivetran API Secret",
             },
             "placeholders": {
-                'login': 'api key',
-                'password': 'api secret',
+                "login": "api key",
+                "password": "api secret",
             },
         }
 
     def __init__(
         self,
         fivetran_conn_id: str = "fivetran",
-        fivetran_conn = None,
+        fivetran_conn=None,
         timeout_seconds: int = 180,
         retry_limit: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
-        super().__init__(None) # Passing None fixes a runtime problem in Airflow 1
+        super().__init__(None)  # Passing None fixes a runtime problem in Airflow 1
         self.conn_id = fivetran_conn_id
         self.fivetran_conn = fivetran_conn
         self.timeout_seconds = timeout_seconds
@@ -88,9 +88,7 @@ class FivetranHook(BaseHook):
         auth = (self.fivetran_conn.login, self.fivetran_conn.password)
         url = f"{self.api_protocol}://{self.api_host}/{endpoint}"
 
-        headers = {
-            "User-Agent": self.api_user_agent
-        }
+        headers = {"User-Agent": self.api_user_agent}
 
         if method == "GET":
             request_func = requests.get
@@ -110,7 +108,7 @@ class FivetranHook(BaseHook):
                     data=json if method in ("POST", "PATCH") else None,
                     params=json if method in ("GET") else None,
                     auth=auth,
-                    headers=headers
+                    headers=headers,
                 )
                 response.raise_for_status()
                 return response.json()
@@ -159,6 +157,7 @@ class FivetranHook(BaseHook):
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
         :type connector_id: str
+        :return: connector details
         :rtype: Dict
         """
         if connector_id == "":
@@ -166,7 +165,6 @@ class FivetranHook(BaseHook):
         endpoint = self.api_path_connectors + connector_id
         resp = self._do_api_call(("GET", endpoint))
         return resp["data"]
-
 
     def check_connector(self, connector_id):
         """
@@ -195,31 +193,35 @@ class FivetranHook(BaseHook):
         )
         return True
 
-    def set_manual_schedule(self, connector_id):
+    def set_schedule_type(self, connector_id, schedule_type):
         """
-        Set connector to manual sync mode, required to force sync through the API.
-            Syncs will no longer be performed automatically and must be started
-            via the API.
+        Set connector sync mode to switch sync control between API and UI.
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
         :type connector_id: str
+        :param schedule_type: "manual" (schedule controlled via Airlow) or "auto" (schedule controlled via Fivetran)
+        :type schedule_type: str
         """
         endpoint = self.api_path_connectors + connector_id
         return self._do_api_call(
-            ("PATCH", endpoint),
-            json.dumps({"schedule_type": "manual"})
+            ("PATCH", endpoint), json.dumps({"schedule_type": schedule_type})
         )
 
-    def prep_connector(self, connector_id):
+    def prep_connector(self, connector_id, schedule_type):
         """
-        Prepare the connector to run in Airflow by checking that it exists and is a good state, then taking it off of Fivetran's schedule to be managed by Airflow's.
+        Prepare the connector to run in Airflow by checking that it exists and is a good state,
+            then update connector sync schedule type if changed.
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
         :type connector_id: str
+        :param schedule_type: Fivetran connector schedule type
+        :type schedule_type: str
         """
         self.check_connector(connector_id)
-        if self.get_connector(connector_id)['schedule_type'] != 'manual':
-            return self.set_manual_schedule(connector_id)
+        if schedule_type not in {"manual", "auto"}:
+            raise ValueError('schedule_type must be either "manual" or "auto"')
+        if self.get_connector(connector_id)["schedule_type"] != schedule_type:
+            return self.set_schedule_type(connector_id, schedule_type)
         return True
 
     def start_fivetran_sync(self, connector_id):
@@ -227,22 +229,45 @@ class FivetranHook(BaseHook):
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
         :type connector_id: str
+        :return: Timestamp of previously completed sync
+        :rtype: str
         """
-        endpoint = self.api_path_connectors + connector_id + "/force"
-        return self._do_api_call(("POST", endpoint))
+        connector_details = self.get_connector(connector_id)
+        succeeded_at = connector_details["succeeded_at"]
+        failed_at = connector_details["failed_at"]
+        endpoint = self.api_path_connectors + connector_id
+        if self._do_api_call(("GET", endpoint))['data']['paused'] == True:
+            self._do_api_call(("PATCH", endpoint),json.dumps({"paused": False}))
+            if succeeded_at == None and failed_at == None:
+                succeeded_at = str(pendulum.now())
+        self._do_api_call(("POST", endpoint + "/force"))
+        last_sync = (
+            succeeded_at
+            if self._parse_timestamp(succeeded_at) > self._parse_timestamp(failed_at)
+            else failed_at
+        )
+        return last_sync
 
-    def get_last_sync(self, connector_id):
+    def get_last_sync(self, connector_id, xcom=""):
         """
         Get the last time Fivetran connector completed a sync.
             Used with FivetranSensor to monitor sync completion status.
         :param connector_id: Fivetran connector_id, found in connector settings
             page in the Fivetran user interface.
         :type connector_id: str
+        :param xcom: Timestamp as string pull from FivetranOperator via XCOM
+        :type xcom: str
+        :return: Timestamp of last completed sync
+        :rtype: Pendulum.DateTime
         """
-        connector_details = self.get_connector(connector_id)
-        succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
-        failed_at = self._parse_timestamp(connector_details["failed_at"])
-        return succeeded_at if succeeded_at > failed_at else failed_at
+        if xcom:
+            last_sync = self._parse_timestamp(xcom)
+        else:
+            connector_details = self.get_connector(connector_id)
+            succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
+            failed_at = self._parse_timestamp(connector_details["failed_at"])
+            last_sync = succeeded_at if succeeded_at > failed_at else failed_at
+        return last_sync
 
     def get_sync_status(self, connector_id, previous_completed_at):
         """
@@ -259,9 +284,7 @@ class FivetranHook(BaseHook):
         connector_details = self.get_connector(connector_id)
         succeeded_at = self._parse_timestamp(connector_details["succeeded_at"])
         failed_at = self._parse_timestamp(connector_details["failed_at"])
-        current_completed_at = (
-            succeeded_at if succeeded_at > failed_at else failed_at
-        )
+        current_completed_at = succeeded_at if succeeded_at > failed_at else failed_at
 
         # The only way to tell if a sync failed is to check if its latest
         # failed_at value is greater than then last known "sync completed at" value.
@@ -280,8 +303,10 @@ class FivetranHook(BaseHook):
         # Check if sync started by FivetranOperator has finished
         # indicated by new 'succeeded_at' timestamp
         if current_completed_at > previous_completed_at:
-            self.log.info('Connector "{}": succeeded_at: {}'.format(
-                connector_id, succeeded_at.to_iso8601_string())
+            self.log.info(
+                'Connector "{}": succeeded_at: {}'.format(
+                    connector_id, succeeded_at.to_iso8601_string()
+                )
             )
             return True
         else:

--- a/dags/operators/backport/fivetran/operator.py
+++ b/dags/operators/backport/fivetran/operator.py
@@ -1,9 +1,9 @@
-# Ported from https://github.com/fivetran/airflow-provider-fivetran/blob/main/fivetran_provider/operators/fivetran.py
+# Ported from fivetran provider v1.1.2 https://github.com/fivetran/airflow-provider-fivetran/blob/be5ab77defbbffe6000202fc5fc37b6e27c07a54/fivetran_provider/operators/fivetran.py
 
 from airflow.models import BaseOperator, BaseOperatorLink
 from airflow.utils.decorators import apply_defaults
 
-from operators.backport.fivetran.hook import FivetranHook
+from fivetran_provider.hooks.fivetran import FivetranHook
 from typing import Optional
 
 
@@ -24,14 +24,12 @@ class RegistryLink(BaseOperatorLink):
 class FivetranOperator(BaseOperator):
     """
     `FivetranOperator` starts a Fivetran sync job.
-
     `FivetranOperator` requires that you specify the `connector_id` of the sync job to
     start. You can find `connector_id` in the Settings page of the connector you
     configured in the `Fivetran dashboard <https://fivetran.com/dashboard/connectors>`_.
     Note that when a Fivetran sync job is controlled via an Operator, it is no longer
     run on the schedule as managed by Fivetran. In other words, it is now scheduled only
-    from Airflow.
-
+    from Airflow. This can be changed with the schedule_type parameter.
     :param fivetran_conn_id: `Conn ID` of the Connection to be used to configure
         the hook.
     :type fivetran_conn_id: Optional[str]
@@ -42,6 +40,8 @@ class FivetranOperator(BaseOperator):
     :param connector_id: ID of the Fivetran connector to sync, found on the
         Connector settings page.
     :type connector_id: str
+    :param schedule_type: schedule type. Default is "manual" which takes the connector off Fivetran schedule. Set to "auto" to keep connector on Fivetran schedule.
+    :type schedule_type: str
     """
 
     operator_extra_links = (RegistryLink(),)
@@ -59,6 +59,7 @@ class FivetranOperator(BaseOperator):
         fivetran_retry_limit: int = 3,
         fivetran_retry_delay: int = 1,
         poll_frequency: int = 15,
+        schedule_type: str = "manual",
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -67,6 +68,7 @@ class FivetranOperator(BaseOperator):
         self.fivetran_retry_delay = fivetran_retry_delay
         self.connector_id = connector_id
         self.poll_frequency = poll_frequency
+        self.schedule_type = schedule_type
 
     def _get_hook(self) -> FivetranHook:
         return FivetranHook(
@@ -77,5 +79,5 @@ class FivetranOperator(BaseOperator):
 
     def execute(self, context):
         hook = self._get_hook()
-        hook.prep_connector(self.connector_id)
+        hook.prep_connector(self.connector_id, self.schedule_type)
         return hook.start_fivetran_sync(self.connector_id)

--- a/dags/operators/backport/fivetran/sensor.py
+++ b/dags/operators/backport/fivetran/sensor.py
@@ -1,16 +1,15 @@
-# Ported from https://github.com/fivetran/airflow-provider-fivetran/blob/main/fivetran_provider/sensors/fivetran.py
+# Ported from fivetran provider v1.1.2 https://github.com/fivetran/airflow-provider-fivetran/blob/be5ab77defbbffe6000202fc5fc37b6e27c07a54/fivetran_provider/sensors/fivetran.py
 
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 
-from operators.backport.fivetran.hook import FivetranHook
+from fivetran_provider.hooks.fivetran import FivetranHook
 from typing import Any
 
 
 class FivetranSensor(BaseSensorOperator):
     """
     `FivetranSensor` monitors a Fivetran sync job for completion.
-
     Monitoring with `FivetranSensor` allows you to trigger downstream processes only
     when the Fivetran sync jobs have completed, ensuring data consistency. You can
     use multiple instances of `FivetranSensor` to monitor multiple Fivetran
@@ -21,8 +20,6 @@ class FivetranSensor(BaseSensorOperator):
     requires that you specify the `connector_id` of the sync job to start. You can
     find `connector_id` in the Settings page of the connector you configured in the
     `Fivetran dashboard <https://fivetran.com/dashboard/connectors>`_.
-
-
     :param fivetran_conn_id: `Conn ID` of the Connection to be used to configure
         the hook.
     :type fivetran_conn_id: str
@@ -36,10 +33,13 @@ class FivetranSensor(BaseSensorOperator):
     :type fivetran_retry_limit: Optional[int]
     :param fivetran_retry_delay: Time to wait before retrying API request
     :type fivetran_retry_delay: int
+    :param xcom: If used, FivetranSensor receives timestamp of previously
+        completed sync from FivetranOperator via XCOM
+    :type xcom: str
     """
 
     # Define which fields get jinjaified
-    template_fields = ["connector_id"]
+    template_fields = ["connector_id", "xcom"]
 
     @apply_defaults
     def __init__(
@@ -49,6 +49,7 @@ class FivetranSensor(BaseSensorOperator):
         poke_interval: int = 60,
         fivetran_retry_limit: int = 3,
         fivetran_retry_delay: int = 1,
+        xcom: str = "",
         **kwargs: Any
     ) -> None:
         super().__init__(**kwargs)
@@ -59,6 +60,7 @@ class FivetranSensor(BaseSensorOperator):
         self.fivetran_retry_limit = fivetran_retry_limit
         self.fivetran_retry_delay = fivetran_retry_delay
         self.hook = None
+        self.xcom = xcom
 
     def _get_hook(self) -> FivetranHook:
         if self.hook is None:
@@ -72,5 +74,7 @@ class FivetranSensor(BaseSensorOperator):
     def poke(self, context):
         hook = self._get_hook()
         if self.previous_completed_at is None:
-            self.previous_completed_at = hook.get_last_sync(self.connector_id)
+            self.previous_completed_at = hook.get_last_sync(
+                self.connector_id, self.xcom
+            )
         return hook.get_sync_status(self.connector_id, self.previous_completed_at)


### PR DESCRIPTION
This replaces the backported fivetran connector with the newer version 1.1.2, to resolve issues that occur when FivetranOperator syncs finish quickly.

See #1530 -- this is the same as that except that I pulled over the operator and sensor code as well and added a comment to point to the exact commit.

For testing, I've run things locally and confirm that dags still parse; is there anything else I ought to do?