### PR TITLE
Change schedule interval of bqetl_artifact_deployment

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -39,7 +39,7 @@ tags = [Tag.ImpactTier.tier_1]
 with DAG(
     "bqetl_artifact_deployment",
     default_args=default_args,
-    schedule_interval="30 5 * * *",
+    schedule_interval="@daily",
     doc_md=__doc__,
     tags=tags,
 ) as dag:


### PR DESCRIPTION
We had some Airflow failures, because table deploys are scheduled after most of the ETL is already running. Scheduling it to run earlier