### PR TITLE
Fix update_orphaning job

### DIFF
--- a/dags/update_orphaning_dashboard_etl.py
+++ b/dags/update_orphaning_dashboard_etl.py
@@ -24,7 +24,7 @@ default_args = {
     "owner": "akomar@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 10, 12),
-    "email": ["telemetry-alerts@mozilla.com", "rstrong@mozilla.com", "akomar@mozilla.com"],
+    "email": ["telemetry-alerts@mozilla.com", "ahabibi@mozilla.com", "akomar@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,

--- a/dags/update_orphaning_dashboard_etl.py
+++ b/dags/update_orphaning_dashboard_etl.py
@@ -1,14 +1,14 @@
 """
-Powers https://telemetry.mozilla.org/update-orphaning/
+Powers https://telemetry.mozilla.org/update-orphaning/.
 
 See [jobs/update_orphaning_dashboard_etl.py](https://github.com/mozilla/telemetry-airflow/blob/main/jobs/update_orphaning_dashboard_etl.py).
 """
 
-from airflow import DAG
-from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
-from airflow.operators.subdag import SubDagOperator
 from datetime import datetime, timedelta
 
+from airflow import DAG
+from airflow.operators.subdag import SubDagOperator
+from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from utils.constants import DS_WEEKLY
 from utils.dataproc import moz_dataproc_pyspark_runner
 from utils.tags import Tag
@@ -24,7 +24,11 @@ default_args = {
     "owner": "akomar@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 10, 12),
-    "email": ["telemetry-alerts@mozilla.com", "ahabibi@mozilla.com", "akomar@mozilla.com"],
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "ahabibi@mozilla.com",
+        "akomar@mozilla.com",
+    ],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
@@ -43,40 +47,55 @@ dag = DAG(
 )
 
 # Unsalted cluster name so subsequent runs fail if the cluster name exists
-cluster_name = 'app-update-out-of-date-dataproc-cluster'
+cluster_name = "app-update-out-of-date-dataproc-cluster"
 
 # Defined in Airflow's UI -> Admin -> Connections
-gcp_conn_id = 'google_cloud_airflow_dataproc'
+gcp_conn_id = "google_cloud_airflow_dataproc"
 
 # Required to write json output back to s3://telemetry-public-analysis-2/app-update/data/out-of-date/
-write_aws_conn_id='aws_dev_telemetry_public_analysis_2_rw'
+write_aws_conn_id = "aws_dev_telemetry_public_analysis_2_rw"
 aws_access_key, aws_secret_key, session = AwsBaseHook(
-    aws_conn_id=write_aws_conn_id, client_type='s3').get_credentials()
+    aws_conn_id=write_aws_conn_id, client_type="s3"
+).get_credentials()
 
 crash_report_parquet = SubDagOperator(
     task_id="update_orphaning_dashboard_etl",
     dag=dag,
-    subdag = moz_dataproc_pyspark_runner(
+    subdag=moz_dataproc_pyspark_runner(
         parent_dag_name=dag.dag_id,
         dag_name="update_orphaning_dashboard_etl",
         default_args=default_args,
         cluster_name=cluster_name,
         job_name="update_orphaning_dashboard_etl",
         python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/update_orphaning_dashboard_etl.py",
-        init_actions_uris=["gs://dataproc-initialization-actions/python/pip-install.sh"],
-        additional_metadata={'PIP_PACKAGES': "google-cloud-bigquery==1.20.0 google-cloud-storage==1.19.1 boto3==1.9.253"},
-        additional_properties={"spark:spark.jars.packages": "org.apache.spark:spark-avro_2.11:2.4.3"},
+        init_actions_uris=[
+            "gs://dataproc-initialization-actions/python/pip-install.sh"
+        ],
+        additional_metadata={
+            "PIP_PACKAGES": "google-cloud-bigquery==1.20.0 google-cloud-storage==1.19.1 boto3==1.9.253"
+        },
+        additional_properties={
+            "spark:spark.jars.packages": "org.apache.spark:spark-avro_2.11:2.4.3"
+        },
         py_args=[
-            "--run-date", DS_WEEKLY,
-            "--gcs-bucket", "mozdata-analysis",
-            "--gcs-prefix", "update-orphaning-airflow",
-            "--s3-output-bucket", "telemetry-public-analysis-2",
-            "--s3-output-path", "app-update/data/out-of-date/",
-            "--aws-access-key-id", aws_access_key,
-            "--aws-secret-access-key", aws_secret_key
+            "--run-date",
+            DS_WEEKLY,
+            "--gcs-bucket",
+            "mozdata-analysis",
+            "--gcs-prefix",
+            "update-orphaning-airflow",
+            "--s3-output-bucket",
+            "telemetry-public-analysis-2",
+            "--s3-output-path",
+            "app-update/data/out-of-date/",
+            "--aws-access-key-id",
+            aws_access_key,
+            "--aws-secret-access-key",
+            aws_secret_key,
         ],
         idle_delete_ttl=14400,
         num_workers=20,
-        worker_machine_type='n1-standard-8',
-        gcp_conn_id=gcp_conn_id)
+        worker_machine_type="n1-standard-8",
+        gcp_conn_id=gcp_conn_id,
+    ),
 )

--- a/jobs/update_orphaning_dashboard_etl.py
+++ b/jobs/update_orphaning_dashboard_etl.py
@@ -415,21 +415,21 @@ common_where_sql
 # Create the SQL for the summary query.
 summary_sql = (""
 "SELECT "
-    "COUNT(CASE WHEN build.major_version[0] >= '{}.' AND build.major_version[0] < '{}.' THEN 1 END) AS versionUpToDate, "
-    "COUNT(CASE WHEN build.major_version[0] < '{}.' AND build.major_version[0] >= '{}.' THEN 1 END) AS versionOutOfDate, "
-    "COUNT(CASE WHEN build.major_version[0] < '{}.' THEN 1 END) AS versionTooLow, "
-    "COUNT(CASE WHEN build.major_version[0] > '{}.' THEN 1 END) AS versionTooHigh, "
-    "COUNT(CASE WHEN NOT build.major_version[0] > '0' THEN 1 END) AS versionMissing "
+    "COUNT(CASE WHEN build.major_version[0] >= {} AND build.major_version[0] < {} THEN 1 END) AS versionUpToDate, "
+    "COUNT(CASE WHEN build.major_version[0] < {} AND build.major_version[0] >= {} THEN 1 END) AS versionOutOfDate, "
+    "COUNT(CASE WHEN build.major_version[0] < {} THEN 1 END) AS versionTooLow, "
+    "COUNT(CASE WHEN build.major_version[0] > {} THEN 1 END) AS versionTooHigh, "
+    "COUNT(CASE WHEN NOT build.major_version[0] > 0 THEN 1 END) AS versionMissing "
 "{} "
 "WHERE "
     "{} AND "
     "{}"
-"").format(str(latest_version - up_to_date_releases),
-           str(latest_version + 2),
-           str(latest_version - up_to_date_releases),
-           str(min_version),
-           str(min_version),
-           str(latest_version + 2),
+"").format(latest_version - up_to_date_releases,
+           latest_version + 2,
+           latest_version - up_to_date_releases,
+           min_version,
+           min_version,
+           latest_version + 2,
            longitudinal_from_sql,
            common_where_sql,
            build_version_where_sql)
@@ -489,13 +489,13 @@ out_of_date_details_sql = (""
 "WHERE "
     "{} AND "
     "{} AND "
-    "build.major_version[0] < '{}.' AND "
-    "build.major_version[0] >= '{}.'"
+    "build.major_version[0] < {} AND "
+    "build.major_version[0] >= {}"
 "").format(longitudinal_from_sql,
            common_where_sql,
            build_version_where_sql,
-           str(latest_version - up_to_date_releases),
-           str(min_version))
+           latest_version - up_to_date_releases,
+           min_version)
 out_of_date_details_sql
 
 

--- a/jobs/update_orphaning_dashboard_etl.py
+++ b/jobs/update_orphaning_dashboard_etl.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding: utf-8
 
+# flake8: noqa
+# fmt: off
+# This is a complex, legacy job. Disabling linter will make browsing history of changes easier.
+
 import argparse
 import boto3
 import datetime as dt
@@ -237,7 +241,7 @@ def longitudinal_shim_transform(project, dataset, table):
         destination_uri,
         location="US",
         job_config=job_config
-    )  
+    )
     extract_job.result()  # Waits for job to complete.
 
     print(
@@ -344,10 +348,10 @@ aggregation_to = max_report_date.strftime("%Y-%m-%d")
 aggregation_from = (max_report_date - dt.timedelta(days=6*31)).strftime("%Y-%m-%d")
 
 longitudinal_shim_aggregate(date_from=aggregation_from, date_to=aggregation_to,
-                                destination_project=AGGREGATION_TABLE_PROJECT, 
+                                destination_project=AGGREGATION_TABLE_PROJECT,
                                 destination_dataset=AGGREGATION_TABLE_DATASET, destination_table=AGGREGATION_TABLE_NAME)
 
-longitudinal_shim_transform(project=AGGREGATION_TABLE_PROJECT, 
+longitudinal_shim_transform(project=AGGREGATION_TABLE_PROJECT,
                                 dataset=AGGREGATION_TABLE_DATASET, table=AGGREGATION_TABLE_NAME)
 
 ####################################### END LONGITUDINAL SHIM ##########################################################
@@ -681,7 +685,7 @@ def is_supported_mapper(d):
                 return False, ping
 
         index += 1
-        
+
     return True, ping
 
 is_supported_rdd = has_min_update_ping_count_true_rdd.map(is_supported_mapper).cache()
@@ -696,7 +700,7 @@ is_supported_true_rdd = is_supported_rdd.filter(lambda p: p[0] == True).values()
 
 
 # Create an RDD of out of date telemetry pings that have and don't have
-# the ability to apply an update along with a dictionary of the count 
+# the ability to apply an update along with a dictionary of the count
 # of True and False.
 def is_able_to_apply_mapper(d):
     ping = d
@@ -771,7 +775,7 @@ of_concern_dict = has_update_enabled_dict
 
 # Create an RDD of the telemetry pings that have the
 # application.update.enabled preference set to True.
-# 
+#
 # This RDD is created from the last "out of date, potentially of concern"
 # RDD and it is named of_concern_true_rdd to simplify the addition of new code
 # without having to modify consumers of the RDD.
@@ -1184,7 +1188,7 @@ results_json = results_json.replace('"true"', '"True"').replace('"false"', '"Fal
 # Save the output to be uploaded automatically once the job completes.
 # The file will be stored at:
 # * https://analysis-output.telemetry.mozilla.org/app-update/data/out-of-date/FILENAME
-    
+
 bucket = args.s3_output_bucket #"telemetry-public-analysis-2"
 path = args.s3_output_path #"app-update/data/out-of-date/"
 timestamped_s3_key = path + report_filename + ".json"
@@ -1204,3 +1208,4 @@ print("End: " + str(end_time.strftime("%Y-%m-%d %H:%M:%S")))
 # Get the elapsed time it took to run this job.
 elapsed_time = end_time - start_time
 print("Elapsed Seconds: " + str(int(elapsed_time.total_seconds())))
+# fmt: on


### PR DESCRIPTION
This uses `mozfun.norm.truncate_version` to extract major version number and use it in subsequent version comparisons.

This is a legacy job that used the longitudinal dataset and back in the day was ported to BQ with a shim function. The approach taken here seems to be the simplest one allowing to minimize risk of breaking things. I have tested this in a sandbox cluster and confirmed that as far as I can tell reasonable statistics are now generated.