### PR TITLE
Fix bin commands to run correctly under docker-compose v2 container naming scheme

### DIFF
--- a/bin/add_gcp_creds
+++ b/bin/add_gcp_creds
@@ -30,7 +30,7 @@ function update_gcp() {
     local conn_id=$1
     local keyfile=$2
 
-    container_id=$(docker ps | grep telemetry-airflow_web | cut -d' ' -f1)
+    container_id=$(docker ps | grep telemetry-airflow\[-_\]web | cut -d' ' -f1)
 
     docker exec $container_id \
         airflow connections delete $conn_id

--- a/bin/add_gcp_creds
+++ b/bin/add_gcp_creds
@@ -30,7 +30,7 @@ function update_gcp() {
     local conn_id=$1
     local keyfile=$2
 
-    container_id=$(docker ps | grep telemetry-airflow\[-_\]web | cut -d' ' -f1)
+    container_id=$(docker ps --filter name=web -q)
 
     docker exec $container_id \
         airflow connections delete $conn_id

--- a/bin/start_gke
+++ b/bin/start_gke
@@ -37,17 +37,16 @@ JSON_CREDS=$(gcloud secrets versions access latest --secret="gke-sandbox-creds" 
 # Upload secret to local wtmo
 GCP_CONN_ID="google_cloud_gke_sandbox"
 
-if ! docker ps | grep telemetry-airflow-\[-_\]web; then
+CONTAINER_ID=$(docker ps --filter name=web -q)
+if [ -z "$CONTAINER_ID" ]; then
     echo "ERROR: Airflow container is likely not running (or docker). Run 'make up' to start airflow containers"
+else
+  echo "Web container id is $CONTAINER_ID. Adding gcp connection..."
+  docker exec $CONTAINER_ID airflow connections delete $GCP_CONN_ID
+
+  docker exec $CONTAINER_ID airflow connections add $GCP_CONN_ID \
+         --conn-type google_cloud_platform \
+         --conn-extra "$JSON_CREDS"
 fi
-
-CONTAINER_ID=$(docker ps | grep telemetry-airflow\[-_\]web | cut -d' ' -f1)
-
-echo "Web container id is $CONTAINER_ID. Adding gcp connection..."
-docker exec $CONTAINER_ID airflow connections delete $GCP_CONN_ID
-
-docker exec $CONTAINER_ID airflow connections add $GCP_CONN_ID \
-       --conn-type google_cloud_platform \
-       --conn-extra "$JSON_CREDS"
 
 echo "visit https://go.corp.mozilla.com/wtmodev for more info"

--- a/bin/start_gke
+++ b/bin/start_gke
@@ -6,7 +6,7 @@ set -eo pipefail
 
 # Set Env var MY_LOCAL_IP or use icanhazip.com to fetch it
 # https://major.io/icanhazip-com-faq/#what-about-my-privacy
-MY_IP=${MY_LOCAL_IP:-$(curl icanhazip.com)}
+MY_IP=${MY_LOCAL_IP:-$(curl -s icanhazip.com)}
 echo "local ip is $MY_IP"
 
 USERNAME=$(gcloud config get-value account | awk -F"@" '{print $1}')
@@ -37,11 +37,11 @@ JSON_CREDS=$(gcloud secrets versions access latest --secret="gke-sandbox-creds" 
 # Upload secret to local wtmo
 GCP_CONN_ID="google_cloud_gke_sandbox"
 
-if ! docker ps | grep _web; then
+if ! docker ps | grep telemetry-airflow-\[-_\]web; then
     echo "ERROR: Airflow container is likely not running (or docker). Run 'make up' to start airflow containers"
 fi
 
-CONTAINER_ID=$(docker ps | grep _web | cut -d' ' -f1)
+CONTAINER_ID=$(docker ps | grep telemetry-airflow\[-_\]web | cut -d' ' -f1)
 
 echo "Web container id is $CONTAINER_ID. Adding gcp connection..."
 docker exec $CONTAINER_ID airflow connections delete $GCP_CONN_ID

--- a/bin/test-parse
+++ b/bin/test-parse
@@ -49,7 +49,7 @@ function get_errors_in_listing {
 
 
 function main() {
-    if [[ -n $(docker-compose ps -q web) ]]; then
+    if [[ -n $(docker-compose ps --status running -q web) ]]; then
         echo "Existing container is up, please bring it down and re-run."
         exit 1
     fi


### PR DESCRIPTION
Grepping for running containers with an `_` separator was failing under docker compose v2. This should make the bin scripts a little more universal.