### PR TITLE
fix(copy_deduplicate): Reduce `copy_deduplicate_all` pods' memory request from 10 GiB to 400 MiB

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -92,7 +92,6 @@ with models.DAG(
             "telemetry_live.saved_session_use_counter_v4",
             "telemetry_live.saved_session_v5",
         ],
-        node_selector={"nodepool": "highmem"},
         container_resources=resources,
     )
 

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -69,8 +69,7 @@ with models.DAG(
     # over all the tables in _live datasets into _stable datasets except those
     # that are specifically used in another DAG.
     resources = k8s.V1ResourceRequirements(
-        requests={"memory": "10240Mi"},
-        limits={"memory": "20480Mi"},
+        requests={"memory": "400Mi"},
     )
 
     copy_deduplicate_all = bigquery_etl_copy_deduplicate(


### PR DESCRIPTION
## Description
This PR:
* Reduces the memory requested by `copy_deduplicate_all` to 400 MiB (in the past two weeks `copy_deduplicate_all` has [used at most 381 MiB of memory](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P14D?pageState=%7B%22domainObjectDeprecationId%22:%22EBCB316F-CD77-43E5-A3DB-7258D717823F%22,%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22legendTemplate%22:%22Used%22,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22groupByFields%22:%5B%5D,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fmemory%2Fused_bytes%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metric.label.%5C%22memory_type%5C%22%3D%5C%22non-evictable%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22moz-fx-data-airflow-gke-prod%5C%22%20resource.label.%5C%22location%5C%22%3D%5C%22us-west1%5C%22%20resource.label.%5C%22cluster_name%5C%22%3D%5C%22workloads-prod-v1%5C%22%20resource.label.%5C%22namespace_name%5C%22%3D%5C%22default%5C%22%20resource.label.%5C%22pod_name%5C%22%3Dmonitoring.regex.full_match(%5C%22copy-deduplicate-all.*%5C%22)%22,%22groupByFields%22:%5B%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D&project=moz-fx-data-airflow-gke-prod), and usually less than 350 MiB of memory).
* Has the `copy_deduplicate_all` pods run in the default node pool rather than the highmem node pool.

This will avoid wasting resources and triggering unnecessary Kubernetes cluster auto-scaling, where cluster scale-downs can currently cause problems with pods getting evicted before they're done and having to get retried by Airflow.

This became more of an issue after the existing pod resource configs were fixed to actually work in #2133.

## Related Tickets & Documents
* https://github.com/mozilla/telemetry-airflow/pull/2133
