### PR TITLE
bqetl_artifact_deployment max_active_runs and remove SQL generation

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -38,6 +38,7 @@ tags = [Tag.ImpactTier.tier_1]
 
 with DAG(
     "bqetl_artifact_deployment",
+    max_active_runs=1,
     default_args=default_args,
     schedule_interval="@daily",
     doc_md=__doc__,
@@ -65,7 +66,6 @@ with DAG(
         task_id="publish_new_tables",
         cmds=["bash", "-x", "-c"],
         arguments=[
-            "script/bqetl generate all --use-cloud-function=false && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-experiments && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-marketing-prod && "
@@ -85,7 +85,6 @@ with DAG(
         task_id="publish_views",
         cmds=["bash", "-x", "-c"],
         arguments=[
-            "script/bqetl generate all --use-cloud-function=false && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-experiments && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-marketing-prod && "
@@ -108,7 +107,6 @@ with DAG(
         task_id="publish_metadata",
         cmds=["bash", "-x", "-c"],
         arguments=[
-            "script/bqetl generate all --use-cloud-function=false && "
             "script/bqetl metadata publish '*' --project_id=moz-fx-data-shared-prod && "
             "script/bqetl metadata publish '*' --project_id=mozdata && "
             "script/bqetl metadata publish '*' --project_id=moz-fx-data-marketing-prod && "


### PR DESCRIPTION
Related to https://github.com/mozilla/bigquery-etl/pull/5136

The `bqetl_artifact_deployment` DAG will be triggered by bigquery-etl changes so this ensures that only task is running even when multiple PRs get merged in a short period of time.

We are also removing the SQL generation to speed things up. bigquery-etl does contain the generated SQL and should be up-to-date enough when deploys are running