### PR TITLE
fix(plugins): Use tuple for timetable plugin registration

### DIFF
--- a/plugins/timetable.py
+++ b/plugins/timetable.py
@@ -64,4 +64,4 @@ class MultiWeekTimetable(Timetable):
 
 class MozillaTimetablePlugin(AirflowPlugin):
     name = "mozilla_timetable_plugin"
-    timetables = MultiWeekTimetable
+    timetables = (MultiWeekTimetable,)


### PR DESCRIPTION
## Description
This PR fixes [this error introduced in this PR](https://github.com/mozilla/telemetry-airflow/pull/2052/files#diff-6bc3f0b18e373dee50a3699d36a6afa83d65925836689c2a4a71b4161470c659)

## Related Tickets & Documents
* None

## Validation
Local env
![image](https://github.com/user-attachments/assets/02218e5c-e267-4329-ae29-192145d5272b)


<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
