### PR TITLE
refactor: Change `lookml_validate_spectacles` task to use environment variables that Spectacles expects

### DIFF
--- a/dags/looker.py
+++ b/dags/looker.py
@@ -67,6 +67,18 @@ looker_api_client_secret_staging = Secret(
     secret="airflow-gke-secrets",
     key="probe_scraper_secret__looker_api_client_secret_staging",
 )
+looker_client_id_prod = Secret(
+    deploy_type="env",
+    deploy_target="LOOKER_CLIENT_ID",
+    secret="airflow-gke-secrets",
+    key="probe_scraper_secret__looker_api_client_id_prod",
+)
+looker_client_secret_prod = Secret(
+    deploy_type="env",
+    deploy_target="LOOKER_CLIENT_SECRET",
+    secret="airflow-gke-secrets",
+    key="probe_scraper_secret__looker_api_client_secret_prod",
+)
 dataops_looker_github_secret_access_token = Secret(
     deploy_type="env",
     deploy_target="GITHUB_ACCESS_TOKEN",
@@ -171,9 +183,6 @@ with DAG(
         arguments=[
             "pip install spectacles==2.4.10 && " # todo: remove this once mozilla-nimbus-schemas supports newer pydantic version
             "spectacles content --verbose"
-            " --base-url ${BASE_URL}"
-            " --client-id {{ var.value.looker_api_client_id_prod }}"
-            " --client-secret {{ var.value.looker_api_client_secret_prod }}"
             " --project spoke-default"
             " --branch ${BRANCH}"
             " --pin-imports looker-hub:main"
@@ -181,9 +190,9 @@ with DAG(
         ],
         env_vars={
             "BRANCH": "main-validation", # this branch is a mirror of main, but Looker cannot open production branches (like main) for validation
-            "BASE_URL": "https://mozilla.cloud.looker.com",
+            "LOOKER_BASE_URL": "https://mozilla.cloud.looker.com",
         },
-        secrets=[looker_api_client_id_prod, looker_api_client_secret_prod],
+        secrets=[looker_client_id_prod, looker_client_secret_prod],
         **airflow_gke_prod_kwargs,
     )
 

--- a/dags/looker.py
+++ b/dags/looker.py
@@ -184,12 +184,11 @@ with DAG(
             "pip install spectacles==2.4.10 && " # todo: remove this once mozilla-nimbus-schemas supports newer pydantic version
             "spectacles content --verbose"
             " --project spoke-default"
-            " --branch ${BRANCH}"
+            " --branch main-validation"  # this branch is a mirror of main, but Looker cannot open production branches (like main) for validation
             " --pin-imports looker-hub:main"
             f" --folders {' '.join(looker_folders_to_validate)}"
         ],
         env_vars={
-            "BRANCH": "main-validation", # this branch is a mirror of main, but Looker cannot open production branches (like main) for validation
             "LOOKER_BASE_URL": "https://mozilla.cloud.looker.com",
         },
         secrets=[looker_client_id_prod, looker_client_secret_prod],


### PR DESCRIPTION
## Description

So the Looker base URL, client ID, and client secret don't need to be passed as command line arguments.

## Related Tickets & Documents
* Follow-up to #2076.