### PR TITLE
Undo log removal

### DIFF
--- a/dags/search_term_data_validation.py
+++ b/dags/search_term_data_validation.py
@@ -49,6 +49,5 @@ with DAG(
             "moz-fx-data-shared-prod.search_terms_derived.search_term_data_validation_reports_v1",
         ],
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/search-term-data-validation_docker_etl:latest",
-        get_logs=False,
         dag=dag,
     )


### PR DESCRIPTION
So what happened here was, Merino was pushing an ungodly amount of empty strings into the unprocessed search data, and a job that processes those was running way long and producing beaucoup jobs, and Airflow doesn't have a great failout for the log limit.

Nan has done us the favor of removing those empty strings in Merino logging going forward, and the hope is that this fix is no longer needed. 

