### PR TITLE
fix: Set bhr_collection spark memory to 20g

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -87,7 +87,7 @@ with DAG(
         "additional_properties": {
             "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
             "spark:spark.driver.memory": "18g",
-            "spark:spark.executor.memory": "24g",
+            "spark:spark.executor.memory": "20g",
         },
         "idle_delete_ttl": 14400,
         "num_workers": 6,


### PR DESCRIPTION
## Description

Follow up for https://github.com/mozilla/telemetry-airflow/pull/1995 where memory was increased from 15g to 24g.  This results in the error `Required executor memory (24576), overhead (2457 MB), and PySpark memory (0 MB) is above the max threshold (24576 MB) of this cluster` so lowering to 20g
