### PR TITLE
handle remaining shredder partitions via reserved slots

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -77,22 +77,9 @@ telemetry_main = gke_command(
     name="shredder-telemetry-main",
     command=base_command
     + [
-        # "--parallelism=2",
-        # "--billing-project=moz-fx-data-shredder",
+        "--parallelism=2",
+        "--billing-project=moz-fx-data-shredder",
         "--only=telemetry_stable.main_v4",
-        # handle backlog using on-demand slots in 10 backfill projects
-        "--parallelism=10",
-        "--billing-project",
-        "moz-fx-data-backfill-10",
-        "moz-fx-data-backfill-11",
-        "moz-fx-data-backfill-12",
-        "moz-fx-data-backfill-13",
-        "moz-fx-data-backfill-14",
-        "moz-fx-data-backfill-15",
-        "moz-fx-data-backfill-16",
-        "moz-fx-data-backfill-17",
-        "moz-fx-data-backfill-18",
-        "moz-fx-data-backfill-19",
         # handle additional 5 "month" backlog with current run
         "--start-date={{macros.ds_add(ds, 27-28*(2+5))}}",
     ],


### PR DESCRIPTION
still handling the backlog

no longer running new jobs in the on-demand backfill projects, because the only remaining partitions in telemetry main are the ones that have failed ~45 times using on-demand slots, and all other shredder jobs are complete for this cycle, so there's an abundance of available reserved slots.