### PR TITLE
fix(dockerfille): google-cloud-sdk renamed google-cloud-cli.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update \
 RUN apt-get install -y --no-install-recommends \
     lsb-release gnupg curl && \
     CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
-    echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-cli.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y && apt-get install google-cloud-sdk-gke-gcloud-auth-plugin && \
+    apt-get update -y && apt-get install google-cloud-cli -y && apt-get install google-cloud-cli-gke-gcloud-auth-plugin && \
     apt-get remove -y lsb-release gnupg
 
 RUN apt-get autoremove -yqq --purge && \


### PR DESCRIPTION
# Description
Fix broken pipeline since they renamed `google-cloud-sdk` to `google-cloud-cli`.