### PR TITLE
fix(glam_imports): Wait on TaskGroup instead of task

### DIFF
--- a/dags/glam_glean_imports.py
+++ b/dags/glam_glean_imports.py
@@ -70,7 +70,7 @@ wait_for_fog = ExternalTaskSensor(
 wait_for_glam = ExternalTaskSensor(
     task_id="wait_for_glam",
     external_dag_id="glam",
-    external_task_id="extracts",
+    external_task_group_id="extracts",
     execution_delta=timedelta(hours=3),
     check_existence=True,
     mode="reschedule",


### PR DESCRIPTION
## Description


This PR  fixes a dependency that `glam_glean_imports` has on `glam`. The task depended on in the latter DAG became a TaskGroup.

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
