### PR TITLE
fix(shredder): Reduce sampling parallelism to 4

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -165,7 +165,7 @@ with_sampling = GKEPodOperator(
     arguments=[
         *base_command,
         "--parallelism=1",
-        "--sampling-parallelism=8",
+        "--sampling-parallelism=4",
         "--temp-dataset=moz-fx-data-shredder.shredder_tmp",
         "--billing-project=moz-fx-data-bq-batch-prod",
         "--only",


### PR DESCRIPTION
## Description

follow-up for https://github.com/mozilla/telemetry-airflow/pull/2093

Slots are approximately evenly distributed across queries so having `--sampling-parallelism` too high takes slots away from non-sampling queries.  Setting to 4 should make it closer to what it was without sampling

## Related Tickets & Documents
* DENG-4641