### PR TITLE
fix: DENG-3412 braze to bq add source format

### DIFF
--- a/dags/braze_gcs_to_bigquery.py
+++ b/dags/braze_gcs_to_bigquery.py
@@ -59,4 +59,5 @@ with DAG(
         ],
         destination_project_dataset_table=f"{project_id}.{dataset_id}.hard_bounces",
         write_disposition="WRITE_TRUNCATE",
+        source_format="AVRO",
     )


### PR DESCRIPTION
## Description

Trouble shooting #1963 
```
google.api_core.exceptions.Forbidden: 403 POST https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-airflow-gke-prod/jobs?prettyPrint=false: Access Denied: Project moz-fx-data-airflow-gke-prod: User does not have bigquery.jobs.create permission in project moz-fx-data-airflow-gke-prod.
INFO - Marking task as UP_FOR_RETRY. dag_id=bqetl_braze_currents_to_bigquery, task_id=hard_bounce_2bq, execution_date=20240415T184511, start_date=20240415T184513, end_date=20240415T184514
ERROR - Failed to execute job 4708594 for task hard_bounce_2bq (403 POST https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-airflow-gke-prod/jobs?prettyPrint=false: Access Denied: Project moz-fx-data-airflow-gke-prod: User does not have bigquery.jobs.create permission in project moz-fx-data-airflow-gke-prod.; 411629)
```
I created the table manually and added the source_format .. hope that helps

## Related Tickets & Documents
* DENG-3412


