### PR TITLE
chore(bqetl_artifact_deployment): unschedule DAG

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -1,7 +1,9 @@
 """
-Deploy of bigquery etl tables and views, typically triggered by bigquery-etl merges to main.
+Deploy bigquery etl artifacts.
 
-SQL generation can optionally run during the tasks using the `generate_sql` DAG param.
+This DAG is triggered by CircleCI on merges to the `main` branch and by Jenkins after [schemas deploys](https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27920974/BigQuery+shared-prod#BigQuery(shared-prod)-JenkinsJobs).
+
+SQL generation can optionally run during the tasks using the `generate_sql` DAG param, which is used primarily by Jenkins.
 
 *Triage notes*
 
@@ -96,7 +98,7 @@ with DAG(
     "bqetl_artifact_deployment",
     max_active_runs=1,
     default_args=default_args,
-    schedule_interval="@daily",
+    schedule_interval=None,
     doc_md=__doc__,
     tags=tags,
     params=params,


### PR DESCRIPTION
## Description

Requires https://github.com/mozilla-services/cloudops-infra/pull/5736. We should then be running bqetl artifact deploys after every merge to main and every new schemas deploy. Note that on days where there are no schemas updates/bqetl merges, this DAG won't run, so if there is some reason to keep a fallback scheduled this shouldn't land as-is.

## Related Tickets & Documents
* DENG-2963
