### PR TITLE
glam - bucket_counts 10 substeps for another execution

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -268,7 +268,7 @@ clients_histogram_bucket_counts = SubDagOperator(
         dag.schedule_interval,
         dataset_id,
         ("submission_date:DATE:{{ds}}",),
-        25,
+        10,
         None,
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/glam-dev-bigquery-etl:latest",
     ),


### PR DESCRIPTION
Upon discussion we want to see this thing running again with 10 substeps for result consistency sake.