### PR TITLE
fix: Change webcompat_kb DAG to run a module instead of a script

### DIFF
--- a/dags/webcompat_kb.py
+++ b/dags/webcompat_kb.py
@@ -62,7 +62,7 @@ with DAG(
         task_id="webcompat_kb",
         arguments=[
             "python",
-            "-m"
+            "-m",
             "webcompat_kb.main",
             "--bq_project_id",
             "moz-fx-dev-dschubert-wckb",

--- a/dags/webcompat_kb.py
+++ b/dags/webcompat_kb.py
@@ -62,7 +62,8 @@ with DAG(
         task_id="webcompat_kb",
         arguments=[
             "python",
-            "webcompat_kb/main.py",
+            "-m"
+            "webcompat_kb.main",
             "--bq_project_id",
             "moz-fx-dev-dschubert-wckb",
             "--bq_dataset_id",


### PR DESCRIPTION
## Description
Since webcompat_kb was converted to a module in https://github.com/mozilla/docker-etl/pull/298#event-15123335703, the job is failing as it still trying to run a script, this PR fixes it.  

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
