### PR TITLE
fix: 1951 - acoustic suppression list date format

### DIFF
--- a/dags/fivetran_acoustic.py
+++ b/dags/fivetran_acoustic.py
@@ -183,6 +183,7 @@ REPORTS_CONFIG = {
         <DATE_START>{date_start}</DATE_START>
         <DATE_END>{date_end}</DATE_END>
         <VISIBILITY>{visibility}</VISIBILITY>
+        <LIST_DATE_FORMAT>"yyyy-MM-dd"</LIST_DATE_FORMAT>
         </ExportList>
     </Body>
     </Envelope>


### PR DESCRIPTION
## Description

This PR fixes #1951 by changing the date format 

## Related Tickets & Documents
* [DENG-3082](https://mozilla-hub.atlassian.net/browse/DENG-3082)

Without specifying it the dates get exported as "01/02/2020 12:02:01 PM" which can't be parsed with SQL DATE()

[DENG-3082]: https://mozilla-hub.atlassian.net/browse/DENG-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ