### PR TITLE
Add project moz-fx-data-glam-prod-fca7 to the DAG bqetl_artifact_depl…

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -75,6 +75,8 @@ with DAG(
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-experiments && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-marketing-prod"
+            "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
+            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
         ],
         docker_image=docker_image,
     )
@@ -91,6 +93,7 @@ with DAG(
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod && "
+            "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-glam-prod-fca7 --project-id=moz-fx-data-glam-prod-fca7 && "
             "script/bqetl view clean --skip-authorized --target-project=mozdata --user-facing-only && "
             "script/publish_public_data_views --target-project=moz-fx-data-shared-prod && "
             "script/publish_public_data_views --target-project=mozdata"


### PR DESCRIPTION
Required for glam-etl files [PR-5025](https://github.com/mozilla/bigquery-etl/pull/5025), which are failing to deploy.
Related [Bug 1879890](https://bugzilla.mozilla.org/show_bug.cgi?id=1879890).
