### PR TITLE
Bug 1804769: update glam glean import image to use fix

### DIFF
--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -84,16 +84,16 @@ wait_for_glam = ExternalTaskSensor(
 )
 
 # Move logic from Glam deployment's GKE Cronjob to this dag for better dependency timing
-default_glean_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.11.0-31'
+default_glean_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.12.1-37'
 
 base_docker_args = ['/venv/bin/python', 'manage.py']
 
 for env in ['Dev','Prod']:
     glean_import_image = default_glean_import_image
     if env == 'Dev':
-        glean_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.11.0-31'
+        glean_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.12.1-37'
     elif env == 'Prod':
-        glean_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.11.0-31'
+        glean_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.12.1-37'
 
     env_vars = dict(
         DATABASE_URL = Variable.get(env + "_glam_secret__database_url"),
@@ -145,16 +145,16 @@ for env in ['Dev','Prod']:
 
 
 
-default_glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.11.0-31'
+default_glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.12.1-37'
 
 base_docker_args = ['/venv/bin/python', 'manage.py']
 
 for env in ['Dev','Prod']:
     glam_import_image = default_glam_import_image
     if env == 'Dev':
-        glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.11.0-31'
+        glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.12.1-37'
     elif env == 'Prod':
-        glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.11.0-31'
+        glam_import_image = 'gcr.io/moz-fx-dataops-images-global/gcp-pipelines/glam/glam-production/glam:2022.12.1-37'
 
     env_vars = dict(
         DATABASE_URL = Variable.get(env + "_glam_secret__database_url"),


### PR DESCRIPTION
Fixes [1804769](https://bugzilla.mozilla.org/show_bug.cgi?id=1804769)

This is the next step to make use of the fix implemented in [GLAM PR #2258](https://github.com/mozilla/glam/pull/2258).
A [release](https://github.com/mozilla/glam/releases/tag/2022.12.1) was created from that PR, which triggered a deployment process and now we have the image with the bug fix on GCR tagged `2022.12.1-37`

After this lands I will re-run the import task that failed (see bug) and see that it completes.