### PR TITLE
feat(DENG-794): added mobile apps to the active_users_aggregates DAG

### DIFF
--- a/dags/dim_active_users_aggregates.py
+++ b/dags/dim_active_users_aggregates.py
@@ -40,7 +40,16 @@ IMAGE = "gcr.io/moz-fx-data-airflow-prod-88e0/dim:latest"
 Config = namedtuple("Config", "exec_date apps")
 CONFIGS = {
     "desktop": Config("{{ ds }}", ("firefox_desktop",)),
-    # "mobile": Config("{{ macros.ds_add(ds, -1) }}", ("firefox_ios", "fenix",)),
+    "mobile": Config(
+        "{{ macros.ds_add(ds, -1) }}",
+        (
+            "fenix",
+            "focus_android",
+            "firefox_ios",
+            "focus_ios",
+            "klar_ios",
+        ),
+    ),
 }
 
 PROJECT_ID = "mozdata"


### PR DESCRIPTION
# feat(DENG-794): added mobile apps to the active_users_aggregates DAG

The following mobile apps are being added:

- fenix
- focus_android
- firefox_ios
- focus_ios

This PR depends on:

- https://github.com/mozilla/dim/pull/85
- https://github.com/mozilla/dim/pull/84
- https://github.com/mozilla/dim/pull/83
- https://github.com/mozilla/dim/pull/81