### PR TITLE
fix(DENG-4142): Update from marketing-prod to shared-prod path

### DIFF
--- a/dags/ga4_site_metrics_summary_backfill.py
+++ b/dags/ga4_site_metrics_summary_backfill.py
@@ -8,15 +8,13 @@ from utils.gcp import bigquery_dq_check, bigquery_etl_query
 docs = """
 ### ga4_site_metrics_summary_backfill
 
-Backfills the past three days of data for moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2 since late data can arrive for a few days
+Backfills the past three days of data for moz-fx-data-shared-prod.mozilla_org_derived.www_site_metrics_summary_v2 since late data can arrive for a few days
 
 Built from bigquery-etl repo, [`dags/bqetl_google_analytics_derived_ga4.py`](https://github.com/mozilla/bigquery-etl/blob/generated-sql/dags/bqetl_google_analytics_derived_ga4.py).
 
 This file is meant to look very similar to generated DAGs in bigquery-etl.
 
-#### Owner
-
-kwindau@mozilla.com
+Owner: kwindau@mozilla.com
 """
 
 default_args = {
@@ -41,15 +39,15 @@ with DAG(
     tags=tags,
 ) as dag:
     for day_offset in ["-3", "-2", "-1"]:
-        task_id = "ga_derived__www_site_metrics_summary__v2__backfill_" + day_offset
+        task_id = "mozilla_org_derived__www_site_metrics_summary__v2__backfill_" + day_offset
         date_str = "macros.ds_add(ds, " + day_offset + ")"
         date_str_no_dash = "macros.ds_format(" + date_str + ", '%Y-%m-%d', '%Y%m%d')"
 
         ga4_www_site_metrics_summary_v2_checks = bigquery_dq_check(
             task_id="checks__fail_" + task_id,
             source_table="www_site_metrics_summary_v2",
-            dataset_id="ga_derived",
-            project_id="moz-fx-data-marketing-prod",
+            dataset_id="mozilla_org_derived",
+            project_id="moz-fx-data-shared-prod",
             is_dq_check_fail=True,
             owner="kwindau@mozilla.com",
             email=["kwindau@mozilla.com", "telemetry-alerts@mozilla.com"],
@@ -63,8 +61,8 @@ with DAG(
             destination_table="www_site_metrics_summary_v2${{ "
             + date_str_no_dash
             + " }}",
-            dataset_id="ga_derived",
-            project_id="moz-fx-data-marketing-prod",
+            dataset_id="mozilla_org_derived",
+            project_id="moz-fx-data-shared-prod",
             owner="kwindau@mozilla.com",
             email=["kwindau@mozilla.com", "telemetry-alerts@mozilla.com"],
             date_partition_parameter=None,
@@ -73,7 +71,7 @@ with DAG(
         )
 
         todays_ga4_www_site_metrics_summary_v2 = ExternalTaskMarker(
-            task_id="rerun__ga_derived__www_site_metrics_summary__v2__" + day_offset,
+            task_id="rerun__mozilla_org_derived__www_site_metrics_summary__v2__" + day_offset,
             external_dag_id="bqetl_google_analytics_derived_ga4",
             external_task_id="wait_for_" + task_id,
             execution_date="{{ (execution_date - macros.timedelta(days=-1, seconds=82800)).isoformat() }}",


### PR DESCRIPTION
## Description

On Friday, we moved the GA4 tables out of marketing-prod and into shared-prod.  As a follow-up to this PR, we need to update this secondary GA4 DAG to point to the new location for the www_site_metrics_summary_v2 table in shared-prod instead of the old location since the table is no longer there.
* Old location: `moz-fx-data-marketing-prod.ga_derived.www_site_metrics_summary_v2`
* New location: `moz-fx-data-shared-prod.mozilla_org_derived.www_site_metrics_summary_v2`

## Related Tickets & Documents
* [DENG-4152](https://mozilla-hub.atlassian.net/browse/DENG-4152)


[DENG-4152]: https://mozilla-hub.atlassian.net/browse/DENG-4152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ