### PR TITLE
fix(looker): Run branch deletion after LookML validation

### DIFF
--- a/dags/looker.py
+++ b/dags/looker.py
@@ -235,6 +235,5 @@ with DAG(
     )
 
     lookml_generator_staging >> lookml_generator_prod
-    lookml_generator_prod >> validate_content_spectacles
-    lookml_generator_prod >> validate_lookml_spoke_default_spectacles
-    lookml_generator_prod >> delete_outdated_branches
+    lookml_generator_prod >> validate_content_spectacles >> delete_outdated_branches
+    lookml_generator_prod >> validate_lookml_spoke_default_spectacles >> delete_outdated_branches


### PR DESCRIPTION
Running the branch deletion in parallel to the LookML validation did cause some errors: https://workflow.telemetry.mozilla.org/dags/looker/grid?dag_run_id=manual__2025-01-02T17%3A29%3A18.636250%2B00%3A00&task_id=validate_content_spectacles&tab=logs

The same Looker user is used for both tasks, switching to dev mode in the branch deletion task caused the validation task to fail, which was running at the same time. We can run the deletion after validation finishes

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
