### PR TITLE
Add no_triage tag to glam_dev DAG

### DIFF
--- a/dags/glam_dev.py
+++ b/dags/glam_dev.py
@@ -44,7 +44,10 @@ GLAM_DAG = "glam-dev"
 GLAM_CLIENTS_HISTOGRAM_AGGREGATES_SUBDAG = "clients_histogram_aggregates"
 PERCENT_RELEASE_WINDOWS_SAMPLING = "10"
 
-tags = [Tag.ImpactTier.tier_3]
+tags = [
+    Tag.ImpactTier.tier_3,
+    Tag.Triage.no_triage,
+]
 
 dag = DAG(
     GLAM_DAG,


### PR DESCRIPTION
This is consistent with the DAG doc that says `Please disregard any failures from this DAG. It is being monitored by efilho`