### PR TITLE
Bug 1775035 - Add DAP Collector DAG

### DIFF
--- a/dags/dap_collector.py
+++ b/dags/dap_collector.py
@@ -54,7 +54,7 @@ with DAG(
     schedule_interval="@daily",
     tags=tags,
 ) as dag:
-    play_store_export = gke_command(
+    dap_collector = gke_command(
         task_id="dap_collector",
         command=[
             "python",

--- a/dags/dap_collector.py
+++ b/dags/dap_collector.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from utils.gcp import gke_command
+from utils.tags import Tag
+
+DOCS = """
+### DAP Collector
+
+#### Description
+
+Runs a Docker image that collects data from a DAP (Distributed Aggregation Protocol) leader and stores it in BigQuery.
+
+The container is defined in
+[docker-etl](https://github.com/mozilla/docker-etl/tree/main/jobs/dap-collector)
+
+For more information on Privacy Preserving Measurement in Firefox see
+https://bugzilla.mozilla.org/show_bug.cgi?id=1775035
+
+This DAG requires following variables to be defined in Airflow:
+* dap_auth_token
+* dap_hpke_private_key
+
+This job is under active development, occasional failures are expected.
+
+#### Owner
+
+sfriedberger@mozilla.com
+"""
+
+default_args = {
+    "owner": "sfriedberger@mozilla.com",
+    "email": ["akomarzewski@mozilla.com", "sfriedberger@mozilla.com"],
+    "depends_on_past": False,
+    "start_date": datetime(2023, 3, 8),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 1,
+    "retry_delay": timedelta(hours=2),
+}
+
+project_id = "mozdata"
+table_id = "analysis.sfriedberger_dap_test"
+
+tags = [
+    Tag.ImpactTier.tier_3,
+    Tag.Triage.no_triage,
+]
+
+with DAG(
+    "dap_collector",
+    default_args=default_args,
+    doc_md=DOCS,
+    schedule_interval="@daily",
+    tags=tags,
+) as dag:
+    play_store_export = gke_command(
+        task_id="dap_collector",
+        command=[
+            "python",
+            "dap_collector/main.py",
+            "--auth-token={{ var.value.dap_auth_token }}",
+            "--hpke-private-key={{ var.value.dap_hpke_private_key }}",
+            "--project",
+            project_id,
+            "--table-id",
+            table_id,
+        ],
+        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/dap-collector_docker_etl:latest",
+        gcp_conn_id="google_cloud_airflow_gke",
+    )


### PR DESCRIPTION
This adds collector job for fetching DAP (Distributed Aggregation Protocol) metrics.

`dap_auth_token` and `dap_hpke_private_key` variables are now set in Airflow.