### PR TITLE
fix(backfill): fix BackfillParams import issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Git
+.git
+.gitignore
+
+# CI
+.circleci/
+
+# Docker
+docker-compose.yml
+
+# cache
+__pycache__/
+.pytest_cache/
+
+# Airflow stuff
+logs/
+{AIRFLOW_HOME}/
+examples/
+
+# Virtual environment
+.env/
+.venv/
+venv/
+
+# IDE
+.idea
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 *.retry
 *undo-tree~
 *.un~
-venv
+venv/
+.venv/
 
 logs
 unittests.cfg
@@ -21,5 +22,6 @@ airflow-worker.pid
 
 .cache
 
-# VsCode artifacts
-.vscode/*.log
+# IDE
+.idea
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "env/bin/python"
-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,15 @@ MAINTAINER Harold Woo <hwoo@mozilla.com>
 
 # Due to AIRFLOW-6854, Python 3.7 is chosen as the base python version.
 
+ARG AIRFLOW_UID=10001
+ARG AIRFLOW_GID=10001
+ARG PROJECT_DIR="/app"
+
 # add a non-privileged user for installing and running the application
-RUN mkdir /app && \
-    chown 10001:10001 /app && \
-    groupadd --gid 10001 app && \
-    useradd --no-create-home --uid 10001 --gid 10001 --home-dir /app app
+RUN mkdir $PROJECT_DIR && \
+    chown $AIRFLOW_UID:$AIRFLOW_GID $PROJECT_DIR && \
+    groupadd --gid $AIRFLOW_GID app && \
+    useradd --no-create-home --uid $AIRFLOW_UID --gid $AIRFLOW_GID --home-dir $PROJECT_DIR app
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -36,21 +40,22 @@ RUN pip install --upgrade pip
 RUN export SLUGIFY_USES_TEXT_UNIDECODE=yes && pip install --no-cache-dir -r requirements.txt
 
 # Switch back to home directory
-WORKDIR /app
+WORKDIR $PROJECT_DIR
 
-COPY . /app
+COPY . $PROJECT_DIR
 
-RUN chown -R 10001:10001 /app
+RUN chown -R $AIRFLOW_UID:$AIRFLOW_GID $PROJECT_DIR
 
-USER 10001
+USER $AIRFLOW_UID
 
 ENV PYTHONUNBUFFERED=1 \
-    PORT=8000
+    PORT=8000\
+    PYTHONPATH="$PYTHONPATH:$PROJECT_DIR"
     # AWS_ACCESS_KEY_ID= \
     # AWS_SECRET_ACCESS_KEY= \
     # DEPLOY_ENVIRONMENT =
 
-ENV AIRFLOW_HOME=/app \
+ENV AIRFLOW_HOME=$PROJECT_DIR \
     AIRFLOW_EMAIL_BACKEND="airflow.utils.email.send_email_smtp"
     # AIRFLOW_AUTHENTICATE= \
     # AIRFLOW_AUTH_BACKEND= \

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,27 @@
 .PHONY: build clean migrate redis-cli run secret shell stop up
 
+
 help:
 	@echo "Welcome to the Telemetry Airflow\n"
 	@echo "The list of commands for local development:\n"
-	@echo "  build      Builds the docker images for the docker-compose setup"
-	@echo "  clean      Stops and removes all docker containers"
-	@echo "  migrate    Runs the Django database migrations"
-	@echo "  redis-cli  Opens a Redis CLI"
-	@echo "  run        Run a airflow command"
-	@echo "  secret     Create a secret to be used for a config variable"
-	@echo "  shell      Opens a Bash shell"
-	@echo "  up         Runs the whole stack, served under http://localhost:8000/"
-	@echo "  gke        Create a sandbox gke cluster for testing"
-	@echo "  clean-gke  Delete the sandbox gke cluster"
-	@echo "  stop       Stops the docker containers"
+	@echo "  build      	Builds the docker images for the docker-compose setup"
+	@echo "  build-linux	Builds the docker images using the current user ID and group ID"
+	@echo "  clean      	Stops and removes all docker containers"
+	@echo "  migrate    	Runs the Django database migrations"
+	@echo "  redis-cli  	Opens a Redis CLI"
+	@echo "  run        	Run a airflow command"
+	@echo "  secret     	Create a secret to be used for a config variable"
+	@echo "  shell      	Opens a Bash shell"
+	@echo "  up         	Runs the whole stack, served under http://localhost:8000/"
+	@echo "  gke        	Create a sandbox gke cluster for testing"
+	@echo "  clean-gke  	Delete the sandbox gke cluster"
+	@echo "  stop       	Stops the docker containers"
 
 build:
 	docker-compose build
+
+build-linux:
+	docker-compose build --build-arg AIRFLOW_UID="$$(id -u)" --build-arg AIRFLOW_GID="$$(id -g)"
 
 clean:	stop
 	docker-compose rm -f

--- a/README.md
+++ b/README.md
@@ -75,16 +75,32 @@ test this by restarting the orchestrated containers and checking for error messa
 administration UI at `localhost:8000`.
 
 ### Local Deployment
-
-Assuming you're using macOS and Docker for macOS, start the docker service,
+#### macOS
+Assuming you're using Docker for Docker Desktop for macOS, start the docker service,
 click the docker icon in the menu bar, click on preferences and change the
 available memory to 4GB.
 
 To deploy the Airflow container on the docker engine, with its required dependencies, run:
 
 ```bash
+make build
 make up
 ```
+
+#### Linux
+
+Users on Linux distributions will encounter permission issues with `docker-compose`.
+This is because the local application folder is mounted as a volume into the running container.
+The Airflow user and group in the container is set to `10001`.
+
+To work around this, use `build-linux` Make command.
+
+```bash
+make build-linux
+make up
+```
+
+### Usage
 
 You can now connect to your local Airflow web console at
 `http://localhost:8000/`.
@@ -93,18 +109,6 @@ All DAGs are paused by default for local instances and our staging instance of A
 In order to submit a DAG via the UI, you'll need to toggle the DAG from "Off" to "On".
 You'll likely want to toggle the DAG back to "Off" as soon as your desired task starts running.
 
-#### Workaround for permission issues
-
-Users on Linux distributions will encounter permission issues with `docker-compose`.
-This is because the local application folder is mounted as a volume into the running container.
-The Airflow user and group in the container is set to `10001`.
-
-To work around this, replace all instances of `10001` in `Dockerfile.dev` with the host user id.
-
-```bash
-sed -i "s/10001/$(id -u)/g" Dockerfile.dev
-
-```
 
 ### Testing GKE Jobs (including BigQuery-etl changes)
 
@@ -247,13 +251,6 @@ docker-compose exec web airflow list_dags
   - Click the "Clear" button
   - Confirm that you want to clear it
   - The task should be scheduled to run again straight away.
-
-### Triggering backfill tasks using the CLI
-
-- SSH into the ECS container instance
-- List docker containers using `docker ps`
-- Log in to one of the docker containers using `docker exec -it <container_id> bash`. The web server instance is a good choice.
-- Run the desired backfill command, something like `$ airflow backfill main_summary -s 2018-05-20 -e 2018-05-26`
 
 ### CircleCI
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from airflow.plugins_manager import AirflowPlugin
 # Inbuilt Imports
 from flask import Blueprint
-from airflow.plugins_manager import AirflowPlugin
-from airflow import configuration
 
 # Backfill Plugin Imports
-from backfill.main import Backfill
+from plugins.backfill.main import Backfill
 
 # Init the plugin in Webserver's "Admin" Menu with Menu Item as "Backfill"
 backfill_admin_view = {"category" : "Admin", "name" : "Backfill (Alpha)",  "view": Backfill()}


### PR DESCRIPTION
# Description
This PR fixes the error below. This was introduced in https://github.com/mozilla/telemetry-airflow/pull/1580 when the logic for backfill command generation was moved out of `plugins/backfill/main.py` to `dags/utils/backfill.py`. 

The issue is that Airflow adds `dags`, `plugins` and `config` to `sys.path` at runtime (ref [here](https://airflow.apache.org/docs/apache-airflow/stable/modules_management.html#built-in-pythonpath-entries-in-airflow)) but does not add the project directory `airflow_home`. 

Hence, imports between `plugins` and `dags` will fail in deployments but should work in your IDE since IDE's add the project directory, i.e. `airflow_home`, to `sys.path`.

```shell
telemetry-airflow-web-1        | [2022-11-17 16:42:41,954] {{plugins_manager.py:247}} ERROR - Failed to import plugin /app/plugins/backfill/main.py
telemetry-airflow-web-1        | Traceback (most recent call last):
telemetry-airflow-web-1        |   File "/usr/local/lib/python3.7/site-packages/airflow/plugins_manager.py", line 239, in load_plugins_from_plugin_directory
telemetry-airflow-web-1        |     loader.exec_module(mod)
telemetry-airflow-web-1        |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
telemetry-airflow-web-1        |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
telemetry-airflow-web-1        |   File "/app/plugins/backfill/main.py", line 20, in <module>
telemetry-airflow-web-1        |     from dags.utils.backfill import BackfillParams
telemetry-airflow-web-1        | ModuleNotFoundError: No module named 'dags'
```

## Changes
### Fixes
- add the project directory `/app` to `PYTHONPATH` in `Dockerfile`

### Improvements
- Simplify local deployment with Linux
  - add `AIRFLOW_UID`, `AIRFLOW_GID` docker args
  - add `make build-linux` command to build with the right UID and GID
- add `PROJECT_DIR` docker args
- update readme to reflect local deployment changes and remove part about SSH'ing into ECS to run backfills
- remove vscode settings file that was committed in https://github.com/mozilla/telemetry-airflow/commit/a552e0517a9a5948327d8d9d2ae79750dc03b24f
- add `.dockerignore` to speed up building locally

## Validation
`airflow info` **before**
```shell
Paths info
airflow_home    | /app                                                                                                                                                                              
system_path     | /usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin                                                                                                       
python_path     | /usr/local/bin:/usr/local/lib/python37.zip:/usr/local/lib/python3.7:/usr/local/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/site-packages:/app/dags:/app/config:/app/plugins
airflow_on_path | True    
```

`airflow info` **after**
```shell
Paths info
airflow_home    | /app                                                                                                                                                                                   
system_path     | /usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin                                                                                                            
python_path     | /usr/local/bin:/app:/usr/local/lib/python37.zip:/usr/local/lib/python3.7:/usr/local/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/site-packages:/app/dags:/app/config:/app/plugins
airflow_on_path | True     
```