### PR TITLE
fix(glam): reschedule to give fenix and fog more time

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -55,7 +55,7 @@ tags = [Tag.ImpactTier.tier_2]
 dag = DAG(
     GLAM_DAG,
     default_args=default_args,
-    schedule_interval="0 13 * * *",
+    schedule_interval="0 16 * * *",
     doc_md=__doc__,
     tags=tags,
 )

--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -33,7 +33,7 @@ tags = [Tag.ImpactTier.tier_2]
 dag = DAG(
     "glam_glean_imports",
     default_args=default_args,
-    schedule_interval="0 16 * * *",
+    schedule_interval="0 19 * * *",
     doc_md=__doc__,
     tags=tags,
 )
@@ -43,7 +43,7 @@ wait_for_fenix = ExternalTaskSensor(
     task_id="wait_for_fenix",
     external_dag_id="glam_fenix",
     external_task_id="pre_import",
-    execution_delta=timedelta(hours=14),
+    execution_delta=timedelta(hours=17),
     check_existence=True,
     mode="reschedule",
     allowed_states=ALLOWED_STATES,
@@ -57,7 +57,7 @@ wait_for_fog = ExternalTaskSensor(
     task_id="wait_for_fog",
     external_dag_id="glam_fog",
     external_task_id="pre_import",
-    execution_delta=timedelta(hours=14),
+    execution_delta=timedelta(hours=17),
     check_existence=True,
     mode="reschedule",
     allowed_states=ALLOWED_STATES,


### PR DESCRIPTION
## Description



This PR changes `glam` schedule as an attempt to avoid jobs on `glam_fog` and `glam_fenix` from timing out due to competition for slots. 

## Related Tickets & Documents
* DSRE-1599

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
