### PR TITLE
Limit Fivetran task concurrency so it only tries to run one sync per connector at a time

### DIFF
--- a/dags/casa.py
+++ b/dags/casa.py
@@ -41,4 +41,5 @@ with DAG(
     casa_sync_start = FivetranOperator(
         connector_id="{{ var.value.fivetran_casa_connector_id }}",
         task_id="casa-task",
+        task_concurrency=1,
     )

--- a/dags/fivetran_acoustic.py
+++ b/dags/fivetran_acoustic.py
@@ -194,6 +194,7 @@ for report_type, _config in REPORTS_CONFIG.items():
         sync_trigger = FivetranOperator(
             task_id="trigger_fivetran_connector",
             connector_id=f"{{{{ var.value.fivetran_acoustic_{report_type}_connector_id }}}}",
+            task_concurrency=1,
         )
 
         load_completed = EmptyOperator(


### PR DESCRIPTION
This only makes sense now that we've switched to Astronomer's Fivetran Airflow provider package (https://github.com/mozilla/telemetry-airflow/pull/1922), which allows us to have a single task that both starts the Fivetran sync and waits for it to complete.