### PR TITLE
[DISCO-2645] Modify Telemetry Airflow Jobs Cadence to Run every month

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -61,10 +61,10 @@ tags = [
     Tag.Triage.no_triage,
 ]
 
-# Run weekly on Tuesdays at 5am UTC
+# Run once a month on a Tuesday at 5am UTC.
 with DAG(
     "merino_jobs",
-    schedule_interval="0 5 * * 2",
+    schedule_interval="0 5 1-7 * 2",
     doc_md=DOCS,
     default_args=default_args,
     tags=tags,


### PR DESCRIPTION
The current cadence of the merino_jobs at a weekly run is too often. We want to reduce developer input as these data generation jobs don’t need to run so often. This will be for the Elasticsearch, Wikipedia Indexer and Top Picks Nav Suggestion jobs to run on Tuesdays every month.