### PR TITLE
fix(probe_scraper): Reduce `probe_scraper_moz_central` pods' memory request from 13 GiB to 4,500 MiB

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -127,19 +127,17 @@ with DAG(
     probe_scraper_moz_central = GKEPodOperator(
         task_id="probe_scraper_moz_central",
         name="probe-scraper-moz-central",
-        # Needed to scale the highmem pool from 0 -> 1, because cluster autoscaling
+        # Needed for proper cluster autoscaling, because cluster autoscaling
         # works on pod resource requests, instead of usage
         container_resources=k8s.V1ResourceRequirements(
             requests={"memory": "4500Mi"},
         ),
-        # This python job requires 13 GB of memory, thus the highmem node pool
-        node_selector={"nodepool": "highmem"},
         # Due to the nature of the container run, we set get_logs to False, to avoid
         # urllib3.exceptions.ProtocolError: 'Connection broken: IncompleteRead(0 bytes
         # read)' errors where the pod continues to run, but airflow loses its connection
         # and sets the status to Failed
         get_logs=False,
-        # Give additional time since we will likely always scale up when running this job
+        # Give additional time since the cluster may scale up when running this job
         startup_timeout_seconds=360,
         image=probe_scraper_image,
         arguments=(

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -130,8 +130,7 @@ with DAG(
         # Needed to scale the highmem pool from 0 -> 1, because cluster autoscaling
         # works on pod resource requests, instead of usage
         container_resources=k8s.V1ResourceRequirements(
-            requests={"memory": "13312Mi"},
-            limits={"memory": "20480Mi"},
+            requests={"memory": "4500Mi"},
         ),
         # This python job requires 13 GB of memory, thus the highmem node pool
         node_selector={"nodepool": "highmem"},


### PR DESCRIPTION
## Description
This PR:
* Reduces the memory requested by `probe_scraper_moz_central` to 4,500 MiB (in the past two weeks `probe_scraper_moz_central` has [used at most 4,472 MiB of memory](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P14D?pageState=%7B%22domainObjectDeprecationId%22:%22C28BB218-E1FC-4457-987F-145DE2DB48C4%22,%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22legendTemplate%22:%22Used%22,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22groupByFields%22:%5B%5D,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fmemory%2Fused_bytes%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metric.label.%5C%22memory_type%5C%22%3D%5C%22non-evictable%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22moz-fx-data-airflow-gke-prod%5C%22%20resource.label.%5C%22location%5C%22%3D%5C%22us-west1%5C%22%20resource.label.%5C%22cluster_name%5C%22%3D%5C%22workloads-prod-v1%5C%22%20resource.label.%5C%22namespace_name%5C%22%3D%5C%22default%5C%22%20resource.label.%5C%22pod_name%5C%22%3Dmonitoring.regex.full_match(%5C%22probe-scraper-moz-central.*%5C%22)%22,%22groupByFields%22:%5B%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D&project=moz-fx-data-airflow-gke-prod), and usually less than 3,500 MiB of memory).
* Has the `probe_scraper_moz_central` pods run in the default node pool rather than the highmem node pool.

This will avoid wasting resources and triggering unnecessary Kubernetes cluster auto-scaling, where cluster scale-downs can currently cause problems with pods getting evicted before they're done and having to get retried by Airflow.

This became more of an issue after the existing pod resource configs were fixed to actually work in #2133.

## Related Tickets & Documents
* https://github.com/mozilla/telemetry-airflow/pull/2133
