### PR TITLE
fix(shredder): Set sampling parallelism to 2 for shredder-main

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -101,7 +101,7 @@ telemetry_main = GKEPodOperator(
         "--only=telemetry_stable.main_v5",
         "--sampling-tables",
         "telemetry_stable.main_v5",
-        "--sampling-parallelism=4",
+        "--sampling-parallelism=2",
         "--temp-dataset=moz-fx-data-shredder.shredder_tmp",
     ],
     **common_task_args,


### PR DESCRIPTION
## Description

follow up for https://github.com/mozilla/telemetry-airflow/pull/2100

I actually meant to do 4 total concurrent queries at a time (2 queries each for 2 partitions) based on my testing here https://mozilla-hub.atlassian.net/browse/DENG-4641?focusedCommentId=934259.  It will be interesting to see how this affects runtime/slots in prod though
