### PR TITLE
fix(fxci): change fxci metric export schedule to run at 00:30

### DIFF
--- a/dags/fxci_metric_export.py
+++ b/dags/fxci_metric_export.py
@@ -50,7 +50,7 @@ with DAG(
     "fxci_metric_export",
     default_args=default_args,
     doc_md=__doc__,
-    schedule_interval="@daily",
+    schedule_interval="30 0 * * *",
     tags=tags,
 ) as dag:
     fxci_metric_export = GKEPodOperator(


### PR DESCRIPTION
There's a check in the code that prevents the export from running too close to midnight. This is because there's a slight lag in the Google Cloud Monitoring data becoming available.

Running 30 minutes past the hour should be plenty of buffer time.
