### PR TITLE
Test dataset-aware scheduling in bhr

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -1,6 +1,7 @@
 import datetime
 
 from airflow import models
+from airflow.datasets import Dataset
 from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.utils.task_group import TaskGroup
 from utils.gcp import (
@@ -90,6 +91,7 @@ with models.DAG(
         ],
         node_selector={"nodepool": "highmem"},
         container_resources=resources,
+        outlets=[Dataset("//copy_deduplicate/copy_deduplicate_all")],
     )
 
     with TaskGroup("copy_deduplicate_all_external") as copy_deduplicate_all_external:


### PR DESCRIPTION
Testing out the new dataset-aware scheduling. We might want to keep using `ExternalTaskSensor` for the `bqetl_` generated DAGs though, due to the following shortcoming:
* it is not possible to trigger a specific task, but only an entire DAG to run. So if a DAG has multiple tasks that depend on different upstream tasks, all of them have to wait for all upstream dependencies to finish. If an upstream dependency fails then none of the tasks will run (even if only one of them actually depends on the failed upstream dependency). So this could potentially result in more tasks not getting executed that when using ExternalTaskSensor