### PR TITLE
fix: change owner for probe scraper dag glean dictonary task

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -363,9 +363,9 @@ with DAG(
         endpoint=Variable.get("glean_dictionary_netlify_build_webhook_id"),
         method="POST",
         data={},
-        owner="linh@mozilla.com",
+        owner="jrediger@mozilla.com",
         email=[
-            "linh@mozilla.com",
+            "jrediger@mozilla.com",
             "dataops+alerts@mozilla.com",
             "telemetry-alerts@mozilla.com",
         ],


### PR DESCRIPTION
## Description

switch the owner from Linh to jrediger for the `glean_dictionary_netlify_build` task in the `probescraper` dag