### PR TITLE
fix(dbt_daily): Set dbt account ID

### DIFF
--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -29,7 +29,7 @@ default_args = {
     "retries": 2,
     "retry_delay": timedelta(minutes=30),
     "dbt_cloud_conn_id": "dbt_cloud",
-    "account_id": Variable.get("dbt_account_id")
+    "account_id": "{{ var.value.dbt_account_id }}"
 }
 
 tags = [

--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
+from airflow.models import Variable
 from airflow.providers.dbt.cloud.operators.dbt import DbtCloudRunJobOperator
 from airflow.sensors.external_task import ExternalTaskSensor
 
@@ -27,6 +28,8 @@ default_args = {
     "email_on_retry": True,
     "retries": 2,
     "retry_delay": timedelta(minutes=30),
+    "dbt_cloud_conn_id": "dbt_cloud",
+    "account_id": Variable.get("dbt_account_id")
 }
 
 tags = [

--- a/resources/dev_variables.json
+++ b/resources/dev_variables.json
@@ -21,5 +21,6 @@
     "taar_dataflow_subnetwork": "taar_dataflow_subnetwork",
     "taar_etl_model_storage_bucket": "taar_etl_model_storage_bucket",
     "taar_etl_storage_bucket": "taar_etl_storage_bucket",
-    "taar_gcp_project_id": "taar_gcp_project_id"
+    "taar_gcp_project_id": "taar_gcp_project_id",
+    "dbt_account_id": "dbt_account_id"
 }


### PR DESCRIPTION
The dbt account ID needs to be specified as part of the DAG config. This ID is not secret so it's fine to have it in an environment variable. It's more convenient to store it in a variable for other DAGs triggering dbt to reference it.