### PR TITLE
bug(1809624): graphics_telemetry tweaked to use git instead of pypi repostiory for installing moztelemetry

### DIFF
--- a/dags/graphics_telemetry.py
+++ b/dags/graphics_telemetry.py
@@ -36,7 +36,7 @@ default_args = {
 }
 
 PIP_PACKAGES = [
-    "python_moztelemetry",
+    "git+https://github.com/mozilla/python_moztelemetry.git@v0.10.4#egg=python-moztelemetry",
     "git+https://github.com/FirefoxGraphics/telemetry.git#egg=pkg&subdirectory=analyses/bigquery_shim",
     "boto3==1.16.20",
     "six==1.15.0",


### PR DESCRIPTION
# bug(1809624): graphics_telemetry tweaked to use git instead of pypi repostiory for installing moztelemetry