### PR TITLE
fix(DENG-4152) switch to new location in shared-prod

### DIFF
--- a/dags/ga4_site_metrics_summary_backfill.py
+++ b/dags/ga4_site_metrics_summary_backfill.py
@@ -15,7 +15,6 @@ Built from bigquery-etl repo, [`dags/bqetl_google_analytics_derived_ga4.py`](htt
 This file is meant to look very similar to generated DAGs in bigquery-etl.
 
 #### Owner
-
 kwindau@mozilla.com
 """
 

--- a/dags/ga4_site_metrics_summary_backfill.py
+++ b/dags/ga4_site_metrics_summary_backfill.py
@@ -14,8 +14,7 @@ Built from bigquery-etl repo, [`dags/bqetl_google_analytics_derived_ga4.py`](htt
 
 This file is meant to look very similar to generated DAGs in bigquery-etl.
 
-#### Owner
-kwindau@mozilla.com
+Owner: kwindau@mozilla.com
 """
 
 default_args = {

--- a/dags/ga4_site_metrics_summary_backfill.py
+++ b/dags/ga4_site_metrics_summary_backfill.py
@@ -8,7 +8,7 @@ from utils.gcp import bigquery_dq_check, bigquery_etl_query
 docs = """
 ### ga4_site_metrics_summary_backfill
 
-Backfills the past three days of data for moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2 since late data can arrive for a few days
+Backfills the past three days of data for moz-fx-data-shared-prod.mozilla_org_derived.www_site_metrics_summary_v2 since late data can arrive for a few days
 
 Built from bigquery-etl repo, [`dags/bqetl_google_analytics_derived_ga4.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_google_analytics_derived_ga4.py).
 
@@ -41,15 +41,15 @@ with DAG(
     tags=tags,
 ) as dag:
     for day_offset in ["-3", "-2", "-1"]:
-        task_id = "ga_derived__www_site_metrics_summary__v2__backfill_" + day_offset
+        task_id = "mozilla_org_derived__www_site_metrics_summary__v2__backfill_" + day_offset
         date_str = "macros.ds_add(ds, " + day_offset + ")"
         date_str_no_dash = "macros.ds_format(" + date_str + ", '%Y-%m-%d', '%Y%m%d')"
 
         ga4_www_site_metrics_summary_v2_checks = bigquery_dq_check(
             task_id="checks__fail_" + task_id,
             source_table="www_site_metrics_summary_v2",
-            dataset_id="ga_derived",
-            project_id="moz-fx-data-marketing-prod",
+            dataset_id="mozilla_org_derived",
+            project_id="moz-fx-data-shared-prod",
             is_dq_check_fail=True,
             owner="kwindau@mozilla.com",
             email=["kwindau@mozilla.com", "telemetry-alerts@mozilla.com"],
@@ -63,8 +63,8 @@ with DAG(
             destination_table="www_site_metrics_summary_v2${{ "
             + date_str_no_dash
             + " }}",
-            dataset_id="ga_derived",
-            project_id="moz-fx-data-marketing-prod",
+            dataset_id="mozilla_org_derived",
+            project_id="moz-fx-data-shared-prod",
             owner="kwindau@mozilla.com",
             email=["kwindau@mozilla.com", "telemetry-alerts@mozilla.com"],
             date_partition_parameter=None,
@@ -73,7 +73,7 @@ with DAG(
         )
 
         todays_ga4_www_site_metrics_summary_v2 = ExternalTaskMarker(
-            task_id="rerun__ga_derived__www_site_metrics_summary__v2__" + day_offset,
+            task_id="rerun__mozilla_org_derived__www_site_metrics_summary__v2__" + day_offset,
             external_dag_id="bqetl_google_analytics_derived_ga4",
             external_task_id="wait_for_" + task_id,
             execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=82800)).isoformat() }}",


### PR DESCRIPTION
## Description

* This PR switches the existing DAG that re-runs site metrics summary from its old location in `moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2` to the new location `moz-fx-data-shared-prod.mozilla_org_derived.www_site_metrics_summary_v2`

## Related Tickets & Documents
* [DENG-4152](https://mozilla-hub.atlassian.net/browse/DENG-4152)


[DENG-4152]: https://mozilla-hub.atlassian.net/browse/DENG-4152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ