### PR TITLE
Increase Intacct Fivetran sensor timeout to 6 hours (bug 1807699)

### DIFF
--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -85,7 +85,7 @@ with DAG(
             fivetran_conn_id='fivetran',
             connector_id=connector_id,
             poke_interval=30,
-            execution_timeout=timedelta(hours=3),
+            execution_timeout=timedelta(hours=6),
             retries=0,
             priority_weight=fivetran_sync_start.priority_weight + 1,
         )


### PR DESCRIPTION
The [Intacct Fivetran sync for "MOZ INC"](https://fivetran.com/dashboard/connectors/sage_intacct/sage_intacct_moz/status?requiredGroup=loading_reputation) is now taking longer than 3 hours.

This will fix [bug 1807699](https://bugzilla.mozilla.org/show_bug.cgi?id=1807699) "Airflow task fivetran_intacct_historical.intacct-sensor-moz failing since 2022-12-21".