### PR TITLE
Add ensemble-transposer to airflow

### DIFF
--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -5,21 +5,20 @@ Source code is in the [firefox-public-data-report-etl repository]
 (https://github.com/mozilla/firefox-public-data-report-etl).
 """
 
+from datetime import datetime, timedelta
+
 from airflow import DAG
+from airflow.operators.subdag import SubDagOperator
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.sensors.external_task import ExternalTaskSensor
-from airflow.operators.subdag import SubDagOperator
-from datetime import datetime, timedelta
 from operators.gcp_container_operator import GKEPodOperator
-
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.dataproc import (
-    moz_dataproc_pyspark_runner,
     get_dataproc_parameters,
+    moz_dataproc_pyspark_runner,
 )
 from utils.gcp import bigquery_etl_query
 from utils.tags import Tag
-
 
 """
 The following WTMO connections are needed in order for this job to run:
@@ -30,10 +29,12 @@ default_args = {
     "owner": "akomar@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2020, 4, 6),
-    "email": ["telemetry-alerts@mozilla.com",
-              "firefox-hardware-report-feedback@mozilla.com",
-              "akomar@mozilla.com",
-              "shong@mozilla.com"],
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "firefox-hardware-report-feedback@mozilla.com",
+        "akomar@mozilla.com",
+        "shong@mozilla.com",
+    ],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,
@@ -51,8 +52,10 @@ dag = DAG(
 )
 
 # Required to write json output to s3://telemetry-public-analysis-2/public-data-report/hardware/
-write_aws_conn_id='aws_dev_telemetry_public_analysis_2_rw'
-aws_access_key, aws_secret_key, session = AwsBaseHook(aws_conn_id=write_aws_conn_id, client_type='s3').get_credentials()
+write_aws_conn_id = "aws_dev_telemetry_public_analysis_2_rw"
+aws_access_key, aws_secret_key, session = AwsBaseHook(
+    aws_conn_id=write_aws_conn_id, client_type="s3"
+).get_credentials()
 
 # hardware_report's execution date will be {now}-7days. It will read last week's main pings,
 # therefore we need to wait for yesterday's Main Ping deduplication task to finish
@@ -75,35 +78,48 @@ params = get_dataproc_parameters("google_cloud_airflow_dataproc")
 hardware_report = SubDagOperator(
     task_id="public_data_hardware_report",
     dag=dag,
-    subdag = moz_dataproc_pyspark_runner(
+    subdag=moz_dataproc_pyspark_runner(
         parent_dag_name=dag.dag_id,
-        image_version='1.5-debian10',
+        image_version="1.5-debian10",
         dag_name="public_data_hardware_report",
         default_args=default_args,
         cluster_name="public-data-hardware-report-{{ ds }}",
         job_name="firefox-public-data-hardware-report",
-        python_driver_code="gs://{}/jobs/moz_dataproc_runner.py".format(params.artifact_bucket),
-        init_actions_uris=["gs://dataproc-initialization-actions/python/pip-install.sh"],
-        additional_metadata={'PIP_PACKAGES': "git+https://github.com/mozilla/firefox-public-data-report-etl.git"},
-        additional_properties={"spark:spark.jars":"gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
-                               "spark-env:AWS_ACCESS_KEY_ID": aws_access_key,
-                               "spark-env:AWS_SECRET_ACCESS_KEY": aws_secret_key},
+        python_driver_code="gs://{}/jobs/moz_dataproc_runner.py".format(
+            params.artifact_bucket
+        ),
+        init_actions_uris=[
+            "gs://dataproc-initialization-actions/python/pip-install.sh"
+        ],
+        additional_metadata={
+            "PIP_PACKAGES": "git+https://github.com/mozilla/firefox-public-data-report-etl.git"
+        },
+        additional_properties={
+            "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
+            "spark-env:AWS_ACCESS_KEY_ID": aws_access_key,
+            "spark-env:AWS_SECRET_ACCESS_KEY": aws_secret_key,
+        },
         py_args=[
             "public_data_report",
             "hardware_report",
-            "--date_from", "{{ ds }}",
-            "--bq_table", "moz-fx-data-shared-prod.telemetry_derived.public_data_report_hardware",
-            "--temporary_gcs_bucket", params.storage_bucket,
-            "--s3_bucket", "telemetry-public-analysis-2",
-            "--s3_path", "public-data-report/hardware/",
+            "--date_from",
+            "{{ ds }}",
+            "--bq_table",
+            "moz-fx-data-shared-prod.telemetry_derived.public_data_report_hardware",
+            "--temporary_gcs_bucket",
+            params.storage_bucket,
+            "--s3_bucket",
+            "telemetry-public-analysis-2",
+            "--s3_path",
+            "public-data-report/hardware/",
         ],
         idle_delete_ttl=14400,
         num_workers=2,
-        worker_machine_type='n1-standard-4',
+        worker_machine_type="n1-standard-4",
         gcp_conn_id=params.conn_id,
         service_account=params.client_email,
         storage_bucket=params.storage_bucket,
-    )
+    ),
 )
 
 wait_for_clients_last_seen = ExternalTaskSensor(
@@ -133,11 +149,15 @@ user_activity_usage_behavior_export = GKEPodOperator(
     name="user_activity_export",
     image="gcr.io/moz-fx-data-airflow-prod-88e0/firefox-public-data-report-etl:latest",
     arguments=[
-        "-m", "public_data_report.cli",
+        "-m",
+        "public_data_report.cli",
         "user_activity",
-        "--bq_table", "moz-fx-data-shared-prod.telemetry_derived.public_data_report_user_activity_v1",
-        "--s3_bucket", "telemetry-public-analysis-2",
-        "--s3_path", "public-data-report/user_activity",
+        "--bq_table",
+        "moz-fx-data-shared-prod.telemetry_derived.public_data_report_user_activity_v1",
+        "--s3_bucket",
+        "telemetry-public-analysis-2",
+        "--s3_path",
+        "public-data-report/user_activity",
     ],
     env_vars={
         "AWS_ACCESS_KEY_ID": aws_access_key,
@@ -152,11 +172,15 @@ annotations_export = GKEPodOperator(
     name="annotations_export",
     image="gcr.io/moz-fx-data-airflow-prod-88e0/firefox-public-data-report-etl:latest",
     arguments=[
-        "-m", "public_data_report.cli",
+        "-m",
+        "public_data_report.cli",
         "annotations",
-        "--date_to", "{{ ds }}",
-        "--output_bucket", "telemetry-public-analysis-2",
-        "--output_prefix", "public-data-report/annotations",
+        "--date_to",
+        "{{ ds }}",
+        "--output_bucket",
+        "telemetry-public-analysis-2",
+        "--output_prefix",
+        "public-data-report/annotations",
     ],
     env_vars={
         "AWS_ACCESS_KEY_ID": aws_access_key,
@@ -166,5 +190,18 @@ annotations_export = GKEPodOperator(
     dag=dag,
 )
 
-wait_for_main_ping >> hardware_report
+ensemble_transposer = GKEPodOperator(
+    task_id="ensemble_transposer",
+    name="ensemble_transposer",
+    image="gcr.io/moz-fx-data-airflow-prod-88e0/ensemble-transposer:latest",
+    env_vars={
+        # prod location will be moz-fx-data-static-websit-8565-ensemble
+        "GCS_BUCKET_NAME": "moz-fx-data-static-websit-f7e0-ensemble",
+    },
+    image_pull_policy="Always",
+    dag=dag,
+)
+
+wait_for_main_ping >> hardware_report >> ensemble_transposer
 wait_for_clients_last_seen >> user_activity >> user_activity_usage_behavior_export
+annotations_export >> ensemble_transposer


### PR DESCRIPTION
This is mostly lint, main change is at the bottom.

Background in https://mozilla-hub.atlassian.net/browse/DSRE-1144?focusedCommentId=694637

https://console.cloud.google.com/functions/details/us-central1/data-ensemble-transposer-prod?env=gen1&project=moz-fx-data-ensembl-prod-0371&tab=metrics&pageState=(%22functionsDetailsCharts%22:(%22groupValue%22:%22PT6H%22,%22customValue%22:null)) seems to run hourly but it's only [configured](https://github.com/mozilla/ensemble-transposer/tree/main/config/datasets) to read datasets generated by this DAG. It's possible this behavior (and https://github.com/mozilla/ensemble-transposer/pull/231) are related to caching issues but if we notice them we can address them separately.

The bucket here is backing https://dfc-stage.data-static-websites.nonprod.webservices.mozgcp.net/ via https://github.com/mozilla-it/webservices-infra/tree/DSRE-1144. If this works I'll update to a prod GCS bucket.