### PR TITLE
Deduplicate main_use_counter and _remainder outside of copy_deduplicate_all

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -84,6 +84,8 @@ with models.DAG(
         # copy_deduplicate job elsewhere.
         except_tables=[
             "telemetry_live.main_v4",
+            "telemetry_live.main_use_counter_v4",
+            "telemetry_live.main_remainder_v4",
             "telemetry_live.event_v4",
             "telemetry_live.first_shutdown_v4",
             "telemetry_live.saved_session_v4",
@@ -146,7 +148,11 @@ with models.DAG(
         task_id="copy_deduplicate_main_ping",
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
-        only_tables=["telemetry_live.main_v4"],
+        only_tables=[
+            "telemetry_live.main_v4",
+            "telemetry_live.main_use_counter_v4",
+            "telemetry_live.main_remainder_v4",
+        ],
         priority_weight=100,
         parallelism=5,
         slices=20,


### PR DESCRIPTION
Recently we've been seeing copy_deduplicate_all run time increasing. This might be related to introduction of split main ping tables that were deduplicated in this task. They should be moved to copy_deduplicate_main_ping to properly reflect dataset dependencies.