### PR TITLE
chore(ci): refine new workflow using orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ workflows:
           filters: &ci-filter
             branches:
               ignore: main
+            tags:
+              ignore: /.*/
 
       - unit-tests:
           name: Unit tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ workflows:
                   > version.json
             - run:
                 name: Output version.json
-                command: cat version.json && echo ${DOCKERHUB_REPO:1:-2}
+                command: cat version.json
           deploy: false
           image: $CIRCLE_PROJECT_REPONAME
           tag: ${CIRCLE_SHA1:0:9}
@@ -107,7 +107,7 @@ workflows:
           before_build: *version
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
-          image: $DOCKERHUB_REPO
+          image: mozilla/telemetry-airflow
           tag: latest
           filters:
             branches:
@@ -118,7 +118,7 @@ workflows:
           before_build: *version
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
-          image: $DOCKERHUB_REPO
+          image: mozilla/telemetry-airflow
           tag: $CIRCLE_TAG
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,25 +84,21 @@ workflows:
                   > version.json
             - run:
                 name: Output version.json
-                command: cat version.json
+                command: cat version.json && echo ${DOCKERHUB_REPO:1:-2}
           deploy: false
           image: $CIRCLE_PROJECT_REPONAME
           tag: ${CIRCLE_SHA1:0:9}
-          filters:
-            tags:
-              only: /.*/
+          filters: &ci-filter
+            branches:
+              ignore: main
 
       - unit-tests:
           name: Unit tests
-          filters:
-            tags:
-              only: /.*/
+          filters: *ci-filter
 
       - integration-tests:
           name: Integration tests
-          filters:
-            tags:
-              only: /.*/
+          filters: *ci-filter
 
   publish:
     jobs:


### PR DESCRIPTION
# Description
This is a follow up PR addressing small issues with the new CircleCI workflow that was introduced in the related PR.

### Changes

- CI workflow ran all the time, it now only runs on branches other than main and not on tagged commits
- fix docker image including `docker.io`

# Related PR
* https://github.com/mozilla/telemetry-airflow/pull/1619
