### PR TITLE
feat(DENG-2063): deprecating DIM checks for telemetry_derived.active_users_aggregates_v1 as migrated to ETL checks

### DIFF
--- a/dags/data_monitoring.py
+++ b/dags/data_monitoring.py
@@ -31,8 +31,8 @@ TARGET_DATASETS = (
     "moz-fx-data-shared-prod.telemetry_derived.cohort_daily_statistics_v1",
     "moz-fx-data-shared-prod.telemetry.rolling_cohorts",
     "moz-fx-data-shared-prod.telemetry_derived.rolling_cohorts_v1",
-    "moz-fx-data-shared-prod.telemetry.active_users_aggregates",
-    "moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_v1",
+    # "moz-fx-data-shared-prod.telemetry.active_users_aggregates",  # Migrated over to ETL checks: DENG-2046
+    # "moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_v1",  # Migrated over to ETL checks: DENG-2046
     # "moz-fx-data-shared-prod.internet_outages.global_outages_v1",  Migrated over to ETL checks: DENG-2045
     "moz-fx-data-shared-prod.org_mozilla_fenix_nightly.baseline_clients_last_seen",
 )


### PR DESCRIPTION
# feat(DENG-2063): deprecating DIM checks for telemetry_derived.active_users_aggregates_v1 as migrated to ETL checks

depends on: https://github.com/mozilla/bigquery-etl/pull/4641