### PR TITLE
feat(DENG-2685): Update fivetran imports to use airflow-provider-fivetran-async Airflow Fivetran provider

### DIFF
--- a/dags/casa.py
+++ b/dags/casa.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from fivetran_provider.operators.fivetran import FivetranOperator
-from fivetran_provider.sensors.fivetran import FivetranSensor
+from fivetran_provider_async.operators import FivetranOperator
+from fivetran_provider_async.sensors import FivetranSensor
 from utils.callbacks import retry_tasks_callback
 from utils.tags import Tag
 

--- a/dags/fivetran_acoustic.py
+++ b/dags/fivetran_acoustic.py
@@ -5,8 +5,8 @@ from airflow import DAG
 from airflow.hooks.base import BaseHook
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import PythonOperator
-from fivetran_provider.operators.fivetran import FivetranOperator
-from fivetran_provider.sensors.fivetran import FivetranSensor
+from fivetran_provider_async.operators import FivetranOperator
+from fivetran_provider_async.sensors import FivetranSensor
 
 from utils.acoustic.acoustic_client import AcousticClient
 from utils.callbacks import retry_tasks_callback

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ apache-airflow[amazon,async,celery,cncf.kubernetes,github_enterprise,google_auth
 apache-airflow-providers-google
 apache-airflow-providers-http
 apache-airflow-providers-slack
-airflow-provider-fivetran==1.1.2
+airflow-provider-fivetran-async==2.0.2
 
 # Code quality
 pytest==7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 aiofiles==23.2.1
 aiohttp==3.8.6
 aiosignal==1.3.1
-airflow-provider-fivetran==1.1.2
+airflow-provider-fivetran-async==2.0.2
 alembic==1.12.1
 amqp==5.1.1
 annotated-types==0.6.0


### PR DESCRIPTION
# feat(DENG-2685): Update fivetran imports to use airflow-provider-fivetran-async Airflow Fivetran provider

This is to replace `airflow-provider-fivetran` Airflow Fivetran provider which has been deprecated last year.