### PR TITLE
fix(taar): Set taar_similarity worker ssds to 4

### DIFF
--- a/dags/taar_daily.py
+++ b/dags/taar_daily.py
@@ -206,8 +206,9 @@ with DAG(
             worker_disk_type="pd-ssd",
             master_disk_size=1024,
             worker_disk_size=1024,
+            # https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds
             master_num_local_ssds=2,
-            worker_num_local_ssds=2,
+            worker_num_local_ssds=4,
         ),
     )
 


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mozilla/telemetry-airflow/pull/2129.  n2 instance types have restrictions on the number of ssds depending on # of vcpu so minimum is 4: https://cloud.google.com/compute/docs/disks/local-ssd#lssd_disk_options

Assuming cluster is alive for 25 minutes per run, additional daily cost should be `16 disks * $0.08 / GiB month * 375 GiB/disk / 43800 minutes/month * 25 minutes = $0.274` but performance improvements from n2 might offset that

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1931005