### PR TITLE
bug: corrected data param and passing in ds -1

### DIFF
--- a/dags/data_monitoring.py
+++ b/dags/data_monitoring.py
@@ -57,7 +57,7 @@ with DAG(
                 f"--project_id={project_id}",
                 f"--dataset={dataset}",
                 f"--table={table}"
-                "--date_partition_parameter={{ ds }}"
+                "--date={{ macros.ds_add(ds, -1) }}"
             ],
             env_vars=dict(
                 SLACK_BOT_TOKEN="{{ var.value.dim_slack_secret_token }}"),


### PR DESCRIPTION
# bug: corrected data param and passing in ds -1

- cli param for date is now called `date`
- some tables have two day lag, to compensate for this passing ds - 1 day as the `--date` option value.