### PR TITLE
Change Fivetran Airflow operators to run synchronously so the task concurrency limit is respected

### DIFF
--- a/dags/casa.py
+++ b/dags/casa.py
@@ -41,5 +41,6 @@ with DAG(
     casa_sync_start = FivetranOperator(
         connector_id="{{ var.value.fivetran_casa_connector_id }}",
         task_id="casa-task",
+        deferrable=False,
         task_concurrency=1,
     )

--- a/dags/fivetran_acoustic.py
+++ b/dags/fivetran_acoustic.py
@@ -194,6 +194,7 @@ for report_type, _config in REPORTS_CONFIG.items():
         sync_trigger = FivetranOperator(
             task_id="trigger_fivetran_connector",
             connector_id=f"{{{{ var.value.fivetran_acoustic_{report_type}_connector_id }}}}",
+            deferrable=False,
             task_concurrency=1,
         )
 


### PR DESCRIPTION
https://github.com/mozilla/telemetry-airflow/pull/1923 tried to limit Fivetran task concurrency so it would only run one sync per connector at a time, but that didn't actually work because task concurrency limits apparently don't apply when tasks get deferred (maybe an Airflow bug?). This will address that.

While having the operator be deferred while waiting for the Fivetran sync to complete would be ideal from an Airflow resource usage perspective, I believe having the sync behavior work as intended is more important, and having the Fivetran operator take up a worker slot while it's waiting shouldn't be a dealbreaker since that was the behavior until very recently when we switched to Astronomer's Fivetran Airflow provider package with its deferrable operator implementation (https://github.com/mozilla/telemetry-airflow/pull/1922).

Related PR: https://github.com/mozilla/bigquery-etl/pull/5144