### PR TITLE
 glam - revert bucket_counts subtask count to 25

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -268,7 +268,7 @@ clients_histogram_bucket_counts = SubDagOperator(
         dag.schedule_interval,
         dataset_id,
         ("submission_date:DATE:{{ds}}",),
-        10,
+        25,
         None,
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/glam-dev-bigquery-etl:latest",
     ),


### PR DESCRIPTION
Before I roll back all the changes that attempt to make this etl faster I want to give it another shot by switching the subtask count from 10 back to 25, because previous tests showed potential improvements there too.