### PR TITLE
Temporarily remove logging from data validation DAG:

### DIFF
--- a/dags/search_term_data_validation.py
+++ b/dags/search_term_data_validation.py
@@ -49,5 +49,6 @@ with DAG(
             "moz-fx-data-shared-prod.search_terms_derived.search_term_data_validation_reports_v1",
         ],
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/search-term-data-validation_docker_etl:latest",
+        get_logs=False,
         dag=dag,
     )


### PR DESCRIPTION
You can see precedent for this solution in [this issue record](https://github.com/apache/airflow/issues/12136) as well as [this similar change](https://github.com/mozilla/telemetry-airflow/pull/1615) in this repo. 

I made a timeboxed effort (2 hours) at a more comprehensive solution, but couldn't do so without monkeypatching pieces of Airflow in a way that felt super brittle. 