### PR TITLE
fix(DENG-951): updated gsutil command to use correct path for the image

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -108,7 +108,7 @@ with DAG(
         name="s3-gcs-sync",
         image="google/cloud-sdk:435.0.1-alpine",
         arguments=[
-            "/usr/bin/gsutil",
+            "/google-cloud-sdk/bin/gsutil",
             "-m",
             "rsync",
             "-d",

--- a/dags/crash_symbolication.py
+++ b/dags/crash_symbolication.py
@@ -146,7 +146,7 @@ with DAG(
         name="s3-gcs-sync",
         image="google/cloud-sdk:435.0.1-alpine",
         arguments=[
-            "/usr/bin/gsutil",
+            "/google-cloud-sdk/bin/gsutil",
             "-m",
             "rsync",
             "-d",

--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -208,7 +208,7 @@ gcs_sync = GKEPodOperator(
     name="s3-gcs-sync",
     image="google/cloud-sdk:435.0.1-alpine",
     arguments=[
-        "/usr/bin/gsutil",
+        "/google-cloud-sdk/bin/gsutil",
         "-m",
         "rsync",
         "-d",

--- a/dags/graphics_telemetry.py
+++ b/dags/graphics_telemetry.py
@@ -161,7 +161,7 @@ with DAG(
         name="s3-gcs-sync",
         image="google/cloud-sdk:435.0.1-alpine",
         arguments=[
-            "/usr/bin/gsutil",
+            "/google-cloud-sdk/bin/gsutil",
             "-m",
             "rsync",
             "-d",

--- a/dags/update_orphaning_dashboard_etl.py
+++ b/dags/update_orphaning_dashboard_etl.py
@@ -108,7 +108,7 @@ gcs_sync = GKEPodOperator(
     name="s3-gcs-sync",
     image="google/cloud-sdk:435.0.1-alpine",
     arguments=[
-        "/usr/bin/gsutil",
+        "/google-cloud-sdk/bin/gsutil",
         "-m",
         "rsync",
         "-d",


### PR DESCRIPTION
# fix(DENG-951): updated gsutil command to use correct path for the image

#follows-up: https://github.com/mozilla/telemetry-airflow/pull/1732

I pulled the image locally and identified the correct path to `gsutil` binary:

```
docker run --rm -it --entrypoint bash google/cloud-sdk:435.0.1-alpine
[...]
ebc9fe389797:/# /usr/bin/gsutil
bash: /usr/bin/gsutil: No such file or directory
ebc9fe389797:/# which gsutil
/google-cloud-sdk/bin/gsutil
ebc9fe389797:/# /google-cloud-sdk/bin/gsutil
Usage: gsutil [-D] [-DD] [-h header]... [-i service_account] [-m] [-o section:flag=value]... [-q] [-u user_project] [command [opts...] args...]
Available commands:
[...]
```

This should fix the error in the Airflow tasks.