### PR TITLE
[DENG-1003] Decommission Fivetran Intacct Sync

### DIFF
--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -33,7 +33,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-tags = [Tag.ImpactTier.tier_1, "repo/telemetry-airflow", "decommissioned"]
+tags = [Tag.ImpactTier.tier_1, "repo/telemetry-airflow"]
 
 list_of_connectors = {
     "moz": "decently_wouldst",

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -35,52 +35,51 @@ default_args = {
 
 tags = [Tag.ImpactTier.tier_1, "repo/telemetry-airflow", "decommissioned"]
 
-list_of_connectors ={
-  "moz": "decently_wouldst",
-  "germany": "backslid_mumps",
-  "nz": "bok_chronicler",
-  "france": "inst_panel",
-  "pocket": "hallucinations_tipper",
-  "taiwan": "lien_menace",
-  "australia": "rally_screening",
-  "denmark": "disparate_crib",
-  "finland": "tick_rippling",
-  "sweden": "dignity_palatable",
-  "spain": "prophecy_original",
-  "china_vie": "sifted_ale",
-  "netherlands": "slow_congestive",
-  "china_wofe": "readable_circumscribed",
-  "belgium": "wiser_admit",
-  "canada": "longevity_capturing",
-  "uk": "toy_tribute"
+list_of_connectors = {
+    "moz": "decently_wouldst",
+    "germany": "backslid_mumps",
+    "nz": "bok_chronicler",
+    "france": "inst_panel",
+    "pocket": "hallucinations_tipper",
+    "taiwan": "lien_menace",
+    "australia": "rally_screening",
+    "denmark": "disparate_crib",
+    "finland": "tick_rippling",
+    "sweden": "dignity_palatable",
+    "spain": "prophecy_original",
+    "china_vie": "sifted_ale",
+    "netherlands": "slow_congestive",
+    "china_wofe": "readable_circumscribed",
+    "belgium": "wiser_admit",
+    "canada": "longevity_capturing",
+    "uk": "toy_tribute",
 }
 
 with DAG(
-    'fivetran_intacct_historical',
+    "fivetran_intacct_historical",
     default_args=default_args,
     doc_md=docs,
     schedule_interval="0 2 * * *",
     tags=tags,
 ) as dag:
-
     fivetran_sensors_complete = EmptyOperator(
-        task_id='intacct-fivetran-sensors-complete',
+        task_id="intacct-fivetran-sensors-complete",
     )
 
     for location, connector_id in list_of_connectors.items():
         fivetran_sync_start = FivetranOperator(
-            task_id=f'intacct-task-{location}',
-            fivetran_conn_id='fivetran',
+            task_id=f"intacct-task-{location}",
+            fivetran_conn_id="fivetran",
             connector_id=connector_id,
         )
         fivetran_sync_wait = FivetranSensor(
-            task_id=f'intacct-sensor-{location}',
-            fivetran_conn_id='fivetran',
+            task_id=f"intacct-sensor-{location}",
+            fivetran_conn_id="fivetran",
             connector_id=connector_id,
             poke_interval=30,
             execution_timeout=timedelta(hours=6),
             xcom=f"{{{{ task_instance.xcom_pull('intacct-task-{location}') }}}}",
             on_retry_callback=retry_tasks_callback,
-            params={'retry_tasks': [f'intacct-task-{location}']},
+            params={"retry_tasks": [f"intacct-task-{location}"]},
         )
         fivetran_sync_start >> fivetran_sync_wait >> fivetran_sensors_complete

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -12,7 +12,7 @@ docs = """
 
 #### Description
 
-This DAG is decommissioned. 
+This DAG is decommissioned.
 Sage Intacct is no longer used by FP&A since January 2023. (see DENG-1003)
 
 This DAG triggers Fivetran to import data from Sage Intacct connector.

--- a/dags/intacct_historical.py
+++ b/dags/intacct_historical.py
@@ -12,6 +12,9 @@ docs = """
 
 #### Description
 
+This DAG is decommissioned. 
+Sage Intacct is no longer used by FP&A since January 2023. (see DENG-1003)
+
 This DAG triggers Fivetran to import data from Sage Intacct connector.
 
 #### Owner
@@ -30,7 +33,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-tags = [Tag.ImpactTier.tier_1, "repo/telemetry-airflow", ]
+tags = [Tag.ImpactTier.tier_1, "repo/telemetry-airflow", "decommissioned"]
 
 list_of_connectors ={
   "moz": "decently_wouldst",


### PR DESCRIPTION
Adding documentation to the `fivetran_intacct_historical` DAG to reflect the fact that it is decommissioned. 