### PR TITLE
Create custom timetable to run shredder every 4 weeks

### DIFF
--- a/plugins/timetable.py
+++ b/plugins/timetable.py
@@ -1,0 +1,58 @@
+"""Plugin for alternative timetables that cannot be trivially defined via cron expressions."""
+
+from datetime import timedelta
+
+from airflow.plugins_manager import AirflowPlugin
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+from pendulum import UTC, DateTime, Time
+
+
+class MultiWeekTimetable(Timetable):
+    def __init__(self, *, num_weeks: int, time: Time = Time.min):
+        self.interval_delta = timedelta(days=7 * num_weeks)
+        # only enforced for automated data intervals
+        self.time = time
+
+    def infer_manual_data_interval(self, run_after: DateTime) -> DataInterval:
+        return DataInterval(start=run_after - self.interval_delta, end=run_after)
+
+    def next_dagrun_info(
+        self,
+        *,
+        last_automated_data_interval: DataInterval | None,
+        restriction: TimeRestriction,
+    ) -> DagRunInfo | None:
+        if restriction.earliest is None:  # No start_date specified. Don't schedule.
+            return None
+
+        # Find the first run on the regular schedule.
+        next_end = (
+            DateTime.combine(restriction.earliest, self.time).replace(tzinfo=UTC)
+            + self.interval_delta
+        )
+
+        max_end = next_end
+        if last_automated_data_interval is not None:
+            # There was a previous run on the regular schedule.
+            # Return the next interval after last_automated_data_interval.end that is
+            # aligned with restriction.earliest and self.time
+            max_end = last_automated_data_interval.end + self.interval_delta
+        elif not restriction.catchup:
+            # This is the first ever run on the regular schedule, and catchup is not
+            # enabled. Return the last complete interval before now.
+            max_end = DateTime.utcnow()
+        if next_end < max_end:
+            # Return the last complete interval on or before max_end. Use integer
+            # division on the number of whole days rather than deal with any corner
+            # cases related to leap seconds and partial days.
+            skip_intervals = (max_end - next_end).days // self.interval_delta.days
+            next_end = next_end + (self.interval_delta * skip_intervals)
+
+        if restriction.latest is not None and next_end > restriction.latest:
+            return None  # Over the DAG's scheduled end; don't schedule.
+        return DagRunInfo.interval(start=next_end - self.interval_delta, end=next_end)
+
+
+class MozillaTimetablePlugin(AirflowPlugin):
+    name = "mozilla_timetable_plugin"
+    timetables = [MultiWeekTimetable]

--- a/tests/test_timetable.py
+++ b/tests/test_timetable.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction
+from pendulum import UTC, DateTime, Time
+
+from plugins.timetable import MultiWeekTimetable
+
+
+def test_manual_interval():
+    tt = MultiWeekTimetable(num_weeks=4)
+    actual = tt.infer_manual_data_interval(run_after=DateTime(2023, 1, 29))
+    expected = DataInterval(start=DateTime(2023, 1, 1), end=DateTime(2023, 1, 29))
+    assert actual == expected
+
+
+def test_first_automated_interval():
+    tt = MultiWeekTimetable(num_weeks=4, time=Time(hour=4))
+    actual = tt.next_dagrun_info(
+        last_automated_data_interval=None,
+        restriction=TimeRestriction(
+            earliest=DateTime(2023, 1, 1), latest=None, catchup=True
+        ),
+    )
+    expected = DagRunInfo.interval(
+        start=DateTime(2023, 1, 1, 4, tzinfo=UTC),
+        end=DateTime(2023, 1, 29, 4, tzinfo=UTC),
+    )
+    assert actual == expected
+
+
+def test_first_automated_interval_no_catchup():
+    tt = MultiWeekTimetable(num_weeks=4)
+    with mock.patch.object(
+        DateTime, "utcnow", return_value=DateTime(2023, 2, 28, tzinfo=UTC)
+    ):
+        actual = tt.next_dagrun_info(
+            last_automated_data_interval=None,
+            restriction=TimeRestriction(
+                earliest=DateTime(2023, 1, 1), latest=None, catchup=False
+            ),
+        )
+    expected = DagRunInfo.interval(
+        start=DateTime(2023, 1, 29, tzinfo=UTC), end=DateTime(2023, 2, 26, tzinfo=UTC)
+    )
+    assert actual == expected
+
+
+def test_next_automated_interval():
+    tt = MultiWeekTimetable(num_weeks=4)
+    actual = tt.next_dagrun_info(
+        last_automated_data_interval=DataInterval(
+            start=DateTime(2023, 1, 29, tzinfo=UTC),
+            end=DateTime(2023, 2, 26, tzinfo=UTC),
+        ),
+        restriction=TimeRestriction(
+            earliest=DateTime(2023, 1, 1),
+            latest=DateTime(2023, 3, 26, tzinfo=UTC),
+            catchup=False,
+        ),
+    )
+    expected = DagRunInfo.interval(
+        start=DateTime(2023, 2, 26, tzinfo=UTC), end=DateTime(2023, 3, 26, tzinfo=UTC)
+    )
+    assert actual == expected
+
+
+def test_last_automated_interval():
+    tt = MultiWeekTimetable(num_weeks=4)
+    actual = tt.next_dagrun_info(
+        last_automated_data_interval=DataInterval(
+            start=DateTime(2023, 1, 29, tzinfo=UTC),
+            end=DateTime(2023, 2, 26, tzinfo=UTC),
+        ),
+        restriction=TimeRestriction(
+            earliest=DateTime(2023, 1, 1),
+            latest=DateTime(2023, 2, 26, tzinfo=UTC),
+            catchup=False,
+        ),
+    )
+    assert actual is None


### PR DESCRIPTION
the shredder dag is currently running every 28 days after it was turned on, and sometimes randomly adding new runs based on the current time.

This ensures that the dag will run at UTC midnight every 28 days after start_date.

created following this guide: https://airflow.apache.org/docs/apache-airflow/2.5.3/howto/timetable.html