### PR TITLE
fix: Make sure `pip-tools` is installed before running `pip-compile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build:
 	docker-compose build
 
 pip-compile:
+	pip install -q pip-tools
 	pip-compile --strip-extras --no-annotate
 
 fixes:

--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,9 @@
 # File: https://raw.githubusercontent.com/apache/airflow/constraints-2.8.2/constraints-3.11.txt
 --constraint ./constraints.txt
 
+# Package management
+pip-tools
+
 # Airflow dependencies
 apache-airflow[async,google-auth,password,statsd]==2.8.2
 apache-airflow-providers-amazon

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ black==24.2.0
 blinker==1.7.0
 boto3==1.33.13
 botocore==1.33.13
+build==1.1.1
 cachelib==0.9.0
 cachetools==5.3.2
 cattrs==23.2.3
@@ -200,6 +201,7 @@ pandas==2.1.4
 pandas-gbq==0.21.0
 pathspec==0.12.1
 pendulum==3.0.0
+pip-tools==7.4.1
 platformdirs==3.11.0
 pluggy==1.4.0
 ply==3.11
@@ -220,6 +222,7 @@ pygments==2.17.2
 pyjwt==2.8.0
 pyopenssl==24.0.0
 pyparsing==3.1.1
+pyproject-hooks==1.0.0
 pytest==7.4.4
 pytest-mock==3.12.0
 python-daemon==3.0.1
@@ -275,6 +278,7 @@ watchtower==3.0.1
 wcwidth==0.2.13
 websocket-client==1.7.0
 werkzeug==2.2.3
+wheel==0.43.0
 wrapt==1.16.0
 wtforms==3.1.2
 xmltodict==0.13.0
@@ -284,4 +288,5 @@ zope-event==5.0
 zope-interface==6.2
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools


### PR DESCRIPTION
## Description

When starting with a fresh Python environment, running `make pip-install-local` would fail because it tries to run `pip-compile`, which won't exist until `pip-tools` is installed.

This PR solves that problem by silently installing `pip-tools` if necessary, and adding `pip-tools` as an explicit Python requirement so it gets version-pinned in `requirements.txt` for consistency.

## Related Tickets & Documents

N/A