### PR TITLE
Set reattach_on_restart=True in copy_deduplicate

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -223,6 +223,7 @@ with models.DAG(
     )
 
     event_events = bigquery_etl_query(
+        reattach_on_restart=True,
         task_id="event_events",
         project_id="moz-fx-data-shared-prod",
         destination_table="event_events_v1",
@@ -256,6 +257,7 @@ with models.DAG(
     copy_deduplicate_event_ping >> event_events
 
     bq_main_events = bigquery_etl_query(
+        reattach_on_restart=True,
         task_id="bq_main_events",
         project_id="moz-fx-data-shared-prod",
         destination_table="main_events_v1",
@@ -298,6 +300,7 @@ with models.DAG(
     # being part of the clients daily table in this DAG, it will be easier to
     # reason about dependencies in this single DAG while it is being developed.
     telemetry_derived__core_clients_first_seen__v1 = bigquery_etl_query(
+        reattach_on_restart=True,
         task_id="telemetry_derived__core_clients_first_seen__v1",
         destination_table="core_clients_first_seen_v1",
         dataset_id="telemetry_derived",
@@ -334,6 +337,7 @@ with models.DAG(
     ]
 
     baseline_clients_first_seen = gke_command(
+        reattach_on_restart=True,
         task_id="baseline_clients_first_seen",
         command=[
             "bqetl",
@@ -347,6 +351,7 @@ with models.DAG(
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     )
     baseline_clients_daily = gke_command(
+        reattach_on_restart=True,
         task_id="baseline_clients_daily",
         command=[
             "bqetl",
@@ -358,6 +363,7 @@ with models.DAG(
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     )
     baseline_clients_last_seen = gke_command(
+        reattach_on_restart=True,
         task_id="baseline_clients_last_seen",
         command=[
             "bqetl",
@@ -393,6 +399,7 @@ with models.DAG(
         baseline_clients_last_seen >> baseline_clients_last_seen_external
 
     metrics_clients_daily = gke_command(
+        reattach_on_restart=True,
         task_id="metrics_clients_daily",
         command=[
             "bqetl",
@@ -404,6 +411,7 @@ with models.DAG(
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     )
     metrics_clients_last_seen = gke_command(
+        reattach_on_restart=True,
         task_id="metrics_clients_last_seen",
         command=[
             "bqetl",
@@ -416,6 +424,7 @@ with models.DAG(
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     )
     clients_last_seen_joined = gke_command(
+        reattach_on_restart=True,
         task_id="clients_last_seen_joined",
         command=[
             "bqetl",

--- a/dags/utils/gcp.py
+++ b/dags/utils/gcp.py
@@ -184,6 +184,7 @@ def bigquery_etl_query(
     arguments=(),
     project_id=None,
     sql_file_path=None,
+    reattach_on_restart=False,
     gcp_conn_id="google_cloud_airflow_gke",
     gke_project_id=GCP_PROJECT_ID,
     gke_location="us-west1",
@@ -241,6 +242,7 @@ def bigquery_etl_query(
         parameters += (date_partition_parameter + ":DATE:{{ds}}",)
     args = ["script/bqetl", "query", "run-multipart"] if multipart else ["query"]
     return GKEPodOperator(
+        reattach_on_restart=reattach_on_restart,
         gcp_conn_id=gcp_conn_id,
         project_id=gke_project_id,
         location=gke_location,
@@ -314,6 +316,7 @@ def bigquery_etl_copy_deduplicate(
             table_qualifiers.append(except_table)
     return GKEPodOperator(
         task_id=task_id,
+        reattach_on_restart=True,
         gcp_conn_id=gcp_conn_id,
         project_id=gke_project_id,
         location=gke_location,
@@ -500,6 +503,7 @@ def gke_command(
     gke_cluster_name="workloads-prod-v1",
     gke_namespace="default",
     xcom_push=False,
+    reattach_on_restart=False,
     env_vars=None,
     is_delete_operator_pod=False,
     **kwargs,
@@ -548,6 +552,7 @@ def gke_command(
         image=docker_image,
         arguments=command,
         do_xcom_push=xcom_push,
+        reattach_on_restart=reattach_on_restart,
         env_vars=context_env_vars,
         is_delete_operator_pod=is_delete_operator_pod,
         **kwargs,


### PR DESCRIPTION
We've been recently seeing Airflow declaring running GKE tasks as failed and retrying them. This results in multiple pods running per task run.

This change should stop Airflow from starting duplicate pod instances by reattaching retry runs to existing pods.

`reattach_on_restart` was originally defaulted to `False` in https://github.com/mozilla/telemetry-airflow/pull/1184. It seems fine to enable this now since `run_id` is one of the labels but out of caution this PR does not affect other DAGs.