### PR TITLE
Have glean_dictionary depend on lookml generation

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -404,4 +404,4 @@ with DAG(
         dag=dag,
     )
 
-    probe_scraper >> glean_dictionary_netlify_build
+    lookml_generator_prod >> glean_dictionary_netlify_build


### PR DESCRIPTION
Glean dictionary utilizes data from both generated schemas, and from the lookml namespaces. This dependency will satisfy both.