### PR TITLE
fix(providers): Upgrade to kubernetes provider 8.3.4.

### DIFF
--- a/requirements-override.txt
+++ b/requirements-override.txt
@@ -1,2 +1,3 @@
 bigeye-airflow==0.1.34
 bigeye-sdk==0.4.81
+apache-airflow-providers-cncf-kubernetes==8.3.4


### PR DESCRIPTION
## Description
Patch k8s provider to version 8.3.4 to fix the issue of executor open slots reaching negative number
![image](https://github.com/user-attachments/assets/d25d2c97-4ff2-4066-8542-e2ad58721be9)


<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Validation
![image](https://github.com/user-attachments/assets/c168f6f2-a2ad-4995-be3c-305417b41bdf)
_new provider installed_

![image](https://github.com/user-attachments/assets/59ba7cfd-7cd8-4375-9533-db40b64b4be2)
_running clean_gke_pods_

## Related Tickets & Documents
* https://github.com/apache/airflow/pull/39551
* https://github.com/apache/airflow/issues/36998
* https://github.com/apache/airflow/issues/40106

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
