### PR TITLE
feat: Make args parameter optional in operational_monitoring_backfill

### DIFF
--- a/dags/operational_monitoring_backfill.py
+++ b/dags/operational_monitoring_backfill.py
@@ -53,7 +53,7 @@ tags = [Tag.ImpactTier.tier_3, Tag.Triage.no_triage]
         "args": Param(
             None,
             title="Additional Arguments",
-            type="string",
+            type=["null", "string"],
             description="[Optional] Additional command line arguments",
         ),
     },


### PR DESCRIPTION
## Description

Mark the `args` parameter in `operational_monitoring_backfill` as optional
