### PR TITLE
added triage/record_only && triage/no_triage tags

### DIFF
--- a/bin/test-dag-tags.py
+++ b/bin/test-dag-tags.py
@@ -4,7 +4,7 @@ import subprocess
 from typing import Dict
 
 
-VALID_TAGS = ("impact/tier_1", "impact/tier_2", "impact/tier_3", "repo/bigquery-etl", "repo/telemetry-airflow", "repo/private-bigquery-etl",)
+VALID_TAGS = ("impact/tier_1", "impact/tier_2", "impact/tier_3", "repo/bigquery-etl", "repo/telemetry-airflow", "repo/private-bigquery-etl", "triage/record_only",)
 REQUIRED_TAG_TYPES = ("impact",)
 
 

--- a/bin/test-dag-tags.py
+++ b/bin/test-dag-tags.py
@@ -4,7 +4,16 @@ import subprocess
 from typing import Dict
 
 
-VALID_TAGS = ("impact/tier_1", "impact/tier_2", "impact/tier_3", "repo/bigquery-etl", "repo/telemetry-airflow", "repo/private-bigquery-etl", "triage/record_only",)
+VALID_TAGS = (
+    "impact/tier_1",
+    "impact/tier_2",
+    "impact/tier_3",
+    "repo/bigquery-etl",
+    "repo/telemetry-airflow",
+    "repo/private-bigquery-etl",
+    "triage/record_only",
+    "triage/no_triage",
+)
 REQUIRED_TAG_TYPES = ("impact",)
 
 

--- a/dags/backfill.py
+++ b/dags/backfill.py
@@ -71,7 +71,7 @@ doc_md = """
     catchup=False,
     start_date=datetime.datetime(2022, 11, 1),
     dagrun_timeout=datetime.timedelta(days=1),
-    tags=[Tag.ImpactTier.tier_3],
+    tags=[Tag.ImpactTier.tier_3, Tag.Triage.record_only],
     render_template_as_native_obj=True,
     params={"dag_name": Param("dag_name", type="string"),
             "start_date": Param((datetime.date.today() - datetime.timedelta(days=10)).isoformat(),

--- a/dags/data_monitoring.py
+++ b/dags/data_monitoring.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from airflow import DAG
+from utils.tags import Tag
 
 from operators.gcp_container_operator import GKEPodOperator
 
@@ -45,7 +46,7 @@ default_args = {
     "retries": 0,
 }
 
-TAGS = ["repo/telemetry-airflow", "impact/tier_3",]
+TAGS = ["repo/telemetry-airflow", Tag.ImpactTier.tier_1, Tag.Triage.no_triage]
 IMAGE = "gcr.io/moz-fx-data-airflow-prod-88e0/dim:latest"
 
 with DAG(

--- a/dags/utils/tags.py
+++ b/dags/utils/tags.py
@@ -49,3 +49,4 @@ class Tag(Enum):
         """
 
         record_only: str = "triage/record_only"
+        no_triage: str = "triage/no_triage"

--- a/dags/utils/tags.py
+++ b/dags/utils/tags.py
@@ -41,3 +41,11 @@ class Tag(Enum):
         tier_1: str = "impact/tier_1"
         tier_2: str = "impact/tier_2"
         tier_3: str = "impact/tier_3"
+
+    class Triage(Enum):
+        """
+        Tag for representing that an engineer on triage
+        should attempt to resolve the problem themselves
+        """
+
+        record_only: str = "triage/record_only"


### PR DESCRIPTION
# added triage/record-only tag

This is as part of the proposal to make changes to our current triage process to show that a DAG failure should be recorded/reported without any debugging.

![image](https://user-images.githubusercontent.com/42538694/217834656-731ea4c7-cb7d-42e3-94a6-ef0d7ad3975b.png)

