### PR TITLE
Glam glean imports stops emailing telemetry-alerts to reduce noise

### DIFF
--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -11,11 +11,10 @@ from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.tags import Tag
 
 default_args = {
-    "owner": "akommasani@mozilla.com",
+    "owner": "efilho@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 10, 22),
     "email": [
-        "telemetry-alerts@mozilla.com",
         "akommasani@mozilla.com",
         "akomarzewski@mozilla.com",
         "efilho@mozilla.com",


### PR DESCRIPTION
Removing telemetry-alerts from alert recipient since it's causing too much noise and we already have a good amount of folks left in the `"email"` cfg to look at it.