### PR TITLE
fix(DAG): Workday-XMatters [ASP-4631] - Changes in the on_failure_callback

### DIFF
--- a/dags/eam_workday_xmatters_integration.py
+++ b/dags/eam_workday_xmatters_integration.py
@@ -110,7 +110,7 @@ default_args = {
     "emails": ["jmoscon@mozilla.com"],
     "start_date": datetime(2024, 1, 1),
     "retries": 0,
-    "on_failure_callback": [create_jira_ticket],
+    "on_failure_callback": create_jira_ticket,
 }
 tags = [Tag.ImpactTier.tier_3, Tag.Triage.no_triage]
 

--- a/dags/eam_workday_xmatters_integration.py
+++ b/dags/eam_workday_xmatters_integration.py
@@ -110,7 +110,7 @@ default_args = {
     "emails": ["jmoscon@mozilla.com"],
     "start_date": datetime(2024, 1, 1),
     "retries": 0,
-    "on_failure_callback": create_jira_ticket,
+    "on_failure_callback": [create_jira_ticket],
 }
 tags = [Tag.ImpactTier.tier_3, Tag.Triage.no_triage]
 

--- a/dags/eam_workday_xmatters_integration.py
+++ b/dags/eam_workday_xmatters_integration.py
@@ -110,6 +110,7 @@ default_args = {
     "emails": ["jmoscon@mozilla.com"],
     "start_date": datetime(2024, 1, 1),
     "retries": 0,
+    "on_failure_callback": create_jira_ticket,
 }
 tags = [Tag.ImpactTier.tier_3, Tag.Triage.no_triage]
 
@@ -170,7 +171,6 @@ with DAG(
     "eam-workday-xmatters-integration",
     default_args=default_args,
     doc_md=DOCS,
-    on_failure_callback=create_jira_ticket,
     tags=tags,
     schedule_interval="@daily",
 ) as dag:


### PR DESCRIPTION
Description:
The on_failure_callback set in the DAG is not being called when the task fails. 
Moving it to default_args.

JIRA TICKET ASP [4631](https://mozilla-hub.atlassian.net/browse/ASP-4631)
JIRA EPIC TICKET [ASP-4509](https://mozilla-hub.atlassian.net/browse/ASP-4509)

[ASP-4509]: https://mozilla-hub.atlassian.net/browse/ASP-4509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ