### PR TITLE
DENG-470 adding overwatch DAG

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -182,9 +182,6 @@ init_variables() {
     airflow variables set "Prod_glam_secret__django_secret_key" "Prod_glam_secret__django_secret_key"
     airflow variables set "Dev_glam_project" "Dev_glam_project"
     airflow variables set "Prod_glam_project" "Prod_glam_project"
-    
-    airflow variables set "overwatch_image_version" "overwatch_image_version"
-    airflow variables set "overwatch_slack_token" "overwatch_slack_token"
 }
 
 [ $# -lt 1 ] && usage

--- a/bin/run
+++ b/bin/run
@@ -182,6 +182,9 @@ init_variables() {
     airflow variables set "Prod_glam_secret__django_secret_key" "Prod_glam_secret__django_secret_key"
     airflow variables set "Dev_glam_project" "Dev_glam_project"
     airflow variables set "Prod_glam_project" "Prod_glam_project"
+    
+    airflow variables set "overwatch_image_version" "overwatch_image_version"
+    airflow variables set "overwatch_slack_token" "overwatch_slack_token"
 }
 
 [ $# -lt 1 ] && usage

--- a/dags/overwatch.py
+++ b/dags/overwatch.py
@@ -2,21 +2,17 @@
 Overwatch
 Runs daily at 0700 UTC
 
-Source code is [overwatch repository](https://github.com/mozilla/overwatch-mvp/).
-"""
+Source code is [overwatch-mvp repository](https://github.com/mozilla/overwatch-mvp/).
 
-from datetime import datetime, timedelta
-
-from airflow import DAG
-from airflow.models import Variable
-from operators.gcp_container_operator import GKEPodOperator
-
-docs = """\
 This DAG is executes the Overwatch monitoring system.
 All alerts related to this DAG can be ignored.
 
-(for more info on dim see: https://github.com/mozilla/overwatch-mvp)
 """
+
+from datetime import datetime
+
+from airflow import DAG
+from operators.gcp_container_operator import GKEPodOperator
 
 
 default_args = {
@@ -25,29 +21,28 @@ default_args = {
         "gleonard@mozilla.com",
         "wichan@mozilla.com",
     ],
-    "start_date": datetime(2022, 11, 1),
+    "start_date": datetime(2022, 11, 23),
     "depends_on_past": False,
     "email_on_failure": True,
-    "email_on_retry": True,
     "retries": 0,
 }
 
 tags = ["repo/telemetry-airflow", "impact/tier_3", ]
-image = "gcr.io/moz-fx-data-airflow-prod-88e0/overwatch:" + Variable.get("overwatch_image_version")
+image = "gcr.io/moz-fx-data-airflow-prod-88e0/overwatch:{{ var.value.overwatch_image_version }}"
 
 
 with DAG(
     "overwatch",
     default_args=default_args,
     schedule_interval="0 7 * * *",
-    doc_md=docs,
+    doc_md=__doc__,
     tags=tags,
+    catchup=True,
 ) as dag:
     run_analysis = GKEPodOperator(
         task_id="run_analysis",
         name="run_analysis",
         image=image,
-        dag=dag,
-        env_vars={"SLACK_BOT_TOKEN": Variable.get("overwatch_slack_token")},
+        env_vars={"SLACK_BOT_TOKEN": "{{ var.value.overwatch_slack_token }}"},
         arguments=["run-analysis", "--date={{ ds }}", "./config_files/"],
     )

--- a/dags/overwatch.py
+++ b/dags/overwatch.py
@@ -2,7 +2,7 @@
 Overwatch
 Runs daily at 0700 UTC
 
-Source code is [overwatch repository](https://github.com/mozilla/overwatch/).
+Source code is [overwatch repository](https://github.com/mozilla/overwatch-mvp/).
 """
 
 from datetime import datetime, timedelta

--- a/dags/overwatch.py
+++ b/dags/overwatch.py
@@ -1,0 +1,53 @@
+"""
+Overwatch
+Runs daily at 0700 UTC
+
+Source code is [overwatch repository](https://github.com/mozilla/overwatch/).
+"""
+
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.models import Variable
+from operators.gcp_container_operator import GKEPodOperator
+
+docs = """\
+This DAG is executes the Overwatch monitoring system.
+All alerts related to this DAG can be ignored.
+
+(for more info on dim see: https://github.com/mozilla/overwatch-mvp)
+"""
+
+
+default_args = {
+    "owner": "gleonard@mozilla.com",
+    "email": [
+        "gleonard@mozilla.com",
+        "wichan@mozilla.com",
+    ],
+    "start_date": datetime(2022, 11, 1),
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 0,
+}
+
+tags = ["repo/telemetry-airflow", "impact/tier_3", ]
+image = "gcr.io/moz-fx-data-airflow-prod-88e0/overwatch:" + Variable.get("overwatch_image_version")
+
+
+with DAG(
+    "overwatch",
+    default_args=default_args,
+    schedule_interval="0 7 * * *",
+    doc_md=docs,
+    tags=tags,
+) as dag:
+    run_analysis = GKEPodOperator(
+        task_id="run_analysis",
+        name="run_analysis",
+        image=image,
+        dag=dag,
+        env_vars={"SLACK_BOT_TOKEN": Variable.get("overwatch_slack_token")},
+        arguments=["run-analysis", "--date={{ ds }}", "./config_files/"],
+    )


### PR DESCRIPTION
- Added overwatch DAG
- Errors can be ignored for now since Overwatch is still in active development.
- 2 Airflow variables are required
1. `overwatch_image_version` set to `latest`.  Can be used to roll back release.
2. `overwatch_slack_token` used to publish reports to a Slack channel