### PR TITLE
refactor(GLAM): Remove percentile calculation

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -138,30 +138,6 @@ clients_scalar_aggregates = bigquery_etl_query(
     dag=dag,
 )
 
-scalar_percentiles = GKEPodOperator(
-    reattach_on_restart=True,
-    task_id="scalar_percentiles",
-    arguments=[
-        "python3",
-        "script/glam/run_scalar_agg_clustered_query.py",
-        "--submission-date",
-        "{{ds}}",
-        "--dst-table",
-        "scalar_percentiles_v1",
-        "--project",
-        project_id,
-        "--billing-project",
-        billing_project_id,
-        "--tmp-project",
-        tmp_project,
-        "--dataset",
-        dataset_id,
-    ],
-    image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
-    is_delete_operator_pod=False,
-    dag=dag,
-)
-
 
 # This task runs first and replaces the relevant partition, followed
 # by the next task below that appends to the same partition of the same table.
@@ -233,18 +209,6 @@ clients_histogram_aggregates = SubDagOperator(
         docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     ),
     task_id=GLAM_CLIENTS_HISTOGRAM_AGGREGATES_SUBDAG,
-    dag=dag,
-)
-
-histogram_percentiles = bigquery_etl_query(
-    reattach_on_restart=True,
-    task_id="histogram_percentiles",
-    destination_table="histogram_percentiles_v1",
-    dataset_id=fully_qualified_dataset,
-    sql_file_path=f"sql/{table_project_id}/{dataset_id}/histogram_percentiles_v1/query.sql",
-    project_id=billing_project_id,
-    date_partition_parameter=None,
-    arguments=("--replace", "--clustering_fields=metric,channel"),
     dag=dag,
 )
 
@@ -385,10 +349,7 @@ clients_daily_scalar_aggregates >> clients_daily_keyed_scalar_aggregates
 clients_daily_scalar_aggregates >> clients_daily_keyed_boolean_aggregates
 clients_daily_keyed_boolean_aggregates >> clients_scalar_aggregates
 clients_daily_keyed_scalar_aggregates >> clients_scalar_aggregates
-clients_scalar_aggregates >> scalar_percentiles
-# workaround resources exceeded exception
-# client_scalar_probe_counts is not dependent on scalar_percentiles
-scalar_percentiles >> client_scalar_probe_counts
+clients_scalar_aggregates >> client_scalar_probe_counts
 
 latest_versions >> clients_daily_histogram_aggregates_parent
 clients_daily_histogram_aggregates_parent >> clients_daily_histogram_aggregates_content
@@ -401,17 +362,12 @@ clients_daily_keyed_histogram_aggregates >> clients_histogram_aggregates
 clients_histogram_aggregates >> clients_histogram_bucket_counts
 clients_histogram_aggregates >> glam_user_counts
 clients_histogram_aggregates >> glam_sample_counts
-
-
 clients_histogram_bucket_counts >> clients_histogram_probe_counts
-clients_histogram_probe_counts >> histogram_percentiles
 
 clients_scalar_aggregates >> glam_user_counts
 glam_user_counts >> extract_counts
 
-
 extract_counts >> extracts_per_channel
 client_scalar_probe_counts >> extracts_per_channel
-scalar_percentiles >> extracts_per_channel
-histogram_percentiles >> extracts_per_channel
+clients_histogram_probe_counts >> extracts_per_channel
 glam_sample_counts >> extracts_per_channel

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -158,7 +158,6 @@ with DAG(
         # stage 2 - downstream for export
         scalar_bucket_counts = query(task_name=f"{product}__scalar_bucket_counts_v1")
         scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")
-        scalar_percentile = query(task_name=f"{product}__scalar_percentiles_v1")
 
         histogram_bucket_counts = query(
             task_name=f"{product}__histogram_bucket_counts_v1"
@@ -166,7 +165,6 @@ with DAG(
         histogram_probe_counts = query(
             task_name=f"{product}__histogram_probe_counts_v1"
         )
-        histogram_percentiles = query(task_name=f"{product}__histogram_percentiles_v1")
 
         probe_counts = view(task_name=f"{product}__view_probe_counts_v1")
         extract_probe_counts = query(task_name=f"{product}__extract_probe_counts_v1")
@@ -218,14 +216,12 @@ with DAG(
             clients_scalar_aggregate
             >> scalar_bucket_counts
             >> scalar_probe_counts
-            >> scalar_percentile
             >> probe_counts
         )
         (
             clients_histogram_aggregate
             >> histogram_bucket_counts
             >> histogram_probe_counts
-            >> histogram_percentiles
             >> probe_counts
         )
         probe_counts >> sample_counts >> extract_probe_counts >> export >> pre_import

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -8,8 +8,9 @@ in bigquery-etl and the
 in telemetry-airflow.
 """
 
+import operator
 from datetime import datetime, timedelta
-from functools import partial
+from functools import partial, reduce
 
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
@@ -118,7 +119,7 @@ with DAG(
 
     # the set of logical ids and the set of ids that are not mapped to logical ids
     final_products = set(LOGICAL_MAPPING.keys()) | set(PRODUCTS) - set(
-        sum(LOGICAL_MAPPING.values(), [])
+        reduce(operator.iadd, LOGICAL_MAPPING.values(), [])
     )
     for product in final_products:
         func = partial(

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -139,7 +139,6 @@ with DAG(
         # stage 2 - downstream for export
         scalar_bucket_counts = query(task_name=f"{product}__scalar_bucket_counts_v1")
         scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")
-        scalar_percentile = query(task_name=f"{product}__scalar_percentiles_v1")
 
         histogram_bucket_counts = query(
             task_name=f"{product}__histogram_bucket_counts_v1"
@@ -147,7 +146,6 @@ with DAG(
         histogram_probe_counts = query(
             task_name=f"{product}__histogram_probe_counts_v1"
         )
-        histogram_percentiles = query(task_name=f"{product}__histogram_percentiles_v1")
 
         probe_counts = view(task_name=f"{product}__view_probe_counts_v1")
         extract_probe_counts = query(task_name=f"{product}__extract_probe_counts_v1")
@@ -199,14 +197,12 @@ with DAG(
             clients_scalar_aggregate
             >> scalar_bucket_counts
             >> scalar_probe_counts
-            >> scalar_percentile
             >> probe_counts
         )
         (
             clients_histogram_aggregate
             >> histogram_bucket_counts
             >> histogram_probe_counts
-            >> histogram_percentiles
             >> probe_counts
         )
         probe_counts >> sample_counts >> extract_probe_counts >> export >> pre_import

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -1,5 +1,6 @@
+import operator
 from datetime import datetime, timedelta
-from functools import partial
+from functools import partial, reduce
 
 from airflow import DAG
 from airflow.operators.empty import EmptyOperator
@@ -99,7 +100,7 @@ with DAG(
 
     # the set of logical ids and the set of ids that are not mapped to logical ids
     final_products = set(LOGICAL_MAPPING.keys()) | set(PRODUCTS) - set(
-        sum(LOGICAL_MAPPING.values(), [])
+        reduce(operator.iadd, LOGICAL_MAPPING.values(), [])
     )
     for product in final_products:
         func = partial(


### PR DESCRIPTION
## Description


This PR removes steps that calculate percentiles from the GLAM dags.
Percentiles will be calculated ad hoc from now on for cost savings
See also: https://github.com/mozilla/bigquery-etl/pull/5957 

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
