### PR TITLE
feat(microsoft_store): initial add microsoft_store DAG

### DIFF
--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -1,0 +1,120 @@
+from airflow.providers.cncf.kubernetes.secret import Secret
+from airflow import DAG
+from airflow.sensors.external_task import ExternalTaskMarker
+from airflow.sensors.external_task import ExternalTaskSensor
+from airflow.utils.task_group import TaskGroup
+import datetime
+from operators.gcp_container_operator import GKEPodOperator
+from utils.constants import ALLOWED_STATES, FAILED_STATES
+from utils.gcp import bigquery_etl_query, bigquery_dq_check
+ 
+# Deploy value associated with Microsoft Store keys in k8s secret `airflow-gke-secrets` in environments Microsoft variables
+microsoft_client_id = Secret(deploy_type="env", deploy_target="MICROSOFT_CLIENT_ID", secret="airflow-gke-secrets", key="MICROSOFT_CLIENT_ID")
+microsoft_client_secret = Secret(deploy_type="env", deploy_target="MICROSOFT_CLIENT_SECRET", secret="airflow-gke-secrets", key="MICROSOFT_CLIENT_SECRET")
+microsoft_tenant_id = Secret(deploy_type="env", deploy_target="MICROSOFT_TENANT_ID", secret="airflow-gke-secrets", key="MICROSOFT_TENANT_ID")
+microsoft_store_app_list =  Secret(deploy_type="env", deploy_target="MICROSOFT_STORE_APP_LIST", secret="airflow-gke-secrets", key="MICROSOFT_STORE_APP_LIST")
+
+docs = """
+
+#### Owner
+mhirose@mozilla.com
+#### Tags
+* impact/tier_2
+* repo/bigquery-etl
+"""
+
+default_args = {
+    "owner": "mhirose@mozilla.com",
+    "start_date": datetime.datetime(2024, 6, 18, 0, 0),
+    "end_date": None,
+    "email": ["telemetry-alerts@mozilla.com", "mhirose@mozilla.com"],
+    "depends_on_past": False,
+    "retry_delay": datetime.timedelta(seconds=1800),
+    "email_on_failure": True,
+    "email_on_retry": True,
+    "retries": 2,
+}
+
+read_gke_secret = GKEPodOperator(
+    task_id="read-gke-secret",
+    name="read-gke-secret",
+    image="ubuntu:23.04",
+    arguments=["sleep", "100"],
+    dag=dag,
+    secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list]
+)
+
+with DAG(
+    "microsoft_store",
+    default_args=default_args,
+    schedule_interval="0 4 * * *",
+    doc_md=docs,
+    tags=tags,
+) as dag:
+    microsoft_derived__app_acquisitions__v1 = GKEPodOperator(
+        task_id="microsoft_derived__microsoft_acquisitions__v1",
+        arguments=[
+            "python",
+            "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_acquisitions_v1/query.py",
+        ]
+        + [
+            "--date", 
+            "{{ds}}",
+            "--microsoft_client_id", 
+            "{{var.value.MICROSOFT_CLIENT_ID}}",
+            "--microsoft_store_app_list", 
+            "{{var.value.MICROSOFT_STORE_APP_LIST}}",
+            "--microsoft_tenant_id", 
+            "{{var.value.MICROSOFT_TENANT_ID}}"
+        ],
+        image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
+        owner="mhirose@mozilla.com",
+        email=["mhirose@mozilla.com", "telemetry-alerts@mozilla.com"],
+    )
+
+
+    microsoft_derived__app_conversions__v1 = GKEPodOperator(
+        task_id="microsoft_derived__app_conversions__v1",
+        arguments=[
+            "python",
+            "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_conversions_v1/query.py",
+        ]
+        + [
+            "--date", 
+            "{{ds}}",
+            "--microsoft_client_id", 
+            "{{var.value.MICROSOFT_CLIENT_ID}}",
+            "--microsoft_store_app_list", 
+            "{{var.value.MICROSOFT_STORE_APP_LIST}}",
+            "--microsoft_tenant_id", 
+            "{{var.value.MICROSOFT_TENANT_ID}}"
+        ],
+        image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
+        owner="mhirose@mozilla.com",
+        email=["mhirose@mozilla.com", "telemetry-alerts@mozilla.com"],
+    )
+
+    microsoft_derived__app_installs__v1 = GKEPodOperator(
+        task_id="microsoft_derived__app_installs__v1",
+        arguments=[
+            "python",
+            "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_installs_v1/query.py",
+        ]
+        + [
+            "--date", 
+            "{{ds}}",
+            "--microsoft_client_id", 
+            "{{var.value.MICROSOFT_CLIENT_ID}}",
+            "--microsoft_store_app_list", 
+            "{{var.value.MICROSOFT_STORE_APP_LIST}}",
+            "--microsoft_tenant_id", 
+            "{{var.value.MICROSOFT_TENANT_ID}}"
+        ],
+        image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
+        owner="mhirose@mozilla.com",
+        email=["mhirose@mozilla.com", "telemetry-alerts@mozilla.com"],
+    )
+
+microsoft_derived__app_acquisitions__v1
+microsoft_derived__app_conversions__v1
+microsoft_derived__app_installs__v1

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -52,6 +52,8 @@ default_args = {
     "retries": 2,
 }
 
+TAGS = [Tag.ImpactTier.tier_2]
+
 with DAG(
     "microsoft_store",
     default_args=default_args,

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -60,6 +60,7 @@ with DAG(
     default_args=default_args,
     schedule_interval="0 4 * * *",
     doc_md=docs,
+    tags=tags,
 ) as dag:
     microsoft_derived__app_acquisitions__v1 = GKEPodOperator(
         task_id="microsoft_derived__microsoft_acquisitions__v1",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -69,8 +69,6 @@ with DAG(
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_acquisitions_v1/query.py",
-        ]
-        + [
             "--date",
             "{{ds}}",
             "--microsoft_client_id",
@@ -96,8 +94,6 @@ with DAG(
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_conversions_v1/query.py",
-        ]
-        + [
             "--date",
             "{{ds}}",
             "--microsoft_client_id",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -138,7 +138,3 @@ with DAG(
         owner="mhirose@mozilla.com",
         email=["mhirose@mozilla.com", "telemetry-alerts@mozilla.com"],
     )
-
-microsoft_derived__app_acquisitions__v1
-microsoft_derived__app_conversions__v1
-microsoft_derived__app_installs__v1

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -123,8 +123,6 @@ with DAG(
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_installs_v1/query.py",
-        ]
-        + [
             "--date",
             "{{ds}}",
             "--microsoft_client_id",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -7,12 +7,32 @@ import datetime
 from operators.gcp_container_operator import GKEPodOperator
 from utils.constants import ALLOWED_STATES, FAILED_STATES
 from utils.gcp import bigquery_etl_query, bigquery_dq_check
- 
+
 # Deploy value associated with Microsoft Store keys in k8s secret `airflow-gke-secrets` in environments Microsoft variables
-microsoft_client_id = Secret(deploy_type="env", deploy_target="MICROSOFT_CLIENT_ID", secret="airflow-gke-secrets", key="MICROSOFT_CLIENT_ID")
-microsoft_client_secret = Secret(deploy_type="env", deploy_target="MICROSOFT_CLIENT_SECRET", secret="airflow-gke-secrets", key="MICROSOFT_CLIENT_SECRET")
-microsoft_tenant_id = Secret(deploy_type="env", deploy_target="MICROSOFT_TENANT_ID", secret="airflow-gke-secrets", key="MICROSOFT_TENANT_ID")
-microsoft_store_app_list =  Secret(deploy_type="env", deploy_target="MICROSOFT_STORE_APP_LIST", secret="airflow-gke-secrets", key="MICROSOFT_STORE_APP_LIST")
+microsoft_client_id = Secret(
+    deploy_type="env",
+    deploy_target="MICROSOFT_CLIENT_ID",
+    secret="airflow-gke-secrets",
+    key="MICROSOFT_CLIENT_ID",
+)
+microsoft_client_secret = Secret(
+    deploy_type="env",
+    deploy_target="MICROSOFT_CLIENT_SECRET",
+    secret="airflow-gke-secrets",
+    key="MICROSOFT_CLIENT_SECRET",
+)
+microsoft_tenant_id = Secret(
+    deploy_type="env",
+    deploy_target="MICROSOFT_TENANT_ID",
+    secret="airflow-gke-secrets",
+    key="MICROSOFT_TENANT_ID",
+)
+microsoft_store_app_list = Secret(
+    deploy_type="env",
+    deploy_target="MICROSOFT_STORE_APP_LIST",
+    secret="airflow-gke-secrets",
+    key="MICROSOFT_STORE_APP_LIST",
+)
 
 docs = """
 
@@ -44,43 +64,52 @@ with DAG(
 ) as dag:
     microsoft_derived__app_acquisitions__v1 = GKEPodOperator(
         task_id="microsoft_derived__microsoft_acquisitions__v1",
-        secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list],
+        secrets=[
+            microsoft_client_id,
+            microsoft_client_secret,
+            microsoft_tenant_id,
+            microsoft_store_app_list,
+        ],
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_acquisitions_v1/query.py",
         ]
         + [
-            "--date", 
+            "--date",
             "{{ds}}",
-            "--microsoft_client_id", 
+            "--microsoft_client_id",
             "{{var.value.MICROSOFT_CLIENT_ID}}",
-            "--microsoft_store_app_list", 
+            "--microsoft_store_app_list",
             "{{var.value.MICROSOFT_STORE_APP_LIST}}",
-            "--microsoft_tenant_id", 
-            "{{var.value.MICROSOFT_TENANT_ID}}"
+            "--microsoft_tenant_id",
+            "{{var.value.MICROSOFT_TENANT_ID}}",
         ],
         image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
         owner="mhirose@mozilla.com",
         email=["mhirose@mozilla.com", "telemetry-alerts@mozilla.com"],
     )
 
-
     microsoft_derived__app_conversions__v1 = GKEPodOperator(
         task_id="microsoft_derived__app_conversions__v1",
-        secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list],
+        secrets=[
+            microsoft_client_id,
+            microsoft_client_secret,
+            microsoft_tenant_id,
+            microsoft_store_app_list,
+        ],
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_conversions_v1/query.py",
         ]
         + [
-            "--date", 
+            "--date",
             "{{ds}}",
-            "--microsoft_client_id", 
+            "--microsoft_client_id",
             "{{var.value.MICROSOFT_CLIENT_ID}}",
-            "--microsoft_store_app_list", 
+            "--microsoft_store_app_list",
             "{{var.value.MICROSOFT_STORE_APP_LIST}}",
-            "--microsoft_tenant_id", 
-            "{{var.value.MICROSOFT_TENANT_ID}}"
+            "--microsoft_tenant_id",
+            "{{var.value.MICROSOFT_TENANT_ID}}",
         ],
         image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
         owner="mhirose@mozilla.com",
@@ -89,20 +118,25 @@ with DAG(
 
     microsoft_derived__app_installs__v1 = GKEPodOperator(
         task_id="microsoft_derived__app_installs__v1",
-        secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list],
+        secrets=[
+            microsoft_client_id,
+            microsoft_client_secret,
+            microsoft_tenant_id,
+            microsoft_store_app_list,
+        ],
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_installs_v1/query.py",
         ]
         + [
-            "--date", 
+            "--date",
             "{{ds}}",
-            "--microsoft_client_id", 
+            "--microsoft_client_id",
             "{{var.value.MICROSOFT_CLIENT_ID}}",
-            "--microsoft_store_app_list", 
+            "--microsoft_store_app_list",
             "{{var.value.MICROSOFT_STORE_APP_LIST}}",
-            "--microsoft_tenant_id", 
-            "{{var.value.MICROSOFT_TENANT_ID}}"
+            "--microsoft_tenant_id",
+            "{{var.value.MICROSOFT_TENANT_ID}}",
         ],
         image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
         owner="mhirose@mozilla.com",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -35,15 +35,6 @@ default_args = {
     "retries": 2,
 }
 
-read_gke_secret = GKEPodOperator(
-    task_id="read-gke-secret",
-    name="read-gke-secret",
-    image="ubuntu:23.04",
-    arguments=["sleep", "100"],
-    dag=dag,
-    secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list]
-)
-
 with DAG(
     "microsoft_store",
     default_args=default_args,
@@ -53,6 +44,7 @@ with DAG(
 ) as dag:
     microsoft_derived__app_acquisitions__v1 = GKEPodOperator(
         task_id="microsoft_derived__microsoft_acquisitions__v1",
+        secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list],
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_acquisitions_v1/query.py",
@@ -75,6 +67,7 @@ with DAG(
 
     microsoft_derived__app_conversions__v1 = GKEPodOperator(
         task_id="microsoft_derived__app_conversions__v1",
+        secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list],
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_conversions_v1/query.py",
@@ -96,6 +89,7 @@ with DAG(
 
     microsoft_derived__app_installs__v1 = GKEPodOperator(
         task_id="microsoft_derived__app_installs__v1",
+        secrets=[microsoft_client_id, microsoft_client_secret, microsoft_tenant_id, microsoft_store_app_list],
         arguments=[
             "python",
             "sql/moz-fx-data-shared-prod/microsoft_derived/microsoft_app_installs_v1/query.py",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -1,12 +1,9 @@
-from airflow.providers.cncf.kubernetes.secret import Secret
-from airflow import DAG
-from airflow.sensors.external_task import ExternalTaskMarker
-from airflow.sensors.external_task import ExternalTaskSensor
-from airflow.utils.task_group import TaskGroup
 import datetime
+
+from airflow import DAG
+from airflow.providers.cncf.kubernetes.secret import Secret
+
 from operators.gcp_container_operator import GKEPodOperator
-from utils.constants import ALLOWED_STATES, FAILED_STATES
-from utils.gcp import bigquery_etl_query, bigquery_dq_check
 
 # Deploy value associated with Microsoft Store keys in k8s secret `airflow-gke-secrets` in environments Microsoft variables
 microsoft_client_id = Secret(
@@ -60,7 +57,6 @@ with DAG(
     default_args=default_args,
     schedule_interval="0 4 * * *",
     doc_md=docs,
-    tags=tags,
 ) as dag:
     microsoft_derived__app_acquisitions__v1 = GKEPodOperator(
         task_id="microsoft_derived__microsoft_acquisitions__v1",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -4,6 +4,7 @@ from airflow import DAG
 from airflow.providers.cncf.kubernetes.secret import Secret
 
 from operators.gcp_container_operator import GKEPodOperator
+from utils.tags import Tag
 
 # Deploy value associated with Microsoft Store keys in k8s secret `airflow-gke-secrets` in environments Microsoft variables
 microsoft_client_id = Secret(
@@ -52,7 +53,7 @@ default_args = {
     "retries": 2,
 }
 
-TAGS = [Tag.ImpactTier.tier_2]
+tags = [Tag.ImpactTier.tier_2]
 
 with DAG(
     "microsoft_store",


### PR DESCRIPTION
## Description

<!-- 

This PR adds the DAG for the Microsoft Store API. We need to use telemetry-airflow because the Microsoft Store needs variables such as client_id, client_secret, product app_ids and tenant_id. These variables should not be shared outside of Mozilla. 
-->

## Related Tickets & Documents
* DENG-2631
* DSRE-XXXX

<!-- 
Jira ticket: https://mozilla-hub.atlassian.net/browse/DENG-2631
-->
