### PR TITLE
Change the bucket to gcp for bhr data and remove sync job

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -22,7 +22,6 @@ from airflow.operators.subdag import SubDagOperator
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.sensors.external_task import ExternalTaskSensor
 
-from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.dataproc import get_dataproc_parameters, moz_dataproc_pyspark_runner
 from utils.tags import Tag
@@ -87,17 +86,18 @@ with DAG(
             init_actions_uris=[
                 "gs://dataproc-initialization-actions/python/pip-install.sh"
             ],
-            additional_metadata={"PIP_PACKAGES": "boto3==1.16.20 click==7.1.2"},
+            additional_metadata={
+                "PIP_PACKAGES": "boto3==1.16.20 click==7.1.2 google-cloud-storage==2.7.0"
+            },
             additional_properties={
                 "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
-                "spark-env:AWS_ACCESS_KEY_ID": aws_access_key,
-                "spark-env:AWS_SECRET_ACCESS_KEY": aws_secret_key,
             },
             py_args=[
                 "--date",
                 "{{ ds }}",
                 "--sample-size",
                 "0.5",
+                "--use_gcs",
             ],
             idle_delete_ttl=14400,
             num_workers=6,
@@ -108,24 +108,4 @@ with DAG(
         ),
     )
 
-    # TODO remove this when the job writes to GCS directly
-    gcs_sync = GKEPodOperator(
-        task_id="s3_gcs_sync",
-        name="s3-gcs-sync",
-        image="google/cloud-sdk:435.0.1-alpine",
-        arguments=[
-            "/google-cloud-sdk/bin/gsutil",
-            "-m",
-            "rsync",
-            "-d",
-            "-r",
-            "s3://telemetry-public-analysis-2/bhr/",
-            "gs://moz-fx-data-static-websit-8565-analysis-output/bhr/",
-        ],
-        env_vars={
-            "AWS_ACCESS_KEY_ID": aws_access_key,
-            "AWS_SECRET_ACCESS_KEY": aws_secret_key,
-        },
-        dag=dag,
-    )
-    wait_for_bhr_ping >> bhr_collection >> gcs_sync
+    wait_for_bhr_ping >> bhr_collection


### PR DESCRIPTION
Changing the original task to write the BHR data to GCS bucket. 
In the event of failure the PR will be reverted (There is a potential risk of data loss)