### PR TITLE
fix(bhr): Increase bhr_collection_child cluster size to 10

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -90,8 +90,8 @@ with DAG(
             "spark:spark.executor.memory": "20g",
         },
         "idle_delete_ttl": 14400,
-        # dataproc does not support all GCE instance types, e.g. newer ones
-        # https://cloud.google.com/compute/docs/general-purpose-machines
+        # supported machine types depends on dataproc image version:
+        # https://cloud.google.com/dataproc/docs/concepts/compute/supported-machine-types
         "master_machine_type": "n2-standard-8",
         "worker_machine_type": "n2-highmem-4",
         "gcp_conn_id": params.conn_id,
@@ -130,7 +130,7 @@ with DAG(
             cluster_name="bhr-collection-child-{{ ds }}",
             job_name="bhr-collection-child",
             **shared_runner_args,
-            num_workers=8,
+            num_workers=10,
             py_args=[
                 "--date",
                 "{{ ds }}",


### PR DESCRIPTION
## Description

Job is failing likely due to running out memory possibly related to a ~15% increase in hangs on this thread: https://sql.telemetry.mozilla.org/queries/102988/source#253834

I think increasing workers will work and cost shouldn't be an issue since the runtime is less than an hour and should decrease with more workers.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1924694
