### PR TITLE
bug(1854406): updating python_moztelemetry package to use the new git tag reference

### DIFF
--- a/dags/graphics_telemetry.py
+++ b/dags/graphics_telemetry.py
@@ -34,7 +34,7 @@ default_args = {
 }
 
 PIP_PACKAGES = [
-    "git+https://github.com/mozilla/python_moztelemetry.git@v0.10.4#egg=python-moztelemetry",
+    "git+https://github.com/mozilla/python_moztelemetry.git@v0.10.7#egg=python-moztelemetry",
     "git+https://github.com/FirefoxGraphics/telemetry.git#egg=pkg&subdirectory=analyses/bigquery_shim",
     "boto3==1.16.20",
     "six==1.15.0",

--- a/dags/graphics_telemetry.py
+++ b/dags/graphics_telemetry.py
@@ -15,6 +15,7 @@ import datetime
 from airflow import DAG
 from airflow.operators.subdag import SubDagOperator
 from airflow.sensors.external_task import ExternalTaskSensor
+
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.dataproc import get_dataproc_parameters, moz_dataproc_pyspark_runner
 from utils.tags import Tag


### PR DESCRIPTION
# bug(1854406): updating python_moztelemetry package to use the new git tag reference

A new tag needed to be created in the source repo: https://github.com/mozilla/python_moztelemetry/releases/tag/v0.10.7