### PR TITLE
feat: Bug 1910995 - Enable the detection of TB metrics

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -207,6 +207,7 @@ with DAG(
         for name, url in (
             ("gecko-dev", "https://github.com/mozilla/gecko-dev"),
             ("phabricator", "https://github.com/mozilla-conduit/review"),
+            ("releases-comm-central", "https://github.com/mozilla/releases-comm-central"),
         )
     ]
 


### PR DESCRIPTION
As called out in mozilla/probe-scraper#790 this PR is necessary to address the lack of a way to run the GH workflow for Thunderbird ([docs](https://mozilla.github.io/glean/book/user/adding-glean-to-your-project/enable-data-ingestion.html#validate-and-publish-metrics)). Given that TB uses Mercurial/Git Mirror, I'm replicating the same mechanism used for Firefox Desktop.

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1910995

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
