### PR TITLE
chore: remove search engine usage study

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -207,10 +207,6 @@ with DAG(
         for name, url in (
             ("gecko-dev", "https://github.com/mozilla/gecko-dev"),
             ("phabricator", "https://github.com/mozilla-conduit/review"),
-            (
-                "search_engine_usage_study",
-                "https://github.com/mozilla-rally/search-engine-usage-study",
-            ),
         )
     ]
 


### PR DESCRIPTION
## Description

Not sure what this is but upstream rally stuff was removed in https://github.com/mozilla/probe-scraper/pull/781

## Related Tickets & Documents
* DSRE-1173

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
