### PR TITLE
feat(DENG-2072): deprecating DIM checks for telemetry_derived.unified_metrics_v1

### DIFF
--- a/dags/data_monitoring.py
+++ b/dags/data_monitoring.py
@@ -25,8 +25,8 @@ things fail we will update the DAG.
 # one of the checks.
 
 TARGET_DATASETS = (
-    "moz-fx-data-shared-prod.telemetry.unified_metrics",
-    "moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1",
+    # "moz-fx-data-shared-prod.telemetry.unified_metrics",  # Migrated over to ETL checks: DENG-2049
+    # "moz-fx-data-shared-prod.telemetry_derived.unified_metrics_v1",  # Migrated over to ETL checks: DENG-2049
     # "moz-fx-data-shared-prod.telemetry.cohort_daily_statistics",  # removed as no longer needed: DENG-2065
     # "moz-fx-data-shared-prod.telemetry_derived.cohort_daily_statistics_v1",  # removed as no longer needed: DENG-2065
     # "moz-fx-data-shared-prod.telemetry.rolling_cohorts",  # removed as no longer needed: DENG-2064


### PR DESCRIPTION
feat(DENG-2072): deprecating DIM checks for telemetry_derived.unified_metrics_v1

These have been migrated over to BQETL data checks via: DENG-2049

depends on: https://github.com/mozilla/bigquery-etl/pull/4649