### PR TITLE
feat(DENG-1990): deprecated dim checks for active_users_aggregates mobile

### DIFF
--- a/dags/dim_active_users_aggregates.py
+++ b/dags/dim_active_users_aggregates.py
@@ -41,16 +41,16 @@ IMAGE = "gcr.io/moz-fx-data-airflow-prod-88e0/dim:latest"
 Config = namedtuple("Config", "exec_date apps")
 CONFIGS = {
     "desktop": Config("{{ ds }}", ("firefox_desktop",)),
-    "mobile": Config(
-        "{{ macros.ds_add(ds, -1) }}",
-        (
-            "fenix",
-            "focus_android",
-            "firefox_ios",
-            "focus_ios",
-            "klar_ios",
-        ),
-    ),
+    # "mobile": Config(
+    #     "{{ macros.ds_add(ds, -1) }}",
+    #     (
+    #         "fenix",
+    #         "focus_android",
+    #         "firefox_ios",
+    #         "focus_ios",
+    #         "klar_ios",
+    #     ),
+    # ),  # migrated over to BQETL data checks via: DENG-2051
 }
 
 PROJECT_ID = "mozdata"


### PR DESCRIPTION
# feat(DENG-1990): deprecated dim checks for active_users_aggregates mobile

depends on: https://github.com/mozilla/bigquery-etl/pull/4673