### PR TITLE
fix: Using Airflow variables for LookML validation

### DIFF
--- a/dags/looker.py
+++ b/dags/looker.py
@@ -172,8 +172,8 @@ with DAG(
             "pip install spectacles==2.4.10 && " # todo: remove this once mozilla-nimbus-schemas supports newer pydantic version
             "spectacles content --verbose"
             " --base-url ${BASE_URL}"
-            " --client-id ${LOOKER_API_CLIENT_ID}"
-            " --client-secret ${LOOKER_API_CLIENT_SECRET}"
+            f" --client-id {Variable.get('looker_api_client_id_prod')}"
+            f" --client-secret {Variable.get('looker_api_client_secret_prod')}"
             " --project spoke-default"
             " --branch ${BRANCH}"
             " --pin-imports looker-hub:main"

--- a/resources/dev_variables.json
+++ b/resources/dev_variables.json
@@ -22,5 +22,7 @@
     "taar_etl_model_storage_bucket": "taar_etl_model_storage_bucket",
     "taar_etl_storage_bucket": "taar_etl_storage_bucket",
     "taar_gcp_project_id": "taar_gcp_project_id",
-    "dbt_account_id": "dbt_account_id"
+    "dbt_account_id": "dbt_account_id",
+    "looker_api_client_id_prod": "looker_api_client_id_prod",
+    "looker_api_client_secret_prod": "looker_api_client_secret_prod"
 }


### PR DESCRIPTION
This PR switches from referencing secrets to referencing existing Airflow variables to pass the client secret for LookML validation. Previously the referenced secrets appeared in clear text in the logs. This change will ensure that they are masked