### PR TITLE
Change time of Merino job to Tuesdays

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -1,9 +1,8 @@
 import datetime
-from typing import Any, Dict, List
+from typing import Any
 
 from airflow import DAG
 from airflow.hooks.base import BaseHook
-
 from operators.gcp_container_operator import GKEPodOperator
 from utils.tags import Tag
 
@@ -11,10 +10,13 @@ DOCS = """\
     Merino Jobs
 
     Dag for orchestrating jobs that build datasets that are used in Merino.
-    The jobs are run via the GKEPodOperator 
+    The jobs are run via the GKEPodOperator
 """
 
-def merino_job(name: str, arguments: List[str], env_vars: Dict[str, Any] = {}):
+
+def merino_job(name: str, arguments: list[str], env_vars: dict[str, Any] | None = None):
+    if env_vars is None:
+        env_vars = {}
     return GKEPodOperator(
         task_id=name,
         name=name,
@@ -29,8 +31,8 @@ def merino_job(name: str, arguments: List[str], env_vars: Dict[str, Any] = {}):
         email=[
             "wstuckey@mozilla.com",
         ],
-
     )
+
 
 default_args = {
     "owner": "wstuckey@mozilla.com",
@@ -66,12 +68,14 @@ with DAG(
         arguments=[
             "wikipedia-indexer",
             "copy-export",
-            "--gcs-path", "moz-fx-data-prod-external-data/contextual-services/merino-jobs/wikipedia-exports",
-            "--gcp-project", "moz-fx-data-shared-prod",
+            "--gcs-path",
+            "moz-fx-data-prod-external-data/contextual-services/merino-jobs/wikipedia-exports",
+            "--gcp-project",
+            "moz-fx-data-shared-prod",
         ],
-        env_vars=dict(
-            MERINO_ENV="production",
-        ),
+        env_vars={
+            "MERINO_ENV": "production",
+        },
     )
 
     wikipedia_indexer_build_index = merino_job(
@@ -79,18 +83,22 @@ with DAG(
         arguments=[
             "wikipedia-indexer",
             "index",
-            "--version", "v1",
-            "--total-docs", "6600000", # Estimate of the total number of documents in wikipedia index
-            "--elasticsearch-cloud-id", str(conn.host),
-            "--elasticsearch-api-key", conn.password,
-            "--gcs-path", "moz-fx-data-prod-external-data/contextual-services/merino-jobs/wikipedia-exports",
-            "--gcp-project", "moz-fx-data-shared-prod",
+            "--version",
+            "v1",
+            "--total-docs",
+            "6600000",  # Estimate of the total number of documents in wikipedia index
+            "--elasticsearch-cloud-id",
+            str(conn.host),
+            "--elasticsearch-api-key",
+            conn.password,
+            "--gcs-path",
+            "moz-fx-data-prod-external-data/contextual-services/merino-jobs/wikipedia-exports",
+            "--gcp-project",
+            "moz-fx-data-shared-prod",
         ],
-        env_vars=dict(
-            MERINO_ENV="production",
-        ),
+        env_vars={
+            "MERINO_ENV": "production",
+        },
     )
-
-
 
     wikipedia_indexer_copy_export >> wikipedia_indexer_build_index

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -50,10 +50,10 @@ tags = [
     Tag.Triage.no_triage,
 ]
 
-# Run weekly on Mondays at 5am UTC
+# Run weekly on Tuesdays at 5am UTC
 with DAG(
     "merino_jobs",
-    schedule_interval="0 5 * * 1",
+    schedule_interval="0 5 * * 2",
     doc_md=DOCS,
     default_args=default_args,
     tags=tags,

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 from airflow import DAG
 from airflow.hooks.base import BaseHook
@@ -14,7 +14,9 @@ DOCS = """\
 """
 
 
-def merino_job(name: str, arguments: list[str], env_vars: dict[str, Any] | None = None):
+def merino_job(
+    name: str, arguments: List[str], env_vars: Optional[Dict[str, Any]] = None
+):
     if env_vars is None:
         env_vars = {}
     return GKEPodOperator(
@@ -60,7 +62,6 @@ with DAG(
     default_args=default_args,
     tags=tags,
 ) as dag:
-
     conn = BaseHook.get_connection("merino_elasticsearch")
 
     wikipedia_indexer_copy_export = merino_job(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 known-third-party = ["airflow"]
 
 [tool.ruff]
+target-version = "py38"
 select = [
     "E", # pycodestyle
     "W", # pycodestyle


### PR DESCRIPTION
The job keeps failing on Monday because the upstream Wikimedia export is not ready when we try to download the file. So changing the date to Tuesday to improve our chances of download.