### PR TITLE
Glam - reattach pods on restart

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -73,6 +73,7 @@ wait_for_main_ping = ExternalTaskSensor(
 )
 
 latest_versions = bigquery_etl_query(
+    reattach_on_restart=True,
     task_id="latest_versions",
     destination_table="latest_versions",
     dataset_id=dataset_id,
@@ -85,6 +86,7 @@ latest_versions = bigquery_etl_query(
 # This task runs first and replaces the relevant partition, followed
 # by the next two tasks that append to the same partition of the same table.
 clients_daily_scalar_aggregates = generate_and_run_desktop_query(
+    reattach_on_restart=True,
     task_id="clients_daily_scalar_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -95,6 +97,7 @@ clients_daily_scalar_aggregates = generate_and_run_desktop_query(
 )
 
 clients_daily_keyed_scalar_aggregates = generate_and_run_desktop_query(
+    reattach_on_restart=True,
     task_id="clients_daily_keyed_scalar_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -105,6 +108,7 @@ clients_daily_keyed_scalar_aggregates = generate_and_run_desktop_query(
 )
 
 clients_daily_keyed_boolean_aggregates = generate_and_run_desktop_query(
+    reattach_on_restart=True,
     task_id="clients_daily_keyed_boolean_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -115,6 +119,7 @@ clients_daily_keyed_boolean_aggregates = generate_and_run_desktop_query(
 )
 
 clients_scalar_aggregates = bigquery_etl_query(
+    reattach_on_restart=True,
     task_id="clients_scalar_aggregates",
     destination_table="clients_scalar_aggregates_v1",
     dataset_id=dataset_id,
@@ -125,6 +130,7 @@ clients_scalar_aggregates = bigquery_etl_query(
 )
 
 scalar_percentiles = gke_command(
+    reattach_on_restart=True,
     task_id="scalar_percentiles",
     command=[
         "python3",
@@ -148,6 +154,7 @@ scalar_percentiles = gke_command(
 # This task runs first and replaces the relevant partition, followed
 # by the next task below that appends to the same partition of the same table.
 clients_daily_histogram_aggregates_parent = generate_and_run_desktop_query(
+    reattach_on_restart=True,
     task_id="clients_daily_histogram_aggregates_parent",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -160,6 +167,7 @@ clients_daily_histogram_aggregates_parent = generate_and_run_desktop_query(
 )
 
 clients_daily_histogram_aggregates_content = generate_and_run_desktop_query(
+    reattach_on_restart=True,
     task_id="clients_daily_histogram_aggregates_content",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -172,6 +180,7 @@ clients_daily_histogram_aggregates_content = generate_and_run_desktop_query(
 )
 
 clients_daily_histogram_aggregates_gpu = generate_and_run_desktop_query(
+    reattach_on_restart=True,
     task_id="clients_daily_histogram_aggregates_gpu",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -184,6 +193,7 @@ clients_daily_histogram_aggregates_gpu = generate_and_run_desktop_query(
 )
 
 clients_daily_keyed_histogram_aggregates = generate_and_run_desktop_query(
+    reattach_on_restart=True,
     task_id="clients_daily_keyed_histogram_aggregates",
     project_id=project_id,
     source_dataset_id=dataset_id,
@@ -208,6 +218,7 @@ clients_histogram_aggregates = SubDagOperator(
 )
 
 histogram_percentiles = bigquery_etl_query(
+    reattach_on_restart=True,
     task_id="histogram_percentiles",
     destination_table="histogram_percentiles_v1",
     dataset_id=dataset_id,
@@ -218,6 +229,7 @@ histogram_percentiles = bigquery_etl_query(
 )
 
 glam_user_counts = bigquery_etl_query(
+    reattach_on_restart=True,
     task_id="glam_user_counts",
     destination_table="glam_user_counts_v1",
     dataset_id=dataset_id,
@@ -230,6 +242,7 @@ glam_user_counts = bigquery_etl_query(
 )
 
 glam_sample_counts = bigquery_etl_query(
+    reattach_on_restart=True,
     task_id="glam_sample_counts",
     destination_table="glam_sample_counts_v1",
     dataset_id=dataset_id,
@@ -240,7 +253,9 @@ glam_sample_counts = bigquery_etl_query(
     dag=dag,
     docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
 )
+
 client_scalar_probe_counts = gke_command(
+    reattach_on_restart=True,
     task_id="client_scalar_probe_counts",
     command=[
         "python3",
@@ -294,6 +309,7 @@ clients_non_norm_histogram_bucket_counts = SubDagOperator(
 )
 
 clients_histogram_probe_counts = bigquery_etl_query(
+    reattach_on_restart=True,
     task_id="clients_histogram_probe_counts",
     destination_table="clients_histogram_probe_counts_v1",
     dataset_id=dataset_id,

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -76,7 +76,7 @@ with DAG(
     )
 
     pre_import = EmptyOperator(
-        task_id=f'pre_import',
+        task_id='pre_import',
     )
 
     with TaskGroup('glam_fog_external') as glam_fog_external:

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -1,18 +1,16 @@
 from datetime import datetime, timedelta
+from functools import partial
 
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
-from airflow.sensors.external_task import ExternalTaskMarker
-from airflow.sensors.external_task import ExternalTaskSensor
+from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
 from airflow.utils.task_group import TaskGroup
-
 from glam_subdags.generate_query import (
     generate_and_run_glean_queries,
     generate_and_run_glean_task,
 )
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import gke_command
-from functools import partial
 from utils.tags import Tag
 
 default_args = {
@@ -50,7 +48,6 @@ LOGICAL_MAPPING = {
     "firefox_desktop_glam_nightly": ["firefox_desktop"],
     "firefox_desktop_glam_beta": ["firefox_desktop"],
     "firefox_desktop_glam_release": ["firefox_desktop"],
-   
 }
 
 tags = [Tag.ImpactTier.tier_2]
@@ -76,10 +73,10 @@ with DAG(
     )
 
     pre_import = EmptyOperator(
-        task_id='pre_import',
+        task_id="pre_import",
     )
 
-    with TaskGroup('glam_fog_external') as glam_fog_external:
+    with TaskGroup("glam_fog_external") as glam_fog_external:
         ExternalTaskMarker(
             task_id="glam_glean_imports__wait_for_fog",
             external_dag_id="glam_glean_imports",
@@ -95,8 +92,7 @@ with DAG(
             task_id=f"daily_{product}",
             product=product,
             destination_project_id=PROJECT,
-            env_vars=dict(STAGE="daily"),
-
+            env_vars={"STAGE": "daily"},
         )
         mapping[product] = query
         wait_for_copy_deduplicate >> query
@@ -110,12 +106,12 @@ with DAG(
             generate_and_run_glean_task,
             product=product,
             destination_project_id=PROJECT,
-            env_vars=dict(STAGE="incremental"),
-
+            env_vars={"STAGE": "incremental"},
         )
-        view, init, query = [
-            partial(func, task_type=task_type) for task_type in ["view", "init", "query"]
-        ]
+        view, init, query = (
+            partial(func, task_type=task_type)
+            for task_type in ["view", "init", "query"]
+        )
 
         # stage 1 - incremental
         clients_daily_histogram_aggregates = view(
@@ -145,8 +141,12 @@ with DAG(
         scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")
         scalar_percentile = query(task_name=f"{product}__scalar_percentiles_v1")
 
-        histogram_bucket_counts = query(task_name=f"{product}__histogram_bucket_counts_v1")
-        histogram_probe_counts = query(task_name=f"{product}__histogram_probe_counts_v1")
+        histogram_bucket_counts = query(
+            task_name=f"{product}__histogram_bucket_counts_v1"
+        )
+        histogram_probe_counts = query(
+            task_name=f"{product}__histogram_probe_counts_v1"
+        )
         histogram_percentiles = query(task_name=f"{product}__histogram_percentiles_v1")
 
         probe_counts = view(task_name=f"{product}__view_probe_counts_v1")
@@ -169,7 +169,6 @@ with DAG(
             command=["script/glam/export_csv"],
             docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
             gcp_conn_id="google_cloud_airflow_gke",
-
         )
 
         # set all of the dependencies for all of the tasks
@@ -211,5 +210,11 @@ with DAG(
             >> probe_counts
         )
         probe_counts >> sample_counts >> extract_probe_counts >> export >> pre_import
-        clients_scalar_aggregate >> user_counts >> extract_user_counts >> export >> pre_import
+        (
+            clients_scalar_aggregate
+            >> user_counts
+            >> extract_user_counts
+            >> export
+            >> pre_import
+        )
         clients_histogram_aggregate >> export >> pre_import

--- a/dags/glam_subdags/general.py
+++ b/dags/glam_subdags/general.py
@@ -44,6 +44,7 @@ def repeated_subdag(
         )
 
     task_0 = bigquery_etl_query(
+        reattach_on_restart=True,
         task_id=f"{child_dag_name}_0",
         destination_table=f"{child_dag_name}_v1",
         dataset_id=dataset_id,
@@ -63,6 +64,7 @@ def repeated_subdag(
         max_param = min_param + PARTITION_SIZE - 1
 
         task = bigquery_etl_query(
+            reattach_on_restart=True,
             task_id=f"{child_dag_name}_{partition}",
             destination_table=f"{child_dag_name}_v1",
             dataset_id=dataset_id,

--- a/dags/glam_subdags/generate_query.py
+++ b/dags/glam_subdags/generate_query.py
@@ -90,6 +90,7 @@ def generate_and_run_glean_queries(
     }
 
     return gke_command(
+        reattach_on_restart=True,
         task_id=task_id,
         cmds=["bash", "-c"],
         env_vars=env_vars,
@@ -138,6 +139,7 @@ def generate_and_run_glean_task(
         raise ValueError("task_type must be either a view, init, or query")
 
     return gke_command(
+        reattach_on_restart=True,
         task_id=f"{task_type}_{task_name}",
         cmds=["bash", "-c"],
         env_vars=env_vars,

--- a/dags/glam_subdags/generate_query.py
+++ b/dags/glam_subdags/generate_query.py
@@ -16,6 +16,8 @@ def generate_and_run_desktop_query(
     **kwargs,
 ):
     """
+    Generate and run firefox desktop queries.
+
     :param task_id:                     Airflow task id
     :param project_id:                  GCP project to write to
     :param source_dataset_id:           Bigquery dataset to read from in queries
@@ -67,10 +69,12 @@ def generate_and_run_glean_queries(
     source_project_id="moz-fx-data-shared-prod",
     docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     gcp_conn_id="google_cloud_airflow_gke",
-    env_vars={},
+    env_vars=None,
     **kwargs,
 ):
     """
+    Generate and run fog and fenix queries.
+
     :param task_id:                     Airflow task id
     :param product:                     Product name of glean app
     :param destination_project_id:      Project to store derived tables
@@ -80,6 +84,9 @@ def generate_and_run_glean_queries(
     :param gcp_conn_id:                 Airflow GCP connection
     :param env_vars:                    Additional environment variables to pass
     """
+    if env_vars is None:
+        env_vars = {}
+
     env_vars = {
         "PRODUCT": product,
         "SRC_PROJECT": source_project_id,
@@ -110,11 +117,11 @@ def generate_and_run_glean_task(
     source_project_id="moz-fx-data-shared-prod",
     docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     gcp_conn_id="google_cloud_airflow_gke",
-    env_vars={},
+    env_vars=None,
     **kwargs,
 ):
     """
-    See https://github.com/mozilla/bigquery-etl/blob/main/script/glam/run_glam_sql
+    See https://github.com/mozilla/bigquery-etl/blob/main/script/glam/run_glam_sql.
 
     :param task_type:                   Either view, init, or query
     :param task_name:                   Name of the query
@@ -126,6 +133,9 @@ def generate_and_run_glean_task(
     :param gcp_conn_id:                 Airflow GCP connection
     :param env_vars:                    Additional environment variables to pass
     """
+    if env_vars is None:
+        env_vars = {}
+
     env_vars = {
         "PRODUCT": product,
         "SRC_PROJECT": source_project_id,

--- a/dags/glam_subdags/generate_query.py
+++ b/dags/glam_subdags/generate_query.py
@@ -8,6 +8,7 @@ def generate_and_run_desktop_query(
     sample_size,
     overwrite,
     probe_type,
+    reattach_on_restart=False,
     destination_dataset_id=None,
     process=None,
     docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
@@ -47,6 +48,7 @@ def generate_and_run_desktop_query(
         command.append(process)
 
     return gke_command(
+        reattach_on_restart=reattach_on_restart,
         task_id=task_id,
         cmds=["bash"],
         env_vars=env_vars,

--- a/dags/glam_subdags/histograms.py
+++ b/dags/glam_subdags/histograms.py
@@ -22,6 +22,7 @@ def histogram_aggregates_subdag(
     )
 
     clients_histogram_aggregates_new = bigquery_etl_query(
+        reattach_on_restart=True,
         task_id="clients_histogram_aggregates_new",
         destination_table="clients_histogram_aggregates_new_v1",
         dataset_id=dataset_id,
@@ -34,6 +35,7 @@ def histogram_aggregates_subdag(
     )
 
     clients_histogram_aggregates_final = bigquery_etl_query(
+        reattach_on_restart=True,
         task_id="clients_histogram_aggregates_v2",
         destination_table="clients_histogram_aggregates_v2",
         dataset_id=dataset_id,


### PR DESCRIPTION
Sets the `reattach_on_restart` flag to `True` for glam, glam_fog and glam_fenix DAGs in an effort to get rid of the `More than one pod running...` error.