### PR TITLE
Have `bqetl_artifact_deployment` publish new `glean_usage`-generated tables

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -65,7 +65,7 @@ with DAG(
         task_id="publish_new_tables",
         cmds=["bash", "-x", "-c"],
         command=[
-            "script/bqetl generate all --use-cloud-function=false --ignore glean_usage && "
+            "script/bqetl generate all --use-cloud-function=false && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-experiments && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-marketing-prod && "


### PR DESCRIPTION
This reverts #1843, because after #1858 the `glean_usage`-generated tables are no longer being auto-deployed via Airflow-scheduled `bqetl query backfill` commands, and now that #1893 deploys new tables with init logic using `bqetl query initialize` this should deploy the `baseline_clients_*` tables with correct schemas (at least after mozilla/bigquery-etl#4809 is merged).