### PR TITLE
[DSRE-1101] Fix backfill to not pickle so that newly added dag tasks can run via backfill

### DIFF
--- a/airflow.cfg
+++ b/airflow.cfg
@@ -2,7 +2,7 @@
 default_timezone = utc
 
 hide_sensitive_var_conn_fields = True
-sensitive_var_conn_names = 'cred,CRED,secret,SECRET,pass,PASS,password,PASSWORD,private,PRIVATE,key,KEY,cert,CERT,token,TOKEN,AKIA'
+sensitive_var_conn_names = 'cred,CRED,secret,SECRET,pass,PASS,password,Password,PASSWORD,private,PRIVATE,key,KEY,cert,CERT,token,TOKEN,AKIA'
 
 # This setting would not have any effect in an existing deployment where the default_pool already exists.
 default_pool_task_slot_count = 50

--- a/plugins/backfill/main.py
+++ b/plugins/backfill/main.py
@@ -96,6 +96,7 @@ class Backfill(get_baseview()):
         elif clear == 'false':
             cmd.append('dags')
             cmd.append('backfill')
+            cmd.append('--donot-pickle')
             if dry_run == 'true':
                 cmd.append('--dry-run')
 


### PR DESCRIPTION
The backfill plugin was working for re-running failed tasks. But there is a use case where a dev will add new tasks to an existing dag, e.g. for creating a new table, and then want to use the backfill UI to populate that table for historical data. This is failing because the backfill plugin was only working to re-run failed tasks that had already ran. 

Upon some investigation, the code path that the backfill cli cmd uses pickling (maybe new in v2 or sometime after I had wrote the backfill plugin originally) which was failing in this scenario (new dag task) as opposed to re-running the task manually in the UI which was succeeding (no pickling). So this PR fixes that. I've locally tested that the re-ran task uses code path similar to re-running via UI (non pickle)

Secondly this PR aims to fix outputting of a single secret via console by adding to the regex list of var conn names. 

TODO 
- [x] Test regex filter working to mask out  password for adm_sftp (Looks like the regex config wont mask the secret, will need to fix this in a follow up)
- [ ] Create new release/container
- [ ] Redeploy wtmo