### PR TITLE
fix(ci): Actually exit with error when `manual-publish` runs from main.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
             # Exit if the branch is main
             if [ -z "$COMMIT_BRANCH" ]; then
               echo "This tag is associated with a main branch commit. Exiting."
-              exit 0
+              exit 1
             else
               echo "This tag is not associated with a main branch commit. Proceeding."
             fi


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Fixes small typo from #1997. Job actually needs to fail if the workflow runs from the main branch.

## Related Tickets & Documents
* [DSRE-1658](https://mozilla-hub.atlassian.net/browse/DSRE-1658)

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[DSRE-1658]: https://mozilla-hub.atlassian.net/browse/DSRE-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ