### PR TITLE
add dataset to run args

### DIFF
--- a/dags/experiment_auto_sizing.py
+++ b/dags/experiment_auto_sizing.py
@@ -46,7 +46,8 @@ with DAG(
         arguments=[
             "--log-to-bigquery",
             "run-argo",
-            "--bucket=auto-sizing",
+            "--bucket=auto_sizing",
+            "--dataset-id=auto_sizing",
             # the Airflow cluster doesn't have Compute Engine API access so pass in IP
             # and certificate in order for the pod to connect to the Kubernetes cluster
             # running Jetstream/auto-sizing


### PR DESCRIPTION
Config for running the auto_sizing image was missing the required `dataset-id` parameter.