### PR TITLE
chore: Set `on_finish_action="keep_pod"` by default for GKE pods

### DIFF
--- a/operators/gcp_container_operator.py
+++ b/operators/gcp_container_operator.py
@@ -48,6 +48,7 @@ class GKEPodOperator(UpstreamGKEPodOperator):
         in_cluster=False,
         do_xcom_push=False,
         reattach_on_restart=False,
+        on_finish_action="keep_pod",
         # Defined in Airflow's UI -> Admin -> Connections
         gcp_conn_id="google_cloud_airflow_gke",
         project_id="moz-fx-data-airflow-gke-prod",
@@ -67,6 +68,7 @@ class GKEPodOperator(UpstreamGKEPodOperator):
             in_cluster=in_cluster,
             do_xcom_push=do_xcom_push,
             reattach_on_restart=reattach_on_restart,
+            on_finish_action=on_finish_action,
             gcp_conn_id=gcp_conn_id,
             project_id=project_id,
             location=location,


### PR DESCRIPTION
## Description
Keeping the pods is already the default behavior, but the [underlying `GKEStartPodOperator` code](https://github.com/apache/airflow/blob/c92929b99fc15c42ccc0799cc696417a5af76161/airflow/providers/google/cloud/operators/kubernetes_engine.py#L643) warns that "_Current default is `keep_pod`, but this will be changed in the next major release of this provider._" So this ensures the current behavior will continue when we upgrade to the next major release of the Google Cloud Airflow provider.

NB: The [clean_gke_pods](https://github.com/mozilla/telemetry-airflow/blob/2db834930b56d7c332975c0af892c5e930613b62/dags/clean_gke_pods.py) DAG runs daily to remove completed pods, and we [add a `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation to completed pods](https://github.com/mozilla/telemetry-airflow/blob/2db834930b56d7c332975c0af892c5e930613b62/operators/gcp_container_operator.py#L13-L21) so the cluster can remove them if it needs to scale down.

## Related Tickets & Documents
N/A