### PR TITLE
fix(dags): mad_server secrets are managed on GSM.

### DIFF
--- a/dags/mad_server.py
+++ b/dags/mad_server.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.providers.cncf.kubernetes.secret import Secret
+
 from operators.gcp_container_operator import GKEPodOperator
 from utils.tags import Tag
 
@@ -44,13 +45,13 @@ amo_cred_issuer_secret = Secret(
     deploy_type="env",
     deploy_target="AMO_CRED_ISSUER",
     secret="airflow-gke-secrets",
-    key="mad_server_secret__amo_cred_issuer"
+    key="mad_server_secret__amo_cred_issuer",
 )
 amo_cred_secret_secret = Secret(
     deploy_type="env",
     deploy_target="AMO_CRED_SECRET",
     secret="airflow-gke-secrets",
-    key="mad_server_secret__amo_cred_secret"
+    key="mad_server_secret__amo_cred_secret",
 )
 
 with DAG(


### PR DESCRIPTION
## Description

This PR changes the secret management of the `mad_server` DAG to Google Secret Management (DAG was previously using Airflow variables). 
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* DSRE-1525

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
