### PR TITLE
DENG-1025: gfx export to prod gcs bucket

### DIFF
--- a/dags/graphics_telemetry.py
+++ b/dags/graphics_telemetry.py
@@ -40,7 +40,7 @@ PIP_PACKAGES = [
     "six==1.15.0",
 ]
 
-GCS_BUCKET = "moz-fx-data-static-websit-f7e0-analysis-output"
+GCS_BUCKET = "moz-fx-data-static-websit-8565-analysis-output"
 GCS_PREFIX = "gfx/telemetry-data/"
 
 tags = [Tag.ImpactTier.tier_1]


### PR DESCRIPTION
Follow-up of https://github.com/mozilla/telemetry-airflow/pull/1774
Updating GCS bucket with prod name after testing with nonprod.
Will be merged along with with https://github.com/mozilla/python_mozetl/pull/389