### PR TITLE
fix(glam): build extract tables as TaskGroup

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -369,8 +369,10 @@ extract_counts = SubDagOperator(
 )
 
 with dag as dag:
-    with TaskGroup(group_id="extracts", dag=dag, default_args=default_args) as extracts_per_channel:
-        extracts_sql_file_path = f"sql/moz-fx-data-shared-prod/{dataset_id}/glam_client_probe_counts_extract_v1/query.sql"
+    with TaskGroup(
+        group_id="extracts", dag=dag, default_args=default_args
+    ) as extracts_per_channel:
+        extracts_sql_path = f"sql/moz-fx-data-shared-prod/{dataset_id}/glam_client_probe_counts_extract_v1/query.sql"
         for channel in ("nightly", "beta", "release"):
             bq_extract_table = f"glam_extract_firefox_{channel}_v1"
             etl_query = bigquery_etl_query(
@@ -380,7 +382,7 @@ with dag as dag:
                 project_id=billing_project_id,
                 date_partition_parameter=None,
                 arguments=("--replace",),
-                sql_file_path=extracts_sql_file_path,
+                sql_file_path=extracts_sql_path,
                 parameters=(f"channel:STRING:{channel}",),
                 dag=dag,
             )


### PR DESCRIPTION
## Description
This PR fixes a bug introduced in https://github.com/mozilla/telemetry-airflow/pull/2019, which removed the step that builds `extract` tables along with steps to export data to GCS.
Bringing back the step erroneously removed as a `TaskGroup`  instead of a `SubDag`, because the latter is deprecated. 

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
