### PR TITLE
Temporarily disable logs in publish views task

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -67,6 +67,7 @@ with DAG("bqetl_artifact_deployment", default_args=default_args, schedule_interv
             "script/publish_public_data_views --target-project=mozdata"
         ],
         docker_image=docker_image,
+        get_logs=False,
     )
 
     publish_views.set_upstream(publish_public_udfs)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 1165, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/usr/local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 1283, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/usr/local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 1313, in _execute_task
    result = task_copy.execute(context=context)
  File "/usr/local/lib/python3.7/site-packages/airflow/providers/google/cloud/operators/kubernetes_engine.py", line 335, in execute
    return super().execute(context)
  File "/usr/local/lib/python3.7/site-packages/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py", line 367, in execute
    final_state, remote_pod, result = self.create_new_pod_for_operator(labels, launcher)
  File "/usr/local/lib/python3.7/site-packages/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py", line 521, in create_new_pod_for_operator
    final_state, remote_pod, result = launcher.monitor_pod(pod=self.pod, get_logs=self.get_logs)
  File "/usr/local/lib/python3.7/site-packages/airflow/providers/cncf/kubernetes/utils/pod_launcher.py", line 148, in monitor_pod
    timestamp, message = self.parse_log_line(line.decode('utf-8'))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc1 in position 32: invalid start byte
```

:shrug: 