### PR TITLE
chore(glam_fenix): Turn Fenix histogram_bucket_counts into a TaskGroup

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -159,9 +159,21 @@ with DAG(
         scalar_bucket_counts = query(task_name=f"{product}__scalar_bucket_counts_v1")
         scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")
 
-        histogram_bucket_counts = query(
-            task_name=f"{product}__histogram_bucket_counts_v1"
-        )
+        with TaskGroup(
+            group_id=f"{product}__histogram_bucket_counts_v1", dag=dag, default_args=default_args
+        ) as histogram_bucket_counts:
+            prev_task = None
+            for sample_range in ([0, 19], [20, 39], [40, 59], [60, 79], [80, 99]):
+                histogram_bucket_counts_sampled = query(
+                    task_name=f"{product}__histogram_bucket_counts_v1_sampled_{sample_range[0]}_{sample_range[1]}",
+                    min_sample_id=sample_range[0],
+                    max_sample_id=sample_range[1],
+                    replace_table=(sample_range[0] == 0)
+                )
+                if prev_task:
+                    histogram_bucket_counts_sampled.set_upstream(prev_task)
+                prev_task = histogram_bucket_counts_sampled
+
         histogram_probe_counts = query(
             task_name=f"{product}__histogram_probe_counts_v1"
         )


### PR DESCRIPTION
## Description
fixes: [1919047](https://bugzilla.mozilla.org/show_bug.cgi?id=1919047)

This PR adds the possibility to run GLAM fenix ETL's histogram_bucket_counts in sample ranges and prevent release_histogram_bucket_counts is going over the 6h BQ time limit.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/1919047


<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
