### PR TITLE
feat: [DENG-3277] Replace dataproc usage in public hardware report

### DIFF
--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -16,7 +16,7 @@ from utils.gcp import bigquery_etl_query
 from utils.tags import Tag
 
 default_args = {
-    "owner": "akomar@mozilla.com",
+    "owner": "bewu@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2020, 4, 6),
     "email": [

--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -8,15 +8,10 @@ Source code is in the [firefox-public-data-report-etl repository]
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.operators.subdag import SubDagOperator
 from airflow.sensors.external_task import ExternalTaskSensor
 
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.dataproc import (
-    get_dataproc_parameters,
-    moz_dataproc_pyspark_runner,
-)
 from utils.gcp import bigquery_etl_query
 from utils.tags import Tag
 
@@ -29,6 +24,7 @@ default_args = {
         "firefox-hardware-report-feedback@mozilla.com",
         "akomar@mozilla.com",
         "shong@mozilla.com",
+        "bewu@mozilla.com",
     ],
     "email_on_failure": True,
     "email_on_retry": True,
@@ -62,51 +58,35 @@ wait_for_main_ping = ExternalTaskSensor(
     dag=dag,
 )
 
-params = get_dataproc_parameters("google_cloud_airflow_dataproc")
-
-hardware_report = SubDagOperator(
-    task_id="public_data_hardware_report",
+hardware_report_query = bigquery_etl_query(
+    task_id="hardware_report_query",
+    destination_table="public_data_report_hardware_aggregates_v1",
+    project_id="moz-fx-data-shared-prod",
+    dataset_id="telemetry_derived",
     dag=dag,
-    subdag=moz_dataproc_pyspark_runner(
-        parent_dag_name=dag.dag_id,
-        image_version="1.5-debian10",
-        dag_name="public_data_hardware_report",
-        default_args=default_args,
-        cluster_name="public-data-hardware-report-{{ ds }}",
-        job_name="firefox-public-data-hardware-report",
-        python_driver_code="gs://{}/jobs/moz_dataproc_runner.py".format(
-            params.artifact_bucket
-        ),
-        init_actions_uris=[
-            "gs://dataproc-initialization-actions/python/pip-install.sh"
-        ],
-        additional_metadata={
-            "PIP_PACKAGES": "git+https://github.com/mozilla/firefox-public-data-report-etl.git"
-        },
-        additional_properties={
-            "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
-        },
-        py_args=[
-            "public_data_report",
-            "hardware_report",
-            "--date_from",
-            "{{ ds }}",
-            "--bq_table",
-            "moz-fx-data-shared-prod.telemetry_derived.public_data_report_hardware",
-            "--temporary_gcs_bucket",
-            params.storage_bucket,
-            "--gcs_bucket",
-            "moz-fx-data-static-websit-8565-analysis-output",
-            "--gcs_path",
-            "public-data-report/hardware/",
-        ],
-        idle_delete_ttl=14400,
-        num_workers=2,
-        worker_machine_type="n1-standard-4",
-        gcp_conn_id=params.conn_id,
-        service_account=params.client_email,
-        storage_bucket=params.storage_bucket,
-    ),
+)
+
+hardware_report_export = GKEPodOperator(
+    task_id="hardware_report_export",
+    name="hardware_report_export",
+    image="gcr.io/moz-fx-data-airflow-prod-88e0/firefox-public-data-report-etl:latest",
+    arguments=[
+        "-m",
+        "public_data_report.cli",
+        "hardware_report",
+        "--date_from",
+        "{{ ds }}",
+        "--input_bq_table",
+        "moz-fx-data-shared-prod.telemetry_derived.public_data_report_hardware_aggregates_v1",
+        "--output_bq_table",
+        "moz-fx-data-shared-prod.telemetry_derived.public_data_report_hardware_v1",
+        "--gcs_bucket",
+        "moz-fx-data-static-websit-8565-analysis-output",
+        "--gcs_path",
+        "public-data-report/hardware/",
+    ],
+    image_pull_policy="Always",
+    dag=dag,
 )
 
 wait_for_clients_last_seen = ExternalTaskSensor(
@@ -181,7 +161,16 @@ ensemble_transposer = GKEPodOperator(
 )
 
 
-wait_for_main_ping >> hardware_report >> ensemble_transposer
-wait_for_clients_last_seen >> user_activity >> user_activity_usage_behavior_export
-user_activity_usage_behavior_export >> ensemble_transposer
+(
+    wait_for_main_ping
+    >> hardware_report_query
+    >> hardware_report_export
+    >> ensemble_transposer
+)
+(
+    wait_for_clients_last_seen
+    >> user_activity
+    >> user_activity_usage_behavior_export
+    >> ensemble_transposer
+)
 annotations_export >> ensemble_transposer


### PR DESCRIPTION
## Description

This removes the dataproc operator in the hardware report and uses a biquery etl query and an updated hardware report job that doesn't use spark.  More context is in https://github.com/mozilla/firefox-public-data-report-etl/pull/27

This PR goes with
bigquery-etl: https://github.com/mozilla/bigquery-etl/pull/5332
firefox-public-data-report-etl: https://github.com/mozilla/firefox-public-data-report-etl/pull/27

## Related Tickets & Documents
* DENG-3277