### PR TITLE
feat(DENG-2863): add data-observability-dev to the list of projects covered by artifact_deployment

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -86,6 +86,7 @@ with DAG(
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-experiments && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-marketing-prod && "
+            "script/bqetl query initialize '*' --skip-existing --project-id=data-observability-dev && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-experiments && "
@@ -93,7 +94,9 @@ with DAG(
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
-            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7"
+            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
+            "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=data-observability-dev && "
+            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=data-observability-dev"
         ],
         image=docker_image,
     )
@@ -106,11 +109,13 @@ with DAG(
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-experiments && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-glam-prod-fca7 && "
+            "script/bqetl view publish --add-managed-label --skip-authorized --project-id=data-observability-dev && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod --target-project=mozdata --user-facing-only && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-glam-prod-fca7 --project-id=moz-fx-data-glam-prod-fca7 && "
+            "script/bqetl view clean --skip-authorized --target-project=data-observability-dev --project-id=data-observability-dev && "
             "script/bqetl view clean --skip-authorized --target-project=mozdata --user-facing-only && "
             "script/publish_public_data_views --target-project=moz-fx-data-shared-prod && "
             "script/publish_public_data_views --target-project=mozdata"
@@ -127,7 +132,8 @@ with DAG(
             "script/bqetl metadata publish '*' --project_id=moz-fx-data-shared-prod && "
             "script/bqetl metadata publish '*' --project_id=mozdata && "
             "script/bqetl metadata publish '*' --project_id=moz-fx-data-marketing-prod && "
-            "script/bqetl metadata publish '*' --project_id=moz-fx-data-experiments"
+            "script/bqetl metadata publish '*' --project_id=moz-fx-data-experiments && "
+            "script/bqetl metadata publish '*' --project_id=data-observability-dev"
         ],
         image=docker_image,
     )


### PR DESCRIPTION
# feat(DENG-2863): add data-observability-dev to the list of projects covered by artifact_deployment

## Description

This PR makes an addition to the bqetl_artifcact_deployment DAG to also publish bq resources listed under the `data-observability-dev` project inside [bigquery-etl repo](https://github.com/mozilla/bigquery-etl/tree/main/sql/data-observability-dev).

This is to ensure that the resources used for testing data observability platforms undergo the same creation process and configuration to replicate our production settings as closely as possible.

Once the testing is complete these changes will be removed via: DENG-3102

## Related Tickets & Documents
* DENG-2863
* DENG-3102

