### PR TITLE
fix: Correct `GKEPodOperator` container resource configs so they work properly

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -3,6 +3,7 @@ import datetime
 from airflow import models
 from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.utils.task_group import TaskGroup
+from kubernetes.client import models as k8s
 
 from operators.gcp_container_operator import GKEPodOperator
 from utils.gcp import (
@@ -67,13 +68,10 @@ with models.DAG(
     # This single task is responsible for sequentially running copy queries
     # over all the tables in _live datasets into _stable datasets except those
     # that are specifically used in another DAG.
-    resources = {
-        "request_memory": "10240Mi",
-        "request_cpu": None,
-        "limit_memory": "20480Mi",
-        "limit_cpu": None,
-        "limit_gpu": None,
-    }
+    resources = k8s.V1ResourceRequirements(
+        requests={"memory": "10240Mi"},
+        limits={"memory": "20480Mi"},
+    )
 
     copy_deduplicate_all = bigquery_etl_copy_deduplicate(
         task_id="copy_deduplicate_all",

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -12,6 +12,7 @@ from airflow.providers.cncf.kubernetes.secret import Secret
 from airflow.providers.http.operators.http import SimpleHttpOperator
 from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.weekday import WeekDay
+from kubernetes.client import models as k8s
 
 from operators.gcp_container_operator import GKEPodOperator
 from utils.tags import Tag
@@ -128,13 +129,10 @@ with DAG(
         name="probe-scraper-moz-central",
         # Needed to scale the highmem pool from 0 -> 1, because cluster autoscaling
         # works on pod resource requests, instead of usage
-        container_resources={
-            "request_memory": "13312Mi",
-            "request_cpu": None,
-            "limit_memory": "20480Mi",
-            "limit_cpu": None,
-            "limit_gpu": None,
-        },
+        container_resources=k8s.V1ResourceRequirements(
+            requests={"memory": "13312Mi"},
+            limits={"memory": "20480Mi"},
+        ),
         # This python job requires 13 GB of memory, thus the highmem node pool
         node_selector={"nodepool": "highmem"},
         # Due to the nature of the container run, we set get_logs to False, to avoid

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from airflow import DAG
+from kubernetes.client import models as k8s
 from timetable import MultiWeekTimetable
 
 from operators.gcp_container_operator import GKEPodOperator
@@ -130,13 +131,10 @@ flat_rate = GKEPodOperator(
     ],
     # Needed to scale the highmem pool from 0 -> 1, because cluster autoscaling
     # works on pod resource requests, instead of usage
-    container_resources={
-        "request_memory": "13312Mi",
-        "request_cpu": None,
-        "limit_memory": "20480Mi",
-        "limit_cpu": None,
-        "limit_gpu": None,
-    },
+    container_resources=k8s.V1ResourceRequirements(
+        requests={"memory": "13312Mi"},
+        limits={"memory": "20480Mi"},
+    ),
     # This job was being killed by Kubernetes for using too much memory, thus the highmem node pool
     node_selector={"nodepool": "highmem"},
     # Give additional time since we may need to scale up when running this job


### PR DESCRIPTION
## Description
The previous way of specifying GKE container resource configs as a dictionary apparently doesn't work anymore. This PR switches to the new way using `kubernetes.client.models.V1ResourceRequirements` objects, which I've verified works in #2131.

## Related Tickets & Documents
* https://github.com/mozilla/telemetry-airflow/pull/2131
