### PR TITLE
feat(bigeye): remove Airflow dependencies

### DIFF
--- a/requirements-override.txt
+++ b/requirements-override.txt
@@ -1,3 +1,1 @@
-bigeye-airflow==0.1.35
-bigeye-sdk==0.4.91
 apache-airflow-providers-cncf-kubernetes==8.3.4

--- a/requirements.in
+++ b/requirements.in
@@ -15,9 +15,6 @@ apache-airflow-providers-redis
 apache-airflow-providers-slack
 airflow-provider-fivetran-async==2.0.2
 
-# BigEye integration
-bigeye-airflow
-
 # Acryl DataHub integration
 acryl-datahub-airflow-plugin
 gql

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,6 @@ babel==2.15.0
 backoff==2.2.1
 bcrypt==4.1.3
 beautifulsoup4==4.12.3
-bigeye-airflow==0.1.12
 billiard==4.2.0
 blinker==1.8.2
 boto3==1.34.131


### PR DESCRIPTION
## Description

Depends on https://github.com/mozilla/bigquery-etl/pull/6546 (to remove operator imports)

This removes the Bigeye dependencies that are no longer in use.

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
