### PR TITLE
chore(ci): push image to GAR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,11 +244,11 @@ workflows:
     jobs:
       - docker-build-artifact:
           name: 🛠️ Docker build and persist image
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              ignore: /.*/
 
       - publish-dockerhub:
           name: Publish latest to Dockerhub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
           command: docker load -i artifacts/telemetry-airflow.tar
       - run:
           name: Generate image name
-          command: echo 'export IMAGE_NAME="<< parameters.registry >>/telemetry-airflow:<< parameters.image_tag >>' >> "$BASH_ENV"
+          command: echo 'export IMAGE_NAME="<< parameters.registry >>/telemetry-airflow:<< parameters.image_tag >>"' >> "$BASH_ENV"
       - run:
           name: Re-tag artifact
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
@@ -258,7 +258,7 @@ workflows:
 #              ignore: /.*/
 
       - publish-registry:
-          name: Publish tag to Dockerhub
+          name: Publish tag to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
 #          image_tag: $CIRCLE_TAG
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ version: 2.1
 orbs:
   docker: circleci/docker@2.2.0
   python: circleci/python@2.1.1
-  gcp-cli: circleci/gcp-cli@3.0.1
 
 jobs:
   unit-tests:
@@ -167,29 +166,6 @@ jobs:
           tag: $PARAM_IMAGE_TAG
           registry: $PARAM_REGISTRY
 
-  publish-dockerhub:
-    executor: docker/machine
-    parameters:
-      image_tag:
-        type: string
-        default: latest
-    steps:
-      - checkout
-      - docker/check:
-          docker-password: DOCKER_PASS
-          docker-username: DOCKER_USER
-      - attach_workspace:
-          at: artifacts
-      - run:
-          name: Load Docker image artifact from previous job
-          command: docker load -i artifacts/telemetry-airflow.tar
-      - run:
-          name: Re-tag artifact
-          command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} mozilla/$CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>
-      - docker/push:
-          image: mozilla/$CIRCLE_PROJECT_REPONAME
-          tag: << parameters.image_tag >>
-
   sync_gcs:
     docker:
       - image: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0
@@ -269,9 +245,11 @@ workflows:
 #            branches:
 #              only: main
 
-      - publish-dockerhub:
+      - publish-registry:
           name: Publish tag to Dockerhub
+          registry: mozilla
           image_tag: $CIRCLE_TAG
+          registry_authentication: *mozilla-auth
           requires:
             - 🛠️ Docker build and persist image
           filters:
@@ -283,7 +261,7 @@ workflows:
       - publish-registry:
           name: Publish tag to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
-          image_tag: latest
+          image_tag: $CIRCLE_TAG
           registry_authentication: &gar-auth
             - run:
                 name: Authenticate GAR
@@ -291,14 +269,25 @@ workflows:
                   echo $GAR_SERVICE_KEY | base64 -d > creds.json
                   gcloud auth activate-service-account --key-file creds.json
                   gcloud auth configure-docker us-docker.pkg.dev
-#          image_tag: $CIRCLE_TAG
+
+          requires:
+            - 🛠️ Docker build and persist image
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
+      - publish-registry:
+          name: Publish latest to GAR
+          registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
+          image_tag: latest
+          registry_authentication: *gar-auth
           requires:
             - 🛠️ Docker build and persist image
 #          filters:
-#            tags:
-#              only: /.*/
 #            branches:
-#              ignore: /.*/
+#              only: main
 
       - sync_gcs:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              ignore: /.*/
+              only: main
 
       - publish-registry:
           name: Publish latest to Dockerhub
@@ -237,6 +237,8 @@ workflows:
           requires:
             - 🛠️ Docker build and persist image
           filters:
+            tags:
+              only: /.*/
             branches:
               only: main
 
@@ -254,9 +256,9 @@ workflows:
               ignore: /.*/
 
       - publish-registry:
-          name: Publish tag to GAR
+          name: Publish latest to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
-          image_tag: $CIRCLE_TAG
+          image_tag: latest
           registry_authentication: &gar-auth
             - run:
                 name: Authenticate GAR
@@ -264,7 +266,19 @@ workflows:
                   echo $GAR_SERVICE_KEY | base64 -d > creds.json
                   gcloud auth activate-service-account --key-file creds.json
                   gcloud auth configure-docker us-docker.pkg.dev
+          requires:
+            - 🛠️ Docker build and persist image
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: main
 
+      - publish-registry:
+          name: Publish tag to GAR
+          registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
+          image_tag: $CIRCLE_TAG
+          registry_authentication: *gar-auth
           requires:
             - 🛠️ Docker build and persist image
           filters:
@@ -272,17 +286,6 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
-
-      - publish-registry:
-          name: Publish latest to GAR
-          registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
-          image_tag: latest
-          registry_authentication: *gar-auth
-          requires:
-            - 🛠️ Docker build and persist image
-          filters:
-            branches:
-              only: main
 
       - sync_gcs:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,9 +255,14 @@ workflows:
 #            branches:
 #              ignore: /.*/
 
-      - publish-dockerhub:
+      - publish-registry:
           name: Publish latest to Dockerhub
+          registry: mozilla
           image_tag: latest
+          registry_authentication: &mozilla-auth
+            - docker/check:
+                docker-password: DOCKER_PASS
+                docker-username: DOCKER_USER
           requires:
             - 🛠️ Docker build and persist image
 #          filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ version: 2.1
 orbs:
   docker: circleci/docker@2.2.0
   python: circleci/python@2.1.1
+  gcp-cli: circleci/gcp-cli@3.0.1
 
 jobs:
   unit-tests:
@@ -184,7 +185,7 @@ workflows:
   publish:
     jobs:
       - docker/publish:
-          name: Push latest
+          name: Push latest to Dockerhub
           before_build: *version
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
@@ -195,7 +196,7 @@ workflows:
               only: main
 
       - docker/publish:
-          name: Push tag
+          name: Push tag to Dockerhub
           before_build: *version
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
@@ -206,6 +207,21 @@ workflows:
               only: /.*/
             branches:
               ignore: /.*/
+
+      - docker/publish:
+          name: Push tag to GAR
+          before_build:
+            - <<: *version
+            - run: echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
+          image: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
+          tag: 123
+#          tag: $CIRCLE_TAG
+          deploy: false
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              ignore: /.*/
 
       - sync_gcs:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,14 +214,13 @@ workflows:
             - <<: *version
             - run: echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
           image: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
-          tag: "123"
-#          tag: $CIRCLE_TAG
+          tag: $CIRCLE_TAG
           deploy: false
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              ignore: /.*/
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
 
       - sync_gcs:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,9 @@ jobs:
           command: docker load -i artifacts/telemetry-airflow.tar
       - run:
           name: Re-tag artifact
-          command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>
+          command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} mozilla/$CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>
       - docker/push:
-          image: $CIRCLE_PROJECT_REPONAME
+          image: mozilla/$CIRCLE_PROJECT_REPONAME
           tag: << parameters.image_tag >>
 
   sync_gcs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,12 +132,14 @@ jobs:
             - telemetry-airflow.tar
 
 
-  publish-gar:
+  publish-registry:
     executor: docker/machine
     parameters:
       image_tag:
         type: string
         default: latest
+      registry:
+        type: string
     steps:
       - checkout
       - attach_workspace:
@@ -146,10 +148,11 @@ jobs:
           name: Load Docker image artifact from previous job
           command: docker load -i artifacts/telemetry-airflow.tar
       - run:
+          name: Generate image name
+          command: echo 'export IMAGE_NAME="<< parameters.registry >>/telemetry-airflow:<< parameters.image_tag >>' >> "$BASH_ENV"
+      - run:
           name: Re-tag artifact
-          command: |
-            echo 'export IMAGE_NAME="us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow:<< parameters.image_tag >>' >> "$BASH_ENV"
-            docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
+          command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
       - run:
           name: Push image to GAR
           command: docker push $IMAGE_NAME
@@ -212,7 +215,7 @@ workflows:
   publish:
     jobs:
       - docker/publish:
-          name: Push latest to Dockerhub
+          name: Publish latest to Dockerhub
           before_build: &version
             - run:
                 name: Generate build version.json
@@ -234,7 +237,7 @@ workflows:
               only: main
 
       - docker/publish:
-          name: Push tag to Dockerhub
+          name: Publish tag to Dockerhub
           before_build: *version
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
@@ -254,8 +257,10 @@ workflows:
 #            branches:
 #              ignore: /.*/
 
-      - publish-gar:
-          name: Test
+      - publish-registry:
+          name: Publish tag to Dockerhub
+          registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
+#          image_tag: $CIRCLE_TAG
           requires:
             - 🛠️ Docker build and persist image
 #          name: Push tag to GAR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,12 +153,14 @@ jobs:
           name: Re-tag artifact
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
       - run:
-          name: Push image to GAR
+          name: Authenticate GAR
           command: |
             echo $GAR_SERVICE_KEY | base64 -d > creds.json
             gcloud auth activate-service-account --key-file creds.json
             gcloud auth configure-docker us-docker.pkg.dev
-            docker push $IMAGE_NAME
+      - run:
+          name: Push image to GAR
+          command: docker push $IMAGE_NAME
 
   publish-dockerhub:
     executor: docker/machine
@@ -240,6 +242,14 @@ workflows:
 
   publish:
     jobs:
+      - docker-build-artifact:
+          name: 🛠️ Docker build and persist image
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+
       - publish-dockerhub:
           name: Publish latest to Dockerhub
           image_tag: latest
@@ -260,21 +270,12 @@ workflows:
             branches:
               ignore: /.*/
 
-      - docker-build-artifact:
-          name: 🛠️ Docker build and persist image
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              ignore: /.*/
-
       - publish-gar:
           name: Publish tag to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
 #          image_tag: $CIRCLE_TAG
           requires:
             - 🛠️ Docker build and persist image
-#          name: Push tag to GAR
 #          filters:
 #            tags:
 #              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,16 +131,22 @@ jobs:
           paths:
             - telemetry-airflow.tar
 
-  publish-gar:
+  publish-registry:
     executor: docker/machine
     parameters:
       image_tag:
         type: string
-        default: latest
       registry:
         type: string
+      registry_authentication:
+        default: []
+        description: Steps required to authenticate on targeted registry
+        type: steps
     steps:
       - checkout
+      - when:
+          condition: <<parameters.registry_authentication>>
+          steps: <<parameters.registry_authentication>>
       - attach_workspace:
           at: artifacts
       - run:
@@ -148,18 +154,12 @@ jobs:
           command: docker load -i artifacts/telemetry-airflow.tar
       - run:
           name: Generate image name
-          command: echo 'export IMAGE_NAME="<< parameters.registry >>/telemetry-airflow:<< parameters.image_tag >>"' >> "$BASH_ENV"
+          command: echo 'export IMAGE_NAME="<< parameters.registry >>/$CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>"' >> "$BASH_ENV"
       - run:
           name: Re-tag artifact
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
       - run:
-          name: Authenticate GAR
-          command: |
-            echo $GAR_SERVICE_KEY | base64 -d > creds.json
-            gcloud auth activate-service-account --key-file creds.json
-            gcloud auth configure-docker us-docker.pkg.dev
-      - run:
-          name: Push image to GAR
+          name: Push image to registry
           command: docker push $IMAGE_NAME
 
   publish-dockerhub:
@@ -270,9 +270,17 @@ workflows:
             branches:
               ignore: /.*/
 
-      - publish-gar:
+      - publish-registry:
           name: Publish tag to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
+          image_tag: latest
+          registry_authentication: &gar-auth
+            - run:
+                name: Authenticate GAR
+                command: |
+                  echo $GAR_SERVICE_KEY | base64 -d > creds.json
+                  gcloud auth activate-service-account --key-file creds.json
+                  gcloud auth configure-docker us-docker.pkg.dev
 #          image_tag: $CIRCLE_TAG
           requires:
             - 🛠️ Docker build and persist image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,9 +161,11 @@ jobs:
       - run:
           name: Re-tag artifact
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $PARAM_REGISTRY/$IMAGE_NAME:$PARAM_IMAGE_TAG
-      - run:
+      - docker/push:
           name: Push image to registry
-          command: docker push $PARAM_REGISTRY/$IMAGE_NAME:$PARAM_IMAGE_TAG
+          image: $IMAGE_NAME
+          tag: $PARAM_IMAGE_TAG
+          registry: $PARAM_REGISTRY
 
   publish-dockerhub:
     executor: docker/machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,6 @@ jobs:
           name: Output version.json
           command: cat version.json
       - docker/build:
-          cache_from: $CIRCLE_PROJECT_REPONAME:latest
           image: $CIRCLE_PROJECT_REPONAME
           tag: ${CIRCLE_SHA1:0:9}
       - run:
@@ -172,7 +171,6 @@ jobs:
       - docker/check:
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
-      - docker/configure-docker-credentials-store
       - attach_workspace:
           at: artifacts
       - run:
@@ -183,7 +181,6 @@ jobs:
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>
       - docker/push:
           image: $CIRCLE_PROJECT_REPONAME
-          registry: ~
           tag: << parameters.image_tag >>
 
   sync_gcs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,11 +169,20 @@ jobs:
         default: latest
     steps:
       - checkout
+      - docker/check:
+          docker-password: DOCKER_PASS
+          docker-username: DOCKER_USER
       - attach_workspace:
           at: artifacts
       - run:
           name: Load Docker image artifact from previous job
           command: docker load -i artifacts/telemetry-airflow.tar
+      - run:
+          name: Re-tag artifact
+          command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>
+      - docker/push:
+          image: $CIRCLE_PROJECT_REPONAME
+          tag: << parameters.image_tag >>
       - run:
           name: Push image to GAR
           command: |
@@ -240,33 +249,18 @@ workflows:
 
   publish:
     jobs:
-      - docker/publish:
+      - publish-dockerhub:
           name: Publish latest to Dockerhub
-          before_build: &attach-artifact
-            - attach_workspace:
-                at: artifacts
-            - run:
-                name: Load Docker image artifact from previous job
-                command: docker load -i artifacts/telemetry-airflow.tar
-          cache_from: $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}
-          docker-password: DOCKER_PASS
-          docker-username: DOCKER_USER
-          image: mozilla/telemetry-airflow
-          tag: latest
+          image_tag: latest
           requires:
             - 🛠️ Docker build and persist image
 #          filters:
 #            branches:
 #              only: main
 
-      - docker/publish:
+      - publish-dockerhub:
           name: Publish tag to Dockerhub
-          before_build: *attach-artifact
-          cache_from: $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}
-          docker-password: DOCKER_PASS
-          docker-username: DOCKER_USER
-          image: mozilla/telemetry-airflow
-          tag: $CIRCLE_TAG
+          image_tag: $CIRCLE_TAG
           requires:
             - 🛠️ Docker build and persist image
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@
 # DOCKERHUB_REPO - docker hub repo, format: <username>/<repo>
 # DOCKER_USER
 # DOCKER_PASS
+# GAR_SERVICE_KEY
 #
 # GCLOUD_SERVICE_KEY - key for gsutil rsync bootstrap and jobs with gcs
 # GOOGLE_PROJECT_ID - airflow-dataproc
@@ -101,7 +102,6 @@ jobs:
             pip install pip-tools
             pip-compile --quiet
             git diff --exit-code requirements.txt
-            
 
   docker-build-artifact:
     executor: docker/machine
@@ -119,6 +119,7 @@ jobs:
           name: Output version.json
           command: cat version.json
       - docker/build:
+          cache_from: $CIRCLE_PROJECT_REPONAME:latest
           image: $CIRCLE_PROJECT_REPONAME
           tag: ${CIRCLE_SHA1:0:9}
       - run:
@@ -130,7 +131,6 @@ jobs:
           root: artifacts
           paths:
             - telemetry-airflow.tar
-
 
   publish-gar:
     executor: docker/machine
@@ -172,6 +172,7 @@ jobs:
       - docker/check:
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
+      - docker/configure-docker-credentials-store
       - attach_workspace:
           at: artifacts
       - run:
@@ -182,15 +183,8 @@ jobs:
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>
       - docker/push:
           image: $CIRCLE_PROJECT_REPONAME
+          registry: ~
           tag: << parameters.image_tag >>
-      - run:
-          name: Push image to GAR
-          command: |
-            echo $GAR_SERVICE_KEY | base64 -d > creds.json
-            gcloud auth activate-service-account --key-file creds.json
-            gcloud auth configure-docker us-docker.pkg.dev
-            docker push $IMAGE_NAME
-
 
   sync_gcs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ workflows:
             - <<: *version
             - run: echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
           image: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
-          tag: 123
+          tag: "123"
 #          tag: $CIRCLE_TAG
           deploy: false
 #          filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,58 @@ jobs:
             pip install pip-tools
             pip-compile --quiet
             git diff --exit-code requirements.txt
+            
+
+  docker-build-artifact:
+    executor: docker/machine
+    steps:
+      - checkout
+      - run:
+          name: Generate build version.json
+          command: >
+            printf 
+            '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' 
+            "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" 
+            "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" 
+            > version.json
+      - run:
+          name: Output version.json
+          command: cat version.json
+      - docker/build:
+          image: $CIRCLE_PROJECT_REPONAME
+          tag: ${CIRCLE_SHA1:0:9}
+      - run:
+          name: Persist image
+          command: |
+            mkdir -p artifacts
+            docker save -o artifacts/telemetry-airflow.tar $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}
+      - persist_to_workspace:
+          root: artifacts
+          paths:
+            - telemetry-airflow.tar
+
+
+  publish-gar:
+    executor: docker/machine
+    parameters:
+      image_tag:
+        type: string
+        default: latest
+    steps:
+      - checkout
+      - attach_workspace:
+          at: artifacts
+      - run:
+          name: Load Docker image artifact from previous job
+          command: docker load -i artifacts/telemetry-airflow.tar
+      - run:
+          name: Re-tag artifact
+          command: |
+            echo 'export IMAGE_NAME="us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow:<< parameters.image_tag >>' >> "$BASH_ENV"
+            docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
+      - run:
+          name: Push image to GAR
+          command: docker push $IMAGE_NAME
 
   sync_gcs:
     docker:
@@ -127,33 +179,8 @@ workflows:
             tags:
               ignore: /.*/
 
-      - docker/publish:
+      - docker-build-artifact:
           name: 🛠️ Docker build test
-          before_build: &version
-            - run:
-                name: Generate build version.json
-                command: >
-                  printf 
-                  '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' 
-                  "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" 
-                  "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" 
-                  > version.json
-            - run:
-                name: Output version.json
-                command: cat version.json
-          after_build:
-            - run:
-                name: Persist image
-                command: |
-                  mkdir -p artifacts
-                  docker save -o artifacts/telemetry-airflow.tar $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}
-            - persist_to_workspace:
-                root: artifacts
-                paths:
-                  - telemetry-airflow.tar
-          deploy: false
-          image: $CIRCLE_PROJECT_REPONAME
-          tag: ${CIRCLE_SHA1:0:9}
           filters: *ci-filter
           requires:
             - 🧪 Validate requirements
@@ -186,7 +213,18 @@ workflows:
     jobs:
       - docker/publish:
           name: Push latest to Dockerhub
-          before_build: *version
+          before_build: &version
+            - run:
+                name: Generate build version.json
+                command: >
+                  printf 
+                  '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' 
+                  "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" 
+                  "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" 
+                  > version.json
+            - run:
+                name: Output version.json
+                command: cat version.json
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
           image: mozilla/telemetry-airflow
@@ -208,15 +246,19 @@ workflows:
             branches:
               ignore: /.*/
 
-      - docker/publish:
-          name: Push tag to GAR
-          before_build:
-            - <<: *version
-            - run: echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
-          image: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
-          tag: "latest"
-#          tag: $CIRCLE_TAG
-#          deploy: false
+      - docker-build-artifact:
+          name: 🛠️ Docker build and persist image
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              ignore: /.*/
+
+      - publish-gar:
+          name: Test
+          requires:
+            - 🛠️ Docker build and persist image
+#          name: Push tag to GAR
 #          filters:
 #            tags:
 #              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,12 +46,7 @@ jobs:
             sed -i "s/  build: ./  image: $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}/g" docker-compose.yml
       - run:
           name: Start up local environment
-          command: |
-            echo "AIRFLOW_UID=$(id -u)" >> .env
-            echo "FERNET_KEY=$(python3 -c "from cryptography.fernet import Fernet; fernet_key = Fernet.generate_key(); print(fernet_key.decode())")" >> .env
-            docker-compose up --wait
-            docker-compose exec airflow-webserver airflow variables import dev_variables.json
-            docker-compose exec airflow-webserver airflow connections import dev_connections.json
+          command: make up
 
   black:
     executor: *python-executor
@@ -225,11 +220,11 @@ workflows:
     jobs:
       - docker-build-artifact:
           name: 🛠️ Docker build and persist image
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              ignore: /.*/
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
 
       - publish-registry:
           name: Publish latest to Dockerhub
@@ -241,9 +236,9 @@ workflows:
                 docker-username: DOCKER_USER
           requires:
             - 🛠️ Docker build and persist image
-#          filters:
-#            branches:
-#              only: main
+          filters:
+            branches:
+              only: main
 
       - publish-registry:
           name: Publish tag to Dockerhub
@@ -285,9 +280,9 @@ workflows:
           registry_authentication: *gar-auth
           requires:
             - 🛠️ Docker build and persist image
-#          filters:
-#            branches:
-#              only: main
+          filters:
+            branches:
+              only: main
 
       - sync_gcs:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,14 +213,14 @@ workflows:
           before_build:
             - <<: *version
             - run: echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
-          image: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
-          tag: $CIRCLE_TAG
-          deploy: false
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+          registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod
+          image: telemetry-airflow-prod/telemetry-airflow
+          tag: "latest"
+#          filters:
+#            tags:
+#              only: /.*/
+#            branches:
+#              ignore: /.*/
 
       - sync_gcs:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
             - telemetry-airflow.tar
 
 
-  publish-registry:
+  publish-gar:
     executor: docker/machine
     parameters:
       image_tag:
@@ -155,7 +155,9 @@ jobs:
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
       - run:
           name: Push image to GAR
-          command: docker push $IMAGE_NAME
+          command: |
+            echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
+            docker push $IMAGE_NAME
 
   sync_gcs:
     docker:
@@ -257,7 +259,7 @@ workflows:
 #            branches:
 #              ignore: /.*/
 
-      - publish-registry:
+      - publish-gar:
           name: Publish tag to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
 #          image_tag: $CIRCLE_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,8 +213,8 @@ workflows:
           before_build:
             - <<: *version
             - run: echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
-          registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod
-          image: telemetry-airflow-prod/telemetry-airflow
+          registry: us-docker.pkg.dev
+          image: moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
           tag: "latest"
 #          filters:
 #            tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,9 +213,10 @@ workflows:
           before_build:
             - <<: *version
             - run: echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
-          registry: us-docker.pkg.dev
-          image: moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
+          image: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod/telemetry-airflow
           tag: "latest"
+#          tag: $CIRCLE_TAG
+#          deploy: false
 #          filters:
 #            tags:
 #              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,13 +154,16 @@ jobs:
           command: docker load -i artifacts/telemetry-airflow.tar
       - run:
           name: Generate image name
-          command: echo 'export IMAGE_NAME="<< parameters.registry >>/$CIRCLE_PROJECT_REPONAME:<< parameters.image_tag >>"' >> "$BASH_ENV"
+          command: |
+            echo 'export PARAM_REGISTRY="<< parameters.registry >>"' >> "$BASH_ENV"
+            echo 'export PARAM_IMAGE_TAG="<< parameters.image_tag >>"' >> "$BASH_ENV"
+            echo 'export IMAGE_NAME="$CIRCLE_PROJECT_REPONAME"' >> "$BASH_ENV"
       - run:
           name: Re-tag artifact
-          command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $IMAGE_NAME
+          command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $PARAM_REGISTRY/$IMAGE_NAME:$PARAM_IMAGE_TAG
       - run:
           name: Push image to registry
-          command: docker push $IMAGE_NAME
+          command: docker push $PARAM_REGISTRY/$IMAGE_NAME:$PARAM_IMAGE_TAG
 
   publish-dockerhub:
     executor: docker/machine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,9 @@ jobs:
       - run:
           name: Push image to GAR
           command: |
-            echo $GAR_SERVICE_KEY | docker login -u _json_key_base64 --password-stdin https://us-docker.pkg.dev
+            echo $GAR_SERVICE_KEY | base64 -d > creds.json
+            gcloud auth activate-service-account --key-file creds.json
+            gcloud auth configure-docker us-docker.pkg.dev
             docker push $IMAGE_NAME
 
   sync_gcs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
           name: Re-tag artifact
           command: docker tag $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9} $PARAM_REGISTRY/$IMAGE_NAME:$PARAM_IMAGE_TAG
       - docker/push:
-          name: Push image to registry
+          step-name: Push image to registry
           image: $IMAGE_NAME
           tag: $PARAM_IMAGE_TAG
           registry: $PARAM_REGISTRY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,28 @@ jobs:
             gcloud auth configure-docker us-docker.pkg.dev
             docker push $IMAGE_NAME
 
+  publish-dockerhub:
+    executor: docker/machine
+    parameters:
+      image_tag:
+        type: string
+        default: latest
+    steps:
+      - checkout
+      - attach_workspace:
+          at: artifacts
+      - run:
+          name: Load Docker image artifact from previous job
+          command: docker load -i artifacts/telemetry-airflow.tar
+      - run:
+          name: Push image to GAR
+          command: |
+            echo $GAR_SERVICE_KEY | base64 -d > creds.json
+            gcloud auth activate-service-account --key-file creds.json
+            gcloud auth configure-docker us-docker.pkg.dev
+            docker push $IMAGE_NAME
+
+
   sync_gcs:
     docker:
       - image: gcr.io/google.com/cloudsdktool/cloud-sdk:323.0.0
@@ -220,33 +242,33 @@ workflows:
     jobs:
       - docker/publish:
           name: Publish latest to Dockerhub
-          before_build: &version
+          before_build: &attach-artifact
+            - attach_workspace:
+                at: artifacts
             - run:
-                name: Generate build version.json
-                command: >
-                  printf 
-                  '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' 
-                  "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" 
-                  "$CIRCLE_PROJECT_REPONAME" "$CIRCLE_BUILD_URL" 
-                  > version.json
-            - run:
-                name: Output version.json
-                command: cat version.json
+                name: Load Docker image artifact from previous job
+                command: docker load -i artifacts/telemetry-airflow.tar
+          cache_from: $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
           image: mozilla/telemetry-airflow
           tag: latest
-          filters:
-            branches:
-              only: main
+          requires:
+            - 🛠️ Docker build and persist image
+#          filters:
+#            branches:
+#              only: main
 
       - docker/publish:
           name: Publish tag to Dockerhub
-          before_build: *version
+          before_build: *attach-artifact
+          cache_from: $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}
           docker-password: DOCKER_PASS
           docker-username: DOCKER_USER
           image: mozilla/telemetry-airflow
           tag: $CIRCLE_TAG
+          requires:
+            - 🛠️ Docker build and persist image
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
# Description
This PR adds image pushing to Google Artifact Registry (GAR) in preparation of the migration from `cloudops-infra` to `dataservices`. 

- Modified `docker-build-artifact` job to reuse the same job in the CI and CD workflows
- Add `publish-registry` to support pushing to GCR and GAR using the same job with different parameters
- Convert `publish-dockerhub` jobs to use `publish-registry` instead
- Add workflows to push tagged and untagged releases (latest) to GAR
- Use `make up` instead of duplicating logic for `docker-compose` integration test

# Validation
:point_right:  [Successful publish jobs](https://app.circleci.com/pipelines/github/mozilla/telemetry-airflow/3836/workflows/6b96d518-34fd-41c6-bfb3-553e74cad6cc) pushing latest on GAR and GCR
`latest: digest: sha256:5a1128a3055a5db6530fed4b6744d3f0372954cfde271fe1d1bd4f29bcafc830`
![image](https://user-images.githubusercontent.com/1668835/226463837-ae90ce40-4b94-41a7-9651-7b359e3b93df.png)
![image](https://user-images.githubusercontent.com/1668835/226464171-bda68d65-4495-4413-a93c-4b0bb90b4ef5.png)

# Related Jira Ticket
* https://mozilla-hub.atlassian.net/browse/DSRE-1232