### PR TITLE
glam-dev: switching back to subdag for hist bucket counts 

### DIFF
--- a/dags/glam_dev.py
+++ b/dags/glam_dev.py
@@ -31,7 +31,9 @@ default_args = {
     "owner": "efilho@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 10, 22),
-    "email": ["efilho@mozilla.com",],
+    "email": [
+        "efilho@mozilla.com",
+    ],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 1,
@@ -286,7 +288,7 @@ client_scalar_probe_counts = gke_command(
     dag=dag,
 )
 
-# Testing without SubDag because it keeps getting stuck on "running"
+# Testing without subdag because it keeps getting stuck on "running"
 # and not actually executing anything. Also, they're known for causing deadlocks in
 # Celelery (might be our case) thus are discouraged.
 # clients_histogram_bucket_counts = bigquery_etl_query(


### PR DESCRIPTION
This has no prod impact. This is how the original glam etl dag works and is done to avoid exceeding resources on BQ. I'm test running the step `histogram_bucket_counts` on version-partitioned and clustered tables with a full dataset and it's exceeding resources, so I'm switching back to subdags.

Subdags are originally here to avoid one single step that processes too much data. In the past I made this a single step because I was testing with a sampled dataset. Now since I'm back testing with the full dataset I need the subdags back. 