### PR TITLE
Add production step for wikipedia indexing

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -73,15 +73,15 @@ with DAG(
             "--gcs-path",
             "moz-fx-data-prod-external-data/contextual-services/merino-jobs/wikipedia-exports",
             "--gcp-project",
-            "moz-fx-data-shared-nonprod",
+            "moz-fx-data-shared-prod",
         ],
         env_vars={
-            "MERINO_ENV": "staging",
+            "MERINO_ENV": "production",
         },
     )
 
     wikipedia_indexer_build_index_for_staging = merino_job(
-        "wikipedia_indexer_build_index",
+        "wikipedia_indexer_build_index_staging",
         arguments=[
             "wikipedia-indexer",
             "index",
@@ -97,14 +97,14 @@ with DAG(
             "moz-fx-data-shared-nonprod",
         ],
         env_vars={
-            "MERINO_ENV": "staging",
+            "MERINO_ENV": "production",
             # Using the API key in the argument list leaks the sensitive data into the airflow UI.
             "MERINO_JOBS__WIKIPEDIA_INDEXER__ES_API_KEY": staging_connection.password,
         },
     )
 
     wikipedia_indexer_build_index_for_prod = merino_job(
-        "wikipedia_indexer_build_index",
+        "wikipedia_indexer_build_index_production",
         arguments=[
             "wikipedia-indexer",
             "index",

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -126,4 +126,7 @@ with DAG(
         },
     )
 
-    wikipedia_indexer_copy_export >> [wikipedia_indexer_build_index_for_staging, wikipedia_indexer_build_index_for_prod]
+    wikipedia_indexer_copy_export >> [
+        wikipedia_indexer_build_index_for_staging,
+        wikipedia_indexer_build_index_for_prod,
+    ]

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -126,4 +126,4 @@ with DAG(
         },
     )
 
-    wikipedia_indexer_copy_export_to_production >> [wikipedia_indexer_build_index_for_staging, wikipedia_indexer_build_index_for_prod]
+    wikipedia_indexer_copy_export >> [wikipedia_indexer_build_index_for_staging, wikipedia_indexer_build_index_for_prod]

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -94,7 +94,7 @@ with DAG(
             "--gcs-path",
             "moz-fx-data-prod-external-data/contextual-services/merino-jobs/wikipedia-exports",
             "--gcp-project",
-            "moz-fx-data-shared-nonprod",
+            "moz-fx-data-shared-prod",
         ],
         env_vars={
             "MERINO_ENV": "production",

--- a/resources/dev_connections.json
+++ b/resources/dev_connections.json
@@ -149,9 +149,19 @@
     "schema": null,
     "extra": null
   },
-  "merino_elasticsearch": {
+  "merino_elasticsearch_stage": {
     "conn_type": "http",
-    "description": "Used to authenticate into Merino Elasticsearch cluster",
+    "description": "Used to authenticate into the staging Merino Elasticsearch cluster",
+    "login": "",
+    "password": null,
+    "host": "",
+    "port": null,
+    "schema": null,
+    "extra": "{\"refresh_token\": \"dummy_refresh_token\"}"
+  },
+  "merino_elasticsearch_prod": {
+    "conn_type": "http",
+    "description": "Used to authenticate into the production Merino Elasticsearch cluster",
     "login": "",
     "password": null,
     "host": "",


### PR DESCRIPTION
Merino needs the wikipedia index in both staging and production! This PR updates the Airflow configuration to add the production task.

The flow is that after the wikipedia index file gets copied over to GCS, both staging AND prod indexing can happen in parallel.

If someone close to the project could please check my math on which arguments needed to be switched to what for the staging job relative to prod, I'd be eternally grateful! 