### PR TITLE
fix: Include version in task names to align with dependencies

### DIFF
--- a/dags/kpi_forecasting.py
+++ b/dags/kpi_forecasting.py
@@ -44,8 +44,8 @@ CONFIGS = {
         "dau_mobile.yaml",
         "bqetl_analytics_aggregations",
         [
-            "fenix_active_users_aggregates_v3",
             "firefox_ios_active_users_aggregates_v3",
+            "fenix_active_users_aggregates_v3",
             "focus_android_active_users_aggregates_v3",
             "focus_ios_active_users_aggregates_v3",
         ],

--- a/dags/kpi_forecasting.py
+++ b/dags/kpi_forecasting.py
@@ -37,17 +37,17 @@ CONFIGS = {
         "dau_desktop.yaml",
         "bqetl_analytics_aggregations",
         [
-            "firefox_desktop_active_users_aggregates",
+            "firefox_desktop_active_users_aggregates_v3",
         ],
     ),
     "dau_mobile": Config(
         "dau_mobile.yaml",
         "bqetl_analytics_aggregations",
         [
-            "fenix_active_users_aggregates",
-            "firefox_ios_active_users_aggregates",
-            "focus_android_active_users_aggregates",
-            "focus_ios_active_users_aggregates",
+            "fenix_active_users_aggregates_v3",
+            "firefox_ios_active_users_aggregates_v3",
+            "focus_android_active_users_aggregates_v3",
+            "focus_ios_active_users_aggregates_v3",
         ],
     ),
 }


### PR DESCRIPTION
## Description
This PR updates the task names in the KPI forecasting DAG to align with the bqetl_analytics_aggregations DAG, which now uses versions in the naming.
The version should be updated together with table versions updates or depend on the view.

## Related Tickets & Documents
PR 1/2 for [Bug-1932176](https://bugzilla.mozilla.org/show_bug.cgi?id=1932176).

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
