### PR TITLE
fix: DENG-3412 braze to bq add gcp_conn_id

### DIFF
--- a/dags/braze_gcs_to_bigquery.py
+++ b/dags/braze_gcs_to_bigquery.py
@@ -60,5 +60,5 @@ with DAG(
         destination_project_dataset_table=f"{project_id}.{dataset_id}.hard_bounces",
         write_disposition="WRITE_TRUNCATE",
         source_format="AVRO",
-        gcp_conn_id="google_cloud_airflow_gke"
+        gcp_conn_id="google_cloud_airflow_gke",
     )

--- a/dags/braze_gcs_to_bigquery.py
+++ b/dags/braze_gcs_to_bigquery.py
@@ -60,4 +60,5 @@ with DAG(
         destination_project_dataset_table=f"{project_id}.{dataset_id}.hard_bounces",
         write_disposition="WRITE_TRUNCATE",
         source_format="AVRO",
+        gcp_conn_id="google_cloud_airflow_gke"
     )


### PR DESCRIPTION
## Description

Trouble shooting https://github.com/mozilla/telemetry-airflow/pull/1963

```
google.api_core.exceptions.Forbidden: 403 POST https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-airflow-gke-prod/jobs?prettyPrint=false: Access Denied: Project moz-fx-data-airflow-gke-prod: User does not have bigquery.jobs.create permission in project moz-fx-data-airflow-gke-prod.
INFO - Marking task as UP_FOR_RETRY. dag_id=bqetl_braze_currents_to_bigquery, task_id=hard_bounce_2bq, execution_date=20240415T184511, start_date=20240415T184513, end_date=20240415T184514
ERROR - Failed to execute job 4708594 for task hard_bounce_2bq (403 POST https://bigquery.googleapis.com/bigquery/v2/projects/moz-fx-data-airflow-gke-prod/jobs?prettyPrint=false: Access Denied: Project moz-fx-data-airflow-gke-prod: User does not have bigquery.jobs.create permission in project moz-fx-data-airflow-gke-prod.; 411629)
```

## Related Tickets & Documents
* DENG-3412
* #1963 
* #1964 

Hopefully adding the non-default connection does help 🤞 


