### PR TITLE
fix: Bug 1892258 - Increase bhr_collection spark memory allocation

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -91,6 +91,8 @@ with DAG(
             },
             additional_properties={
                 "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
+                "spark:spark.driver.memory": "12g",
+                "spark:spark.executor.memory": "15g",
             },
             py_args=[
                 "--date",
@@ -100,6 +102,7 @@ with DAG(
                 "--use_gcs",
             ],
             idle_delete_ttl=14400,
+            auto_delete_ttl=28800,
             num_workers=6,
             worker_machine_type="n1-highmem-4",
             gcp_conn_id=params.conn_id,

--- a/utils/dataproc.py
+++ b/utils/dataproc.py
@@ -299,8 +299,8 @@ def moz_dataproc_pyspark_runner(
                                           needs to be whitelisted. To use a NAT'd cluster, set
                                           subnetwork_uri='default', internal_ip_only=True, and
                                           region=us-west2-a|b|c
-    :param str idle_delete_ttl:           The duration in seconds to keep idle cluster alive.
-    :param str auto_delete_ttl:           The duration in seconds that the cluster will live.
+    :param int idle_delete_ttl:           The duration in seconds to keep idle cluster alive.
+    :param int auto_delete_ttl:           The duration in seconds that the cluster will live.
     :param str master_machine_type:       Compute engine machine type to use for master.
     :param str worker_machine_type:       Compute engine machine type to use for the workers.
     :param int num_preemptible_workers:   Number of preemptible worker nodes to spin up.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1892258

## Description

This increases the memory used by the driver and executor processes.  Currently failing with
```
24/04/18 07:17:14 WARN org.apache.spark.scheduler.cluster.YarnSchedulerBackend$YarnSchedulerEndpoint: Requesting driver to remove executor 1 for reason Container killed by YARN for exceeding memory limits.  10.6 GB of 10 GB physical memory used. Consider boosting spark.yarn.executor.memoryOverhead or disabling yarn.nodemanager.vmem-check-enabled because of YARN-4714.
```
Current default settings are `spark:spark.driver.memory=7680m` and `spark:spark.executor.memory=9309m`.  10 GB limit should be the executor memory + 10% from spark.yarn.executor.memoryOverhead. Each vm has 26 GB so it should be fine.

The extent of my testing was making sure the properties are set with:
```sh
gcloud dataproc clusters create bhr-collection \
    --image-version=1.5 \
    --region=us-central1 \
    --metadata='PIP_PACKAGES=boto3==1.16.20 click==7.1.2 google-cloud-storage==2.7.0' \
    --num-workers=6 \
    --worker-machine-type='n1-highmem-4' \
    --properties "spark:spark.jars=gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar,spark:spark.driver.memory=12g,spark:spark.executor.memory=15g" \
    --initialization-actions='gs://dataproc-initialization-actions/python/pip-install.sh'
```
Setting up the infra and permissions to use the airflow operator or even run the job in a test project is more work than it's worth

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
