### PR TITLE
Update schedule

### DIFF
--- a/dags/kpi_forecasting.py
+++ b/dags/kpi_forecasting.py
@@ -53,7 +53,7 @@ CONFIGS = {
 with DAG(
     "kpi_forecasting",
     default_args=default_args,
-    schedule_interval="0 4 * * *",
+    schedule_interval="0 5 * * *",
     doc_md=__doc__,
     tags=TAGS,
 ) as dag:
@@ -77,7 +77,7 @@ with DAG(
                 task_id=f"wait_for_{wait_task}",
                 external_dag_id=config.wait_dag,
                 external_task_id=wait_task,
-                execution_delta=timedelta(seconds=3600),
+                execution_delta=timedelta(minutes=30),
                 check_existence=True,
                 mode="reschedule",
                 allowed_states=ALLOWED_STATES,


### PR DESCRIPTION
The wait tasks for this DAG were never succeeding because the DAG was scheduled to start before the upstream tasks.

The upstream DAGs are scheduled to run at `30 4 * * *`. This DAG will now run at `0 5 * * *` and look for upstream tasks scheduled to start 30 minutes earlier.