### PR TITLE
Remove spectacles pip install

### DIFF
--- a/dags/looker.py
+++ b/dags/looker.py
@@ -181,7 +181,6 @@ with DAG(
         dag=dag,
         cmds=["bash", "-x", "-c"],
         arguments=[
-            "pip install spectacles==2.4.10 && " # todo: remove this once mozilla-nimbus-schemas supports newer pydantic version
             "spectacles content --verbose"
             " --project spoke-default"
             " --branch main-validation"  # this branch is a mirror of main, but Looker cannot open production branches (like main) for validation


### PR DESCRIPTION
With https://github.com/mozilla/lookml-generator/commit/0ad7a716eff08431d392ebde97024dbd05b79278 lookml-generator has now the latest version of spectacles installed. So this line is no longer needed