### PR TITLE
Put job back for asking for help

### DIFF
--- a/dags/search_term_data_validation_v2.py
+++ b/dags/search_term_data_validation_v2.py
@@ -41,7 +41,8 @@ with DAG(
     search_term_data_validation = gke_command(
         task_id="search_term_data_validation_v2",
         command=[
-            "python", "search_term_data_validation_v2/main.py",
+            "python",
+            "search_term_data_validation_v2/main.py",
             "--data_validation_origin",
             "moz-fx-data-shared-prod.search_terms.sanitization_job_data_validation_metrics",
             "--data_validation_reporting_destination",

--- a/dags/search_term_data_validation_v2.py
+++ b/dags/search_term_data_validation_v2.py
@@ -41,7 +41,11 @@ with DAG(
     search_term_data_validation = gke_command(
         task_id="search_term_data_validation_v2",
         command=[
-            'echo "HELLO WORLD!"',
+            "python", "search_term_data_validation_v2/main.py",
+            "--data_validation_origin",
+            "moz-fx-data-shared-prod.search_terms.sanitization_job_data_validation_metrics",
+            "--data_validation_reporting_destination",
+            "moz-fx-data-shared-prod.search_terms_derived.search_term_data_validation_reports_v1",
         ],
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/search-alert_docker_etl:latest",
         dag=dag,


### PR DESCRIPTION
I tried several experiments to figure out what's wrong with this job, and this PR puts it back in its "correct" state.

Here's the issue: this job keeps...not running, on Airflow. It says:
![Screenshot 2023-09-15 at 4 27 08 PM](https://github.com/mozilla/telemetry-airflow/assets/5744164/2c8a8e38-721e-4ff4-9fb0-8af9a0630b27)

When I run this job in telemetry-airflow dev with different values passed into `gke_command` than the defaults for `gcp_conn_id`, `gke_project_id`, `gke_location`, and `gke_cluster_name`, it works. But when I explicitly specify those arguments in this job to match the defaults for the function signature in production, it still doesn't run. 

When I change the command to ['echo "HELLO WORLD!"'], I do get a different error message: 
![Screenshot 2023-09-15 at 4 31 17 PM](https://github.com/mozilla/telemetry-airflow/assets/5744164/5049c446-473e-4fb5-933b-8ed80d085b20)

The problem here is, of course, that I need to put "echo" and the string '"Hello World!"' in their own entries in the command array. When I tried to do this, `black` got upset, and no amount of `make fixes` changed anything about the file, so I gave up and closed the PR. 

What we know is, in dev, this job works. In prod, it doesn't. I can't figure out what's up. 
