### PR TITLE
fix: microsoft store DAG update when DAG runs to day before actual date

### DIFF
--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -80,7 +80,7 @@ with DAG(
             arguments=[
                 "python",
                 f"sql/moz-fx-data-shared-prod/microsoft_derived/{table}_v1/query.py",
-                "--date={{ ds }}",
+                "--date='{{ macros.ds_add(ds, -1) }}",
             ],
             image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
             owner="mhirose@mozilla.com",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -80,7 +80,7 @@ with DAG(
             arguments=[
                 "python",
                 f"sql/moz-fx-data-shared-prod/microsoft_derived/{table}_v1/query.py",
-                "--date='{{ macros.ds_add(ds, -1) }}",
+                "--date='{{ macros.ds_add(ds, -1) }}'",
             ],
             image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
             owner="mhirose@mozilla.com",


### PR DESCRIPTION
## Description

<!-- 
This PR fixes when the DAG runs. DAG was running at the start of the day before any data was collected. This fix makes the DAG run on the previous day AFTER all data has been collected. 
-->

## Related Tickets & Documents
* DENG-2631

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
