### PR TITLE
fix(bqetl_artifact_deployment): Allocate more memory to tasks when they run SQL generation (DENG-6538)

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -94,6 +94,7 @@ def should_run_deployment(dag_id: str, generate_sql: bool) -> bool:
     print(f"Found {len(queued_runs)} queued dag runs for {dag_id}")
     return len(queued_runs) == 0 or generate_sql == "True"
 
+
 bigeye_api_key_secret = Secret(
     deploy_type="env",
     deploy_target="BIGEYE_API_KEY",
@@ -211,7 +212,7 @@ with DAG(
             "script/bqetl monitoring deploy '*' --project_id=moz-fx-data-shared-prod"
         ],
         image=docker_image,
-        secrets=[bigeye_api_key_secret]
+        secrets=[bigeye_api_key_secret],
     )
 
     skip_if_queued_runs_exist.set_downstream(

--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -79,9 +79,6 @@ generate_sql_cmd_template = (
 generate_sql_container_resources = k8s.V1ResourceRequirements(
     requests={"memory": "{{ '5Gi' if params.generate_sql else '2Gi' }}"},
 )
-# TODO: Conditionally choose the appropriate nodepool based on the `generate_sql` parameter
-# once we upgrade to Kubernetes provider >=9.0.1, which adds `node_selector` templating support.
-generate_sql_node_selector = {"nodepool": "highmem"}
 
 
 def should_run_deployment(dag_id: str, generate_sql: bool) -> bool:
@@ -159,7 +156,6 @@ with DAG(
         ],
         image=docker_image,
         container_resources=generate_sql_container_resources,
-        node_selector=generate_sql_node_selector,
     )
 
     publish_views = GKEPodOperator(
@@ -184,7 +180,6 @@ with DAG(
         ],
         image=docker_image,
         container_resources=generate_sql_container_resources,
-        node_selector=generate_sql_node_selector,
         get_logs=False,
         trigger_rule=TriggerRule.ALL_DONE,
     )
@@ -202,7 +197,6 @@ with DAG(
         ],
         image=docker_image,
         container_resources=generate_sql_container_resources,
-        node_selector=generate_sql_node_selector,
     )
 
     publish_bigeye_monitors = GKEPodOperator(


### PR DESCRIPTION
## Description
SQL generation currently requires ~4 GB of memory, and if we don't request at least that amount of memory then when the task tries to allocate more memory as it runs it's at the mercy of whatever memory is available on the node at that time, which might not be enough.

## Related Tickets & Documents
* DENG-6538: publish views and tables tasks occasionally gets stuck