### PR TITLE
Fix `bqetl_artifact_deployment.publish_views` to publish views in alternate projects

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -86,10 +86,10 @@ with DAG(
         cmds=["bash", "-x", "-c"],
         arguments=[
             "script/bqetl generate all --use-cloud-function=false && "
-            "script/bqetl view publish --add-managed-label --skip-authorized --target-project=moz-fx-data-shared-prod && "
-            "script/bqetl view publish --add-managed-label --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments && "
-            "script/bqetl view publish --add-managed-label --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod && "
-            "script/bqetl view publish --add-managed-label --skip-authorized --target-project=mozdata --user-facing-only && "
+            "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod && "
+            "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-experiments && "
+            "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-marketing-prod && "
+            "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod --target-project=mozdata --user-facing-only && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod && "


### PR DESCRIPTION
Views haven't been getting published for the `moz-fx-data-experiments` and `moz-fx-data-marketing-prod` projects, because calling `bqetl view publish` with the `--target-project` argument only considers views in the default `moz-fx-data-shared-prod` project.