### PR TITLE
Run view deploy even if table deploy failed

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -3,6 +3,7 @@ Nightly deploy of bigquery etl views.
 """
 
 from airflow import DAG
+from airflow.utils.trigger_rule import TriggerRule
 from datetime import timedelta, datetime
 from utils.gcp import gke_command
 from utils.tags import Tag
@@ -68,6 +69,7 @@ with DAG("bqetl_artifact_deployment", default_args=default_args, schedule_interv
         ],
         docker_image=docker_image,
         get_logs=False,
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     publish_views.set_upstream(publish_public_udfs)


### PR DESCRIPTION
Currently, if the table deploy fails then view deploys will not get triggered. This PR makes a change to run the view deploy regardless of whether table deploys have failed or succeeded.
The main reason for this change is to ensure that views that are not related to a failing table deploy (e.g due to an incompatible schema) can still get deployed instead of being blocked. Views that depend on a table that failed to deploy will result in a failure during view deployment as well.