### PR TITLE
fix: 1952 Acoustic Suppression List DENG 3082 date format

### DIFF
--- a/dags/fivetran_acoustic.py
+++ b/dags/fivetran_acoustic.py
@@ -169,7 +169,7 @@ REPORTS_CONFIG = {
     "suppression_export": {
         "request_template": """
     <!-- https://developer.goacoustic.com/acoustic-campaign/reference/export-from-a-database -->
-    <!-- date_format: 07/25/2011 12:12:11 (time is optional) -->
+    <!-- date_format: 2011-12-20 12:12 PM (time is optional) -->
     <Envelope>
     <Body>
         <ExportList>
@@ -180,10 +180,10 @@ REPORTS_CONFIG = {
         <EXPORT_COLUMNS>
             {columns}
         </EXPORT_COLUMNS>
-        <DATE_START>{date_start}</DATE_START>
+        <DATE_START>datetime(2024, 3, 13)</DATE_START>
         <DATE_END>{date_end}</DATE_END>
         <VISIBILITY>{visibility}</VISIBILITY>
-        <LIST_DATE_FORMAT>"yyyy-MM-dd"</LIST_DATE_FORMAT>
+        <LIST_DATE_FORMAT>yyyy-MM-dd</LIST_DATE_FORMAT>
         </ExportList>
     </Body>
     </Envelope>

--- a/dags/fivetran_acoustic.py
+++ b/dags/fivetran_acoustic.py
@@ -180,7 +180,7 @@ REPORTS_CONFIG = {
         <EXPORT_COLUMNS>
             {columns}
         </EXPORT_COLUMNS>
-        <DATE_START>datetime(2024, 3, 13)</DATE_START>
+        <DATE_START>{date_start}</DATE_START>
         <DATE_END>{date_end}</DATE_END>
         <VISIBILITY>{visibility}</VISIBILITY>
         <LIST_DATE_FORMAT>yyyy-MM-dd</LIST_DATE_FORMAT>
@@ -207,7 +207,7 @@ DEFAULT_ARGS = {
     "owner": DAG_OWNER,
     "email": [DAG_OWNER],
     "depends_on_past": True,
-    "start_date": datetime(2023, 5, 26),
+    "start_date": datetime(2024, 3, 13),
     "email_on_failure": True,
     "email_on_retry": False,
     "retries": 1,  # at this point we can probably be confident user intervention is required


### PR DESCRIPTION
## Description

This PR should really really fix the broken date format ... 
The attepted fix in #1952 added the quotation marks ending up with `"2023-07-10" 06:33 PM` datetimes 🙃 

This PR also hard codes the starting date for the suppression list DAG since we don't need to backfill from last year but will merge this with a one time download for historic data

## Related Tickets & Documents
* DENG-3082


<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
