### PR TITLE
chore(GLAM): Turn FoG histogram_bucket_counts into TaskGroup

### DIFF
--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -140,9 +140,22 @@ with DAG(
         scalar_bucket_counts = query(task_name=f"{product}__scalar_bucket_counts_v1")
         scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")
 
-        histogram_bucket_counts = query(
-            task_name=f"{product}__histogram_bucket_counts_v1"
-        )
+        with TaskGroup(
+            group_id=f"{product}__histogram_bucket_counts_v1", dag=dag, default_args=default_args
+        ) as histogram_bucket_counts:
+            prev_task = None
+            # Windows + Release data is in [0-9] so we're further splitting that range.
+            for sample_range in ([0, 2], [3, 5], [6, 9], [10, 49], [50, 99]):
+                histogram_bucket_counts = query(
+                    task_name=f"{product}__histogram_bucket_counts_v1_sampled_{sample_range[0]}_{sample_range[1]}",
+                    min_sample_id=sample_range[0],
+                    max_sample_id=sample_range[1],
+                    replace_table=(sample_range[0] == 0)
+                )
+                if prev_task:
+                    histogram_bucket_counts.set_upstream(prev_task)
+                prev_task = histogram_bucket_counts
+
         histogram_probe_counts = query(
             task_name=f"{product}__histogram_probe_counts_v1"
         )

--- a/utils/glam_subdags/generate_query.py
+++ b/utils/glam_subdags/generate_query.py
@@ -140,6 +140,7 @@ def generate_and_run_glean_task(
         env_vars = {}
 
     query_name = task_name.split("_sampled_")[0]
+    # If a range smaller than 100% of the samples is being used then sample_id is needed.
     use_sample_id = min_sample_id > 0 or max_sample_id < 99
 
     env_vars = {

--- a/utils/glam_subdags/generate_query.py
+++ b/utils/glam_subdags/generate_query.py
@@ -118,13 +118,16 @@ def generate_and_run_glean_task(
     source_project_id="moz-fx-data-shared-prod",
     docker_image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
     env_vars=None,
+    min_sample_id = 0,
+    max_sample_id = 99,
+    replace_table = True,
     **kwargs,
 ):
     """
     See https://github.com/mozilla/bigquery-etl/blob/main/script/glam/run_glam_sql.
 
     :param task_type:                   Either view, init, or query
-    :param task_name:                   Name of the query
+    :param task_name:                   Name of the task, derives the name of the query
     :param product:                     Product name of glean app
     :param destination_project_id:      Project to store derived tables
     :param destination_dataset_id:      Name of the dataset to store derived tables
@@ -136,6 +139,9 @@ def generate_and_run_glean_task(
     if env_vars is None:
         env_vars = {}
 
+    query_name = task_name.split("_sampled_")[0]
+    use_sample_id = min_sample_id > 0 or max_sample_id < 99
+
     env_vars = {
         "PRODUCT": product,
         "SRC_PROJECT": source_project_id,
@@ -143,6 +149,7 @@ def generate_and_run_glean_task(
         "DATASET": destination_dataset_id,
         "SUBMISSION_DATE": "{{ ds }}",
         "IMPORT": "true",
+        "USE_SAMPLE_ID": use_sample_id,
         **env_vars,
     }
     if task_type not in ["view", "init", "query"]:
@@ -156,7 +163,7 @@ def generate_and_run_glean_task(
         arguments=[
             "script/glam/generate_glean_sql && "
             "source script/glam/run_glam_sql && "
-            f"run_{task_type} {task_name}"
+            f'run_{task_type} {query_name} false {min_sample_id} {max_sample_id} "" --replace={str(replace_table).lower()}'
         ],
         image=docker_image,
         is_delete_operator_pod=False,


### PR DESCRIPTION
## Description
This PR runs GLAM FoG ETL's `histogram_bucket_counts` in sample ranges, because `release_histogram_bucket_counts` frequently goes over the 6h BQ time limit and has to retry, which spends more money.

Complements https://github.com/mozilla/bigquery-etl/pull/6150 to fix https://github.com/mozilla/glam/issues/2936. 


## Related Tickets & Documents
* https://github.com/mozilla/glam/issues/2936
