### PR TITLE
fix(ci): pin docker-compose version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ jobs:
             sed -i "s/  build: ./  image: $CIRCLE_PROJECT_REPONAME:${CIRCLE_SHA1:0:9}/g" docker-compose.yml
       - run:
           name: Start up local environment
-          command: make up
+          command: |
+            pip3 install cryptography -c constraints.txt
+            make up
 
   black:
     executor: *python-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: artifacts
-      - docker/install-docker-compose
+      - docker/install-docker-compose:
+          version: v2.17.3
       - run:
           name: Load Docker image artifact from previous job
           command: docker load -i artifacts/telemetry-airflow.tar

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ stop:
 
 up:
 	grep -qF 'AIRFLOW_UID=' .env || echo "AIRFLOW_UID=$$(id -u)" >> .env
-	grep -qF 'FERNET_KEY=' .env || echo "FERNET_KEY=$$(python -c "from cryptography.fernet import Fernet; fernet_key = Fernet.generate_key(); print(fernet_key.decode())")" >> .env
+	grep -qF 'FERNET_KEY=' .env || echo "FERNET_KEY=$$(python3 -c "from cryptography.fernet import Fernet; fernet_key = Fernet.generate_key(); print(fernet_key.decode())")" >> .env
 	docker-compose up --wait
 	docker-compose exec airflow-webserver airflow variables import dev_variables.json
 	docker-compose exec airflow-webserver airflow connections import dev_connections.json


### PR DESCRIPTION
# Description
Docker-compose v2.18.0 released a couple of hours ago and introduced a regression with our usage of `image` in `docker-compose.yaml`. We don't know when they'll fix it, so were pinning to the previous version for now.

Also fixes Fernet key generation which has been silently failing in CI probably since it was introduced.