### PR TITLE
feat: Default reattach_on_restart parameter to True in bigquery_etl_query function

### DIFF
--- a/utils/gcp.py
+++ b/utils/gcp.py
@@ -182,7 +182,7 @@ def bigquery_etl_query(
     arguments=(),
     project_id=None,
     sql_file_path=None,
-    reattach_on_restart=False,
+    reattach_on_restart=True,
     gcp_conn_id="google_cloud_airflow_gke",
     gke_project_id=GCP_PROJECT_ID,
     gke_location="us-west1",


### PR DESCRIPTION
We've been hit (again) by Airflow losing track of a running pod, restarting a task and failing with `More than one pod running with labels ...` error. We previously set some of the tasks to reattach to running pods on restart ([1], [2], [3]) which solved this problem for them. We didn't set it by default for all tasks back then to avoid situations where not-autodeleted pods are stuck with the old code. Now that DEs have permissions required to delete pods it seems safe to revisit this.

[1] https://github.com/mozilla/telemetry-airflow/pull/1820
[2] https://github.com/mozilla/telemetry-airflow/pull/1834
[3] https://github.com/mozilla/telemetry-airflow/pull/1837
