### PR TITLE
Bugzilla-1830328: Resolve blurry top pick favicons

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -145,6 +145,8 @@ with DAG(
             "--dst-cdn-hostname",
             "stagepy-images.merino.nonprod.cloudops.mozgcp.net",
             "--force-upload",
+            "--min-favicon-width",
+            "52",
         ],
     )
 
@@ -162,6 +164,8 @@ with DAG(
             "--dst-cdn-hostname",
             "merino-images.services.mozilla.com",
             "--force-upload",
+            "--min-favicon-width",
+            "52",
         ],
     )
 


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1830328

Added cli option "--min-favicon-width" and set it to 52 for both staging and prod environment