### PR TITLE
fix(bqetl_backfill): sandbox arguments are still in main...need to be removed

### DIFF
--- a/dags/bqetl_backfill.py
+++ b/dags/bqetl_backfill.py
@@ -174,11 +174,7 @@ def bqetl_backfill_dag():
         task_id="bqetl_backfill",
         arguments=generate_backfill_command(),
         image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
-        # gcp_conn_id="google_cloud_airflow_gke",
-        gcp_conn_id="google_cloud_gke_sandbox",
-        project_id="moz-fx-data-gke-sandbox",
-        location="us-west1",
-        cluster_name="breyes-gke-sandbox",
+        gcp_conn_id="google_cloud_airflow_gke",
     )
 
 


### PR DESCRIPTION
## Description

This PR removes sandbox arguments added in error from previous PRs related to AD-243