### PR TITLE
chore(shredder): Stop shredder sampling for main

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -96,13 +96,9 @@ telemetry_main = GKEPodOperator(
     name="shredder-telemetry-main",
     arguments=[
         *base_command,
-        "--parallelism={{ var.value.get('shredder_main_parallelism', 2) }}",
+        "--parallelism=2",
         "--billing-project=moz-fx-data-shredder",
         "--only=telemetry_stable.main_v5",
-        "--sampling-tables",
-        "telemetry_stable.main_v5",
-        "--sampling-parallelism={{ var.value.get('shredder_main_sampling_parallelism', 2) }}",
-        "--temp-dataset=moz-fx-data-shredder.shredder_tmp",
     ],
     **common_task_args,
 )


### PR DESCRIPTION
## Description

Main seems to be taking longer on lower volume days (weekends) which offsets any small improvements for the other days.  Also storage costs for the temp dataset are higher than I expected so removing this while I try a workaround, otherwise it's not worth it.

## Related Tickets & Documents
* DENG-4641
