### PR TITLE
docs: added triage notes to dag docs for bqetl_artifact_deployment, mad_server and taar_weekly

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -1,5 +1,11 @@
 """
 Nightly deploy of bigquery etl views.
+
+*Triage notes*
+
+The DAG always re-deploys all bqetl views. So as long as the most recent DAG run
+is successful the job can be considered healthy. This means previous failed DAG runs
+can be ignored or marked as successful.
 """
 
 from airflow import DAG

--- a/dags/data_monitoring.py
+++ b/dags/data_monitoring.py
@@ -9,6 +9,13 @@ This DAG is related to data monitoring project it is still under development.
 All alerts related to this DAG can be ignored.
 
 (for more info on dim see: https://github.com/mozilla/dim)
+
+*Triage notes*
+
+This process is WIP and the DAG is currently set up on purpose to fail unless
+all data checks pass. Please *ignore all failures* for this DAG and do not change
+their status. Once we have a proper dashboard build to track and observe when
+things fail we will update the DAG.
 """
 
 # telemetry_derived for the same tables as in telemetry are needed as different tests are executed

--- a/dags/mad_server.py
+++ b/dags/mad_server.py
@@ -4,6 +4,15 @@ Malicious Addons Detection
 This runs once a week to emit a trained model to GCS.
 
 Source code is in the private [mad-server repository](https://github.com/mozilla/mad-server/).
+
+*Triage notes*
+
+The way the app was designed it is decoupled from Airflow and will pull all data since the last
+successful data pull. What this means if we have a failed DAG run followed by
+a successful DAG run it will cover the data from the previous run.
+
+So as long as the most recent DAG run is successful the job can be considered healthy
+and not action is required for failed DAG runs.
 """
 
 from airflow import DAG

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -16,6 +16,12 @@ from utils.tags import Tag
 DOCS = """\
 # Probe Scraper
 
+*Triage notes*
+
+As long as the most recent DAG run is successful this job can be considered healthy.
+In such case, past DAG failures can be ignored.
+
+
 ## Debugging failures
 
 probe_scraper and probe_scraper_moz_central task logs aren't available via the Airflow web console. In

--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -4,6 +4,13 @@ Daily data exports used by TAAR.
 Source code is in [mozilla/telemetry-batch-view](https://github.com/mozilla/telemetry-batch-view/blob/main/src/main/scala/com/mozilla/telemetry/ml/AddonRecommender.scala).
 
 For context, see https://github.com/mozilla/taar
+
+
+*Triage notes*
+
+Each run of this jobs overwrites existing data, as long as the most recent DAG run
+is successful then this job can be considered healthy and there is not need to take
+any actions for the past failed DAG runs.
 """
 
 

--- a/dags/taar_weekly.py
+++ b/dags/taar_weekly.py
@@ -2,6 +2,12 @@
 This configures a weekly DAG to run the TAAR Ensemble job off.
 
 For context, see https://github.com/mozilla/taar
+
+*Triage notes*
+
+Each run of this jobs overwrites existing data, as long as the most recent DAG run
+is successful then this job can be considered healthy and there is not need to take
+any actions for the past failed DAG runs.
 """
 
 from airflow import DAG


### PR DESCRIPTION
# docs: added triage notes to dag docs for bqetl_artifact_deployment, mad_server and taar_weekly

Provides additional information around the DAG to make the triaging easier.