### PR TITLE
fix: Increase bhr_collection spark memory

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -87,7 +87,7 @@ with DAG(
         "additional_properties": {
             "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
             "spark:spark.driver.memory": "18g",
-            "spark:spark.executor.memory": "22g",
+            "spark:spark.executor.memory": "24g",
         },
         "idle_delete_ttl": 14400,
         "num_workers": 6,


### PR DESCRIPTION
## Description

Continuation of:
https://bugzilla.mozilla.org/show_bug.cgi?id=1892258
https://bugzilla.mozilla.org/show_bug.cgi?id=1897484

Switching vm types to n2 which have slightly more memory per core, and increasing the spark memory allocation