### PR TITLE
chore(ci): add integration test to validate local environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,25 @@ jobs:
   test-local-environment:
     executor: docker/machine
     steps:
+      - attach_workspace:
+          at: artifacts
       - checkout
       - docker/install-docker-compose
       - run:
-          name: Docker
+          name: Load Docker image artifact from previous job
+          command: docker load -i artifacts/telemetry-airflow.tar
+      - run:
+          name: Override docker-compose.yaml with artifact
           command: |
+            sed -i "s/  build: ./  image: $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}/g" docker-compose.yml
+      - run:
+          name: Start up local environment
+          command: |
+            echo "AIRFLOW_UID=$(id -u)" >> .env
+            echo "FERNET_KEY=$(python3 -c "from cryptography.fernet import Fernet; fernet_key = Fernet.generate_key(); print(fernet_key.decode())")" >> .env
             docker-compose up --wait
+            docker-compose exec airflow-webserver airflow variables import dev_variables.json
+            docker-compose exec airflow-webserver airflow connections import dev_connections.json
 
   black:
     executor: *python-executor
@@ -127,12 +140,23 @@ workflows:
             - run:
                 name: Output version.json
                 command: cat version.json
+          after_build:
+            - run:
+                name: Persist image
+                command: |
+                  mkdir -p artifacts
+                  docker save -o artifacts/telemetry-airflow.tar $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}
+            - persist_to_workspace:
+                root: artifacts
+                paths:
+                  - telemetry-airflow.tar
           deploy: false
           image: $CIRCLE_PROJECT_REPONAME
           tag: ${CIRCLE_SHA1:0:9}
           filters: *ci-filter
           requires:
             - 🧪 Validate requirements
+
       - test-local-environment:
           name: 🧪 Validate local environment
           filters: *ci-filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,16 @@ jobs:
       - store_test_results:
           path: test-results
 
+  test-local-environment:
+    executor: docker/machine
+    steps:
+      - checkout
+      - docker/install-docker-compose
+      - run:
+          name: Docker
+          command: |
+            docker-compose up --wait
+
   black:
     executor: *python-executor
     steps:
@@ -102,6 +112,7 @@ workflows:
               ignore: main
             tags:
               ignore: /.*/
+
       - docker/publish:
           name: 🛠️ Docker build test
           before_build: &version
@@ -122,6 +133,12 @@ workflows:
           filters: *ci-filter
           requires:
             - 🧪 Validate requirements
+      - test-local-environment:
+          name: 🧪 Validate local environment
+          filters: *ci-filter
+          requires:
+            - 🛠️ Docker build test
+
       - black:
           name: ⚫ black
           filters: *ci-filter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,9 @@ jobs:
   test-local-environment:
     executor: docker/machine
     steps:
+      - checkout
       - attach_workspace:
           at: artifacts
-      - checkout
       - docker/install-docker-compose
       - run:
           name: Load Docker image artifact from previous job


### PR DESCRIPTION
# Description
Add an integration test to validate local environment. Implementation persists image built in the docker build job and reuses it for docker-compose to save time by building once.

### 🛠️ Docker build test job 
- builds the image, 
- save the image to a local artifacts directory,
- uses `persist_to_workspace` step to persist docker image artifact

### 🧪 **Validate local environment** job
- attach to artifacts workspace
- load docker image from previous job
- override docker-compose.yaml to use the image artifact instead of rebuilding
- start up local environment

# References
* https://circleci.com/docs/workspaces/
* https://support.circleci.com/hc/en-us/articles/360019182513-Build-a-Docker-image-in-one-job-and-use-it-in-another-job
