### PR TITLE
Add link to GKE cluster in top bar menu

### DIFF
--- a/plugins/mozmenu.py
+++ b/plugins/mozmenu.py
@@ -39,4 +39,9 @@ class MozMenuPlugin(AirflowPlugin):
     hooks = []
     executors = []
     appbuilder_views = []
-    appbuilder_menu_items = [telemetry_airflow, wtmo_dev, airflow_triage_guide]
+    appbuilder_menu_items = [
+        telemetry_airflow,
+        wtmo_dev,
+        airflow_triage_guide,
+        gke_cluster,
+    ]


### PR DESCRIPTION
This is a follow up to https://github.com/mozilla/telemetry-airflow/pull/1838