### PR TITLE
docs(): updating airflow triage reference link + black formatting on mozmenu.py

### DIFF
--- a/plugins/mozmenu.py
+++ b/plugins/mozmenu.py
@@ -6,17 +6,16 @@ https://github.com/airflow-plugins/Getting-Started/blob/master/Tutorial/creating
 """
 from airflow.plugins_manager import AirflowPlugin
 
-
 telemetry_airflow = {
     "name": "telemetry-airflow on GitHub",
     "category": "Mozilla",
-    "href": "https://github.com/mozilla/telemetry-airflow"
+    "href": "https://github.com/mozilla/telemetry-airflow",
 }
 
 wtmo_dev = {
     "name": "WTMO Developer Guide",
     "category": "Mozilla",
-    "href": "https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922811/WTMO+Developer+Guide"
+    "href": "https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922811/WTMO+Developer+Guide",
 }
 
 airflow_triage_guide = {

--- a/plugins/mozmenu.py
+++ b/plugins/mozmenu.py
@@ -22,7 +22,7 @@ wtmo_dev = {
 airflow_triage_guide = {
     "name": "Airflow Triage Guide",
     "category": "Mozilla",
-    "href": "https://mana.mozilla.org/wiki/display/DATA/Airflow+Triage+Process",
+    "href": "https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/175603730/Airflow+Triage+Guide",
 }
 
 


### PR DESCRIPTION
# docs(): updating airflow triage reference link + black formatting on mozmenu.py

