### PR TITLE
chore(ci): Filter manual-publish workflows.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,6 +365,6 @@ workflows:
             - 🛠️ Docker build and persist image
           filters:
             tags:
-              only: /.*/
+              only: /^dev-.*/
             branches:
-              ignore: /.*/
+              ignore: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,9 +353,9 @@ workflows:
           name: 🛠️ Docker build and persist image
           filters:
             tags:
-              only: /.*/
+              only: /^dev-.*/
             branches:
-              ignore: /.*/
+              ignore: main
       - publish-registry:
           name: Publish image with manually created tag to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,27 @@ jobs:
             git commit -m "Automatic commit - DAGs from commit $GIT_SHA1_SHORT build ${CIRCLE_BUILD_NUM} [skip ci]" \
               && git push \
               || echo "Skipping push since it looks like there were no changes"
+            
+  check-branch:
+    executor: *python-executor
+    steps:
+      - checkout
+      - run:
+          name: "Determine branch of the commit"
+          command: |
+            # Fetch the branch name for the commit associated with the tag
+            COMMIT_BRANCH=$(git branch -r --contains "$(git rev-parse HEAD)" | grep -v 'main' || true)
+            
+            # Exit if the branch is main
+            if [ -z "$COMMIT_BRANCH" ]; then
+              echo "This tag is associated with a main branch commit. Exiting."
+              exit 0
+            else
+              echo "This tag is not associated with a main branch commit. Proceeding."
+            fi
+      - run:
+          name: "Run job on dev- tag creation"
+          command: echo "This job runs on tags prefixed with dev- on non-main branches."
 
 workflows:
   ci:
@@ -349,22 +370,32 @@ workflows:
 
   manual-publish:
     jobs:
-      - docker-build-artifact:
-          name: 🛠️ Docker build and persist image
+      - check-branch:
+          name: 👮 Check workflow runs on non-main branch
           filters:
             tags:
               only: /^dev-.*/
             branches:
-              ignore: main
+              ignore: /.*/
+      - docker-build-artifact:
+          name: 🛠️ Docker build and persist image
+          requires:
+            - 👮 Check workflow runs on non-main branch
+          filters:
+            tags:
+              only: /^dev-.*/
+            branches:
+              ignore: /.*/
       - publish-registry:
           name: Publish image with manually created tag to GAR
           registry: us-docker.pkg.dev/moz-fx-telemetry-airflow-prod/telemetry-airflow-prod
           additional_tags: $CIRCLE_TAG
           registry_authentication: *gar-auth
           requires:
+            - 👮 Check workflow runs on non-main branch
             - 🛠️ Docker build and persist image
           filters:
             tags:
               only: /^dev-.*/
             branches:
-              ignore: main
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,10 @@ jobs:
             git diff --exit-code requirements.txt requirements-dev.txt
 
   docker-build-artifact:
-    executor: docker/machine
+    executor:
+      name: docker/machine
+      image: ubuntu-2204:2023.04.2
+    resource_class: large
     steps:
       - checkout
       - run: *prepare-env
@@ -392,7 +395,6 @@ workflows:
           additional_tags: $CIRCLE_TAG
           registry_authentication: *gar-auth
           requires:
-            - 👮 Check workflow runs on non-main branch
             - 🛠️ Docker build and persist image
           filters:
             tags:


### PR DESCRIPTION
## Description
This PR restricts the `manual-publish` workflow to non-`main` and tagged commits prefixed by `dev-`. CircleCI uses `OR` for multiple filter conditions, this is why we need a job that checks which branches it runs on.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Validation
![image](https://github.com/mozilla/telemetry-airflow/assets/1668835/c72ab6bb-69cc-49e8-b31d-e7c40a1f2d46)
Created a Github [release](https://github.com/mozilla/telemetry-airflow/releases/tag/dev-manual-release) with tag `dev-manual-release` which triggered this [workflow](https://app.circleci.com/pipelines/github/mozilla/telemetry-airflow/5533/workflows/b0b30e37-0fc1-4667-9b1b-483ef6b986fe) to push the image in GAR.


## Related Tickets & Documents
* DSRE-1658

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
