### PR TITLE
feat(url):[Workday/Everfi]Changed the Jira link to prod. Removed tag no_triage.

### DIFF
--- a/dags/eam_workday_everfi_integration.py
+++ b/dags/eam_workday_everfi_integration.py
@@ -49,7 +49,7 @@ def create_jira_ticket(context):
     ).get_connection(conn_id)
     log_url = get_airflow_log_link(context)
 
-    jira_domain = "mozilla-hub-sandbox-721.atlassian.net"
+    jira_domain = "mozilla-hub.atlassian.net"
     url = f"https://{jira_domain}/rest/api/3/issue"
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
     auth = HTTPBasicAuth(conn.login, conn.password)
@@ -116,7 +116,7 @@ default_args = {
     "retry_delay": datetime.timedelta(minutes=5),
     "on_failure_callback": create_jira_ticket,
 }
-tags = [Tag.ImpactTier.tier_3, Tag.Triage.no_triage]
+tags = [Tag.ImpactTier.tier_3]
 
 
 EVERFI_INTEG_WORKDAY_USERNAME = Secret(


### PR DESCRIPTION
Go-live preparation: Changed the Jira link to production — removed tag no_triage.

[Jira ticket ASP-5115](https://mozilla-hub.atlassian.net/browse/ASP-5115)
[Epic ASP-4744](https://mozilla-hub.atlassian.net/browse/ASP-4744)

