### PR TITLE
Glam non norm agg

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -268,11 +268,28 @@ clients_histogram_bucket_counts = SubDagOperator(
         dag.schedule_interval,
         dataset_id,
         ("submission_date:DATE:{{ds}}",),
-        10,
+        20,
         None,
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     ),
     task_id="clients_histogram_bucket_counts",
+    dag=dag,
+)
+
+clients_non_norm_histogram_bucket_counts = SubDagOperator(
+    subdag=repeated_subdag(
+        GLAM_DAG,
+        "clients_non_norm_histogram_bucket_counts",
+        default_args,
+        dag.schedule_interval,
+        dataset_id,
+        ("submission_date:DATE:{{ds}}",),
+        20,
+        None,
+        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
+        parallel=False,
+    ),
+    task_id="clients_non_norm_histogram_bucket_counts",
     dag=dag,
 )
 
@@ -340,11 +357,13 @@ clients_daily_histogram_aggregates_gpu >> clients_histogram_aggregates
 clients_daily_keyed_histogram_aggregates >> clients_histogram_aggregates
 
 clients_histogram_aggregates >> clients_histogram_bucket_counts
+clients_histogram_aggregates >> clients_non_norm_histogram_bucket_counts
 clients_histogram_aggregates >> glam_user_counts
 clients_histogram_aggregates >> glam_sample_counts
 
 
 clients_histogram_bucket_counts >> clients_histogram_probe_counts
+clients_non_norm_histogram_bucket_counts >> clients_histogram_probe_counts
 clients_histogram_probe_counts >> histogram_percentiles
 
 clients_scalar_aggregates >> glam_user_counts


### PR DESCRIPTION
Adds a non-normalized aggregation step and increases the number of `bucket_counts` tasks to 20 to avoid `out of slots` error