### PR TITLE
Run replacement data validation job daily at 8 AM

### DIFF
--- a/dags/search_term_data_validation_v2.py
+++ b/dags/search_term_data_validation_v2.py
@@ -1,0 +1,53 @@
+"""
+See [search-term-data-validation in the docker-etl repository](https://github.com/mozilla/docker-etl/blob/main/jobs/search-term-data-validation-v2).
+
+This job populates a table for evaluating whether our recorded search terms
+(candidate search volume for being sanitized and stored) are changing in ways
+that might invalidate assumptions on which we've built our sanitization model.
+
+This DAG is low priority.
+"""
+
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from utils.gcp import gke_command
+from utils.tags import Tag
+
+default_args = {
+    "owner": "ctroy@mozilla.com",
+    "email": ["ctroy@mozilla.com", "wstuckey@mozilla.com"],
+    "depends_on_past": False,
+    "start_date": datetime(2023, 9, 5),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+    "retry_delay": timedelta(minutes=30),
+}
+
+tags = [
+    Tag.ImpactTier.tier_3,
+    Tag.Triage.no_triage,
+]
+
+daily_at_8AM = "0 8 * * *"
+with DAG(
+    "search_term_data_validation_v2",
+    default_args=default_args,
+    schedule_interval=daily_at_8AM,
+    doc_md=__doc__,
+    tags=tags,
+) as dag:
+    search_term_data_validation = gke_command(
+        task_id="search_term_data_validation_v2",
+        command=[
+            "python",
+            "search_term_data_validation_v2/main.py",
+            "--data_validation_origin",
+            "moz-fx-data-shared-prod.search_terms.sanitization_job_data_validation_metrics",
+            "--data_validation_reporting_destination",
+            "moz-fx-data-shared-prod.search_terms_derived.search_term_data_validation_reports_v1",
+        ],
+        docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/search-term-data-validation_v2_docker_etl:latest",
+        dag=dag,
+    )

--- a/dags/search_term_data_validation_v2.py
+++ b/dags/search_term_data_validation_v2.py
@@ -1,5 +1,5 @@
 """
-See [search-term-data-validation in the docker-etl repository](https://github.com/mozilla/docker-etl/blob/main/jobs/search-term-data-validation-v2).
+See [search-term-data-validation-v2 in the docker-etl repository](https://github.com/mozilla/docker-etl/blob/main/jobs/search-term-data-validation-v2).
 
 This job populates a table for evaluating whether our recorded search terms
 (candidate search volume for being sanitized and stored) are changing in ways


### PR DESCRIPTION
This is a scheduled daily job to run search term data validation via [this container configuration](https://github.com/mozilla/docker-etl/compare/ctroy-replace-dataval?expand=1).
