### PR TITLE
fix(glam): fix wait for copy dedup exec delta

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -66,7 +66,7 @@ wait_for_main_ping = ExternalTaskSensor(
     task_id="wait_for_copy_deduplicate_main_ping",
     external_dag_id="copy_deduplicate",
     external_task_id="copy_deduplicate_main_ping",
-    execution_delta=timedelta(hours=12),
+    execution_delta=timedelta(hours=15),
     check_existence=True,
     mode="reschedule",
     allowed_states=ALLOWED_STATES,


### PR DESCRIPTION
## Description


This PR fixes the `execution_delta` of `glam` dag's upstream `copy_deduplicate` (missed in https://github.com/mozilla/telemetry-airflow/pull/2000). 


<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
