### PR TITLE
Add DAGs for initiating and completing backfills

### DIFF
--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -1,7 +1,5 @@
-"""
-This DAG completes backfills of BigQuery tables.
+"""DAG for completing registered bigquery-etl backfills."""
 
-"""
 from datetime import datetime
 
 from airflow import DAG
@@ -51,7 +49,7 @@ with DAG(
         task_id="slack_notify_initate",
         username="Backfill",
         text=":hourglass_flowing_sand: Completing backfill of `{{ params.qualified_table_name }}`. A snapshot of the "
-             "current production data will be kept as a backup.",
+        "current production data will be kept as a backup.",
         slack_conn_id="slack_api",
     ).expand(channel=slack_users)
 

--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -1,0 +1,73 @@
+"""
+This DAG completes backfills of BigQuery tables.
+
+"""
+from datetime import datetime
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models import Param
+from airflow.operators.python import get_current_context
+from airflow.providers.slack.operators.slack import SlackAPIPostOperator
+
+from utils.gcp import gke_command
+from utils.tags import Tag
+
+DOCKER_IMAGE = "mozilla/bigquery-etl:latest"
+
+tags = [Tag.ImpactTier.tier_3]
+
+with DAG(
+    "bqetl_backfill_complete",
+    doc_md=__doc__,
+    tags=tags,
+    schedule_interval=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    params={
+        "qualified_table_name": Param(
+            default="moz-fx-data-shared-prod.dataset.table",
+            description="The qualified table with the backfill entry.",
+            type="string",
+        ),
+        "notify_emails": Param(
+            default=[],
+            description="Slack users to notify about backfill processing.",
+            type="array",
+        ),
+    },
+) as dag:
+
+    @task
+    def get_slack_users():
+        context = get_current_context()
+        return [
+            f"@{email.split('@')[0]}" for email in context["params"]["notify_emails"]
+        ]
+
+    slack_users = get_slack_users()
+
+    notify_initate = SlackAPIPostOperator.partial(
+        task_id="slack_notify_initate",
+        username="Backfill",
+        text=":hourglass_flowing_sand: Completing backfill of `{{ params.qualified_table_name }}`. A snapshot of the "
+             "current production data will be kept as a backup.",
+        slack_conn_id="slack_api",
+    ).expand(channel=slack_users)
+
+    complete_backfill = gke_command(
+        task_id="complete_backfill",
+        cmds=["bash", "-x", "-c"],
+        command=["script/bqetl backfill complete {{ params.qualified_table_name }}"],
+        docker_image=DOCKER_IMAGE,
+        gcp_conn_id="google_cloud_airflow_gke",
+    )
+
+    notify_processing_complete = SlackAPIPostOperator.partial(
+        task_id="slack_notify_swap_complete",
+        username="Backfill",
+        text=":white_check_mark: Backfill is complete. Production data has been updated.",
+        slack_conn_id="slack_api",
+    ).expand(channel=slack_users)
+
+    notify_initate >> complete_backfill >> notify_processing_complete

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -1,0 +1,96 @@
+"""
+This DAG detects and initiates backfills of BigQuery tables.
+
+"""
+from datetime import datetime
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.models import Param
+from airflow.operators.python import get_current_context
+from airflow.providers.slack.operators.slack import SlackAPIPostOperator
+
+from utils.gcp import gke_command
+from utils.tags import Tag
+
+DOCKER_IMAGE = "mozilla/bigquery-etl:latest"
+
+tags = [Tag.ImpactTier.tier_3]
+
+with DAG(
+    "bqetl_backfill_initiate",
+    doc_md=__doc__,
+    tags=tags,
+    schedule_interval=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    params={
+        "qualified_table_name": Param(
+            default="moz-fx-data-shared-prod.dataset.table",
+            description="The qualified table with the backfill entry.",
+            type="string",
+        ),
+        "notify_emails": Param(
+            default=[],
+            description="Slack users to notify about backfill processing.",
+            type="array",
+        ),
+        "entry_date": Param(
+            default="2021-01-01",
+            description="The entry date for the backfill being processed.",
+            type="string",
+        ),
+    },
+) as dag:
+
+    @task
+    def get_slack_users():
+        context = get_current_context()
+        return [
+            f"@{email.split('@')[0]}" for email in context["params"]["notify_emails"]
+        ]
+
+    slack_users = get_slack_users()
+
+    notify_initate = SlackAPIPostOperator.partial(
+        task_id="slack_notify_initate",
+        username="Backfill",
+        text=":hourglass_flowing_sand: Initiating backfill scheduled for `{{ params.qualified_table_name }}`.",
+        slack_conn_id="slack_api",
+    ).expand(channel=slack_users)
+
+    process_backfill = gke_command(
+        task_id="process_backfill",
+        cmds=["bash", "-x", "-c"],
+        command=["script/bqetl backfill process {{ params.qualified_table_name }}"],
+        docker_image=DOCKER_IMAGE,
+        gcp_conn_id="google_cloud_airflow_gke",
+    )
+
+    @task
+    def get_staging_location():
+        # TODO: This should probably be communicated via XCom by the processing step
+        context = get_current_context()
+        qualified_table_name = context["params"]["qualified_table_name"]
+        project, _, table = qualified_table_name.split(".")
+        backfill_table_id = (
+            f"{table}_{context['params']['entry_date'].replace('-', '_')}"
+        )
+        return f"{project}.backfills_staging_derived.{table}_{backfill_table_id}"
+
+    notify_processing_complete = SlackAPIPostOperator.partial(
+        task_id="slack_notify_processing_complete",
+        username="Backfill",
+        text=":white_check_mark: Backfill processing is complete. Staging location: "
+        "`{{ ti.xcom_pull(task_ids='get_staging_location') }}`. "
+        "Please validate that your data has changed as you expect and complete your backfill by updating the "
+        "Backfill entry's status to Complete in the bigquery-etl repository.",
+        slack_conn_id="slack_api",
+    ).expand(channel=slack_users)
+
+    (
+        notify_initate
+        >> process_backfill
+        >> get_staging_location()
+        >> notify_processing_complete
+    )

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -1,7 +1,5 @@
-"""
-This DAG detects and initiates backfills of BigQuery tables.
+"""DAG for initiating registered bigquery-etl backfills."""
 
-"""
 from datetime import datetime
 
 from airflow import DAG

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -9,7 +9,6 @@ from airflow.operators.python import get_current_context
 from airflow.providers.slack.operators.slack import SlackAPIPostOperator
 
 from operators.gcp_container_operator import GKEPodOperator
-from utils.gcp import gke_command
 from utils.tags import Tag
 
 DOCKER_IMAGE = "mozilla/bigquery-etl:latest"

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -8,6 +8,7 @@ from airflow.models import Param
 from airflow.operators.python import get_current_context
 from airflow.providers.slack.operators.slack import SlackAPIPostOperator
 
+from operators.gcp_container_operator import GKEPodOperator
 from utils.gcp import gke_command
 from utils.tags import Tag
 
@@ -57,12 +58,12 @@ with DAG(
         slack_conn_id="slack_api",
     ).expand(channel=slack_users)
 
-    process_backfill = gke_command(
+    process_backfill = GKEPodOperator(
         task_id="process_backfill",
+        name="process_backfill",
         cmds=["bash", "-x", "-c"],
-        command=["script/bqetl backfill process {{ params.qualified_table_name }}"],
-        docker_image=DOCKER_IMAGE,
-        gcp_conn_id="google_cloud_airflow_gke",
+        arguments=["script/bqetl backfill process {{ params.qualified_table_name }}"],
+        image=DOCKER_IMAGE,
     )
 
     @task


### PR DESCRIPTION
Adds two new unscheduled dags `bqetl_backfill_complete` and `bqetl_backfill_initiate` for completing and initiating a backfill respectively. They're unscheduled because they'll be triggered by API.