### PR TITLE
feat: forecast DAG after complete backfill for desktop aua v4.

### DIFF
--- a/dags/kpi_forecasting.py
+++ b/dags/kpi_forecasting.py
@@ -37,17 +37,17 @@ CONFIGS = {
         "dau_desktop.yaml",
         "bqetl_analytics_aggregations",
         [
-            "firefox_desktop_active_users_aggregates_v3",
+            "firefox_desktop_active_users_aggregates_v4",
         ],
     ),
     "dau_mobile": Config(
         "dau_mobile.yaml",
         "bqetl_analytics_aggregations",
         [
-            "firefox_ios_active_users_aggregates_v3",
-            "fenix_active_users_aggregates_v3",
-            "focus_android_active_users_aggregates_v3",
-            "focus_ios_active_users_aggregates_v3",
+            "firefox_ios_active_users_aggregates_v4",
+            "fenix_active_users_aggregates_v4",
+            "focus_android_active_users_aggregates_v4",
+            "focus_ios_active_users_aggregates_v4",
         ],
     ),
 }

--- a/dags/kpi_forecasting.py
+++ b/dags/kpi_forecasting.py
@@ -44,10 +44,10 @@ CONFIGS = {
         "dau_mobile.yaml",
         "bqetl_analytics_aggregations",
         [
-            "firefox_ios_active_users_aggregates_v4",
-            "fenix_active_users_aggregates_v4",
-            "focus_android_active_users_aggregates_v4",
-            "focus_ios_active_users_aggregates_v4",
+            "firefox_ios_active_users_aggregates_v3",
+            "fenix_active_users_aggregates_v3",
+            "focus_android_active_users_aggregates_v3",
+            "focus_ios_active_users_aggregates_v3",
         ],
     ),
 }


### PR DESCRIPTION
## Description
This PR should only be merged after [PR-6539](https://github.com/mozilla/bigquery-etl/pull/6539).
Upgrades version for Desktop.

## Related Tickets & Documents
[DENG-6360](https://mozilla-hub.atlassian.net/browse/DENG-6360)

Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[DENG-6360]: https://mozilla-hub.atlassian.net/browse/DENG-6360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ