### PR TITLE
fix(taar): Allocate more memory in taar spark jobs

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -150,6 +150,8 @@ with DAG(
             python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_locale.py",
             # GCS bucket for testing is located in `cfr-personalization-experiment` project
             # python_driver_code="gs://taar_models/tmp/jobs/taar_locale.py",
+            master_machine_type="n2-standard-8",
+            worker_machine_type="n2-standard-4",
             num_workers=12,
             py_args=[
                 "--date",
@@ -184,10 +186,12 @@ with DAG(
             additional_properties={
                 "spark:spark.jars.packages": "org.apache.spark:spark-avro_2.11:2.4.3",
                 "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest.jar",
+                "spark:spark.driver.memory": "16g",
+                "spark:spark.executor.memory": "96g",
             },
             num_workers=8,
-            master_machine_type="n1-standard-8",
-            worker_machine_type="n1-highmem-32",
+            master_machine_type="n2-standard-8",
+            worker_machine_type="n2-highmem-32",
             py_args=[
                 "--date",
                 "{{ ds }}",
@@ -227,7 +231,8 @@ with DAG(
             ],
             cluster_name="addon-recommender-{{ds_nodash}}",
             image_version="1.3",
-            worker_machine_type="n1-standard-8",
+            master_machine_type="n2-standard-8",
+            worker_machine_type="n2-standard-8",
             num_workers=20,
             optional_components=[],
             install_component_gateway=False,
@@ -260,6 +265,8 @@ with DAG(
             python_driver_code="gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/taar_lite_guidguid.py",
             # GCS bucket for testing is located in `cfr-personalization-experiment` project
             # python_driver_code="gs://taar_models/tmp/jobs/taar_lite_guidguid.py",
+            master_machine_type="n2-standard-8",
+            worker_machine_type="n2-standard-4",
             num_workers=8,
             py_args=[
                 "--date",


### PR DESCRIPTION
## Description

[Recent taar_similarity runs](https://console.cloud.google.com/dataproc/jobs/TAAR_similarity_7bec0ec5/monitoring?region=us-west1&project=airflow-dataproc) have been failing with `executor 4): java.lang.OutOfMemoryError: unable to create new native thread` so increasing the memory as a low-effort attempt to fix this.

Current defaults are:
```
spark:spark.driver.memory 7680m
spark:spark.executor.memory 38168m
```

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1931005
