### PR TITLE
Bug 1821773 - Update debugging notes for probe scraper and bqetl deploy

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -5,11 +5,28 @@ Nightly deploy of bigquery etl views.
 
 The DAG always re-deploys all bqetl views. So as long as the most recent DAG run
 is successful the job can be considered healthy. This means previous failed DAG runs
-can be ignored or marked as successful.
+can be ignored.
 
 `publish_views` doesn't show any logs due to spitting out invalid unicode.
-To view relevant errors, either check the [Kubernetes pods](https://console.cloud.google.com/kubernetes/workload/overview?project=moz-fx-data-airflow-gke-prod)
-or go to [GCP console and check the query "Project History" tab at the bottom of the page](https://console.cloud.google.com/bigquery?project=moz-fx-data-airflow-gke-prod&ws=!1m0).
+
+Logs can be viewed in the [GCP logs explorer](https://console.cloud.google.com/logs?project=moz-fx-data-airflow-gke-prod)
+with the following query:
+```
+resource.type="k8s_container"
+resource.labels.project_id="moz-fx-data-airflow-gke-prod"
+resource.labels.location="us-west1"
+resource.labels.cluster_name="workloads-prod-v1"
+resource.labels.namespace_name="default"
+resource.labels.pod_name=~"publish-views-.+"
+severity>=DEFAULT
+```
+This link leads to a
+prepopulated query for the last 12 hours: https://cloudlogging.app.goo.gl/vTs1R7fCMQnLxFtV8
+
+To view logs of a specific task run, replace the pod_name value with the pod name that can be
+found at the start of the logs in Airflow, e.g. `INFO - Found matching pod publish-views-abcd1234`.
+
+To find logs for specific datasets/views, add a string to search for to the end of the query.
 """
 
 from datetime import datetime, timedelta

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -32,14 +32,14 @@ and the task re-run.
 ## Debugging failures
 
 probe_scraper and probe_scraper_moz_central task logs aren't available via the Airflow web console. In
-order to access them, go to [GCP Logs Explorer](https://cloudlogging.app.goo.gl/qqvCsTbFGCiFmG7L7).
+order to access them, go to [GCP Logs Explorer](https://cloudlogging.app.goo.gl/sLyJuaPmVM6SnKtu7).
 This link should get you directly to the last 12 hours of probe_scraper pod logs. If necessary, replace
-`"probe-scraper[.]"` with `"probe-scraper-moz-central[.]"` in the query field.
+`"probe-scraper.+"` with `"probe-scraper-moz-central.+"` in the query field.
 If the above link fails, do the following:
 
 1. Navigate to the [Google Cloud Logging console](https://console.cloud.google.com/logs/query?project=moz-fx-data-airflow-gke-prod)
 If you can't access these logs but think you should be able to, [contact Data SRE](https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=DOPS&title=Contacting+Data+SRE).
-2. Search for the following, replacing `"probe-scraper[.]"` with `"probe-scraper-moz-central[.]"` if necessary (make sure to put this in the raw query field - you might need to click the "Show query" button for it to appear):
+2. Search for the following, replacing `"probe-scraper.+"` with `"probe-scraper-moz-central.+"` if necessary (make sure to put this in the raw query field - you might need to click the "Show query" button for it to appear):
 
 ```
 resource.type="k8s_container"
@@ -47,7 +47,7 @@ resource.labels.project_id="moz-fx-data-airflow-gke-prod"
 resource.labels.location="us-west1"
 resource.labels.cluster_name="workloads-prod-v1"
 resource.labels.namespace_name="default"
-resource.labels.pod_name=~"probe-scraper[.]"
+resource.labels.pod_name=~"probe-scraper.+"
 severity>=DEFAULT
 ```
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1821773

Fix the regex in the probe scraper notes and update the bqetl_artifact_deployment notes to point to logs explorer because gke has limited retention