### PR TITLE
WIP test - Modify fivetran operator registryLink get_link func signature for 2.3 release

### DIFF
--- a/dags/operators/backport/fivetran/operator.py
+++ b/dags/operators/backport/fivetran/operator.py
@@ -12,7 +12,12 @@ class RegistryLink(BaseOperatorLink):
 
     name = "Astronomer Registry"
 
-    def get_link(self, operator, dttm):
+    def get_link(
+            self,
+            operator,
+            dttm: Optional[datetime] = None,
+            ti_key: Optional["TaskInstanceKey"] = None,
+    ) -> str:
         """Get link to registry page."""
 
         registry_link = (


### PR DESCRIPTION
Merge after 2.3.3 upgrade if the fivetran operators are failing complaining about registryLink's get_link's func params
ref https://github.com/apache/airflow/pull/21798