### PR TITLE
feat: DENG-3961 Added dataset id to managed backfill staging table name

### DIFF
--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -74,7 +74,9 @@ with DAG(
         @task
         def prepare_slack_processing_complete_parameters(entry):
             project, dataset, table = entry["qualified_table_name"].split(".")
-            backfill_table_id = f"{dataset}__{table}_{entry['entry_date'].replace('-', '_')}"
+            backfill_table_id = (
+                f"{dataset}__{table}_{entry['entry_date'].replace('-', '_')}"
+            )
             staging_location = (
                 f"{project}.backfills_staging_derived.{backfill_table_id}"
             )


### PR DESCRIPTION
## Description

This PR adds the dataset id to the backfill staging table name for slack notifications.  The was already adjusted in bqetl:  https://github.com/mozilla/bigquery-etl/pull/5721

## Related Tickets & Documents
* DENG-3961

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
