### PR TITLE
fix: update fxci_metric_export dag to pass in --date

### DIFF
--- a/dags/fxci_metric_export.py
+++ b/dags/fxci_metric_export.py
@@ -60,6 +60,7 @@ with DAG(
             "metric",
             "export",
             "-vv",
+            "--date={{ ds }}",
         ],
         env_vars=env_vars,
         secrets=secrets,


### PR DESCRIPTION
The underlying ETL is switching to explicitly passing in the date, so adjust accordingly.

## Related Tickets & Documents
* Bug 1912067
