### PR TITLE
feat: remove data-observability-dev from artifact deployment

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -86,7 +86,6 @@ with DAG(
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-experiments && "
             "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-marketing-prod && "
-            "script/bqetl query initialize '*' --skip-existing --project-id=data-observability-dev && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-shared-prod && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-experiments && "
@@ -94,9 +93,7 @@ with DAG(
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
-            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
-            "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=data-observability-dev && "
-            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=data-observability-dev"
+            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7"
         ],
         image=docker_image,
     )
@@ -109,13 +106,11 @@ with DAG(
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-experiments && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-glam-prod-fca7 && "
-            "script/bqetl view publish --add-managed-label --skip-authorized --project-id=data-observability-dev && "
             "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod --target-project=mozdata --user-facing-only && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-glam-prod-fca7 --project-id=moz-fx-data-glam-prod-fca7 && "
-            "script/bqetl view clean --skip-authorized --target-project=data-observability-dev --project-id=data-observability-dev && "
             "script/bqetl view clean --skip-authorized --target-project=mozdata --user-facing-only && "
             "script/publish_public_data_views --target-project=moz-fx-data-shared-prod && "
             "script/publish_public_data_views --target-project=mozdata"
@@ -132,8 +127,7 @@ with DAG(
             "script/bqetl metadata publish '*' --project_id=moz-fx-data-shared-prod && "
             "script/bqetl metadata publish '*' --project_id=mozdata && "
             "script/bqetl metadata publish '*' --project_id=moz-fx-data-marketing-prod && "
-            "script/bqetl metadata publish '*' --project_id=moz-fx-data-experiments && "
-            "script/bqetl metadata publish '*' --project_id=data-observability-dev"
+            "script/bqetl metadata publish '*' --project_id=moz-fx-data-experiments"
         ],
         image=docker_image,
     )


### PR DESCRIPTION
Follow up to https://github.com/mozilla/bigquery-etl/pull/6081, will fix one of the issues currently affecting artifact deployment.