### PR TITLE
fix(search_forecasting): reschedule search_forecasting to match bqetl_search_dashboard DAG

### DIFF
--- a/dags/search_forecasting.py
+++ b/dags/search_forecasting.py
@@ -44,7 +44,7 @@ FORECAST_METRICS_LIST = [
 with DAG(
     "search_forecasting",
     default_args=default_args,
-    schedule_interval="30 4 7 * *",
+    schedule_interval="30 5 7 * *",
     doc_md=__doc__,
     tags=TAGS,
 ) as dag:


### PR DESCRIPTION
## Description
Updates `search_forecasting` DAG schedule to align with changed upstream DAG `bqetl_search_dashboard` schedule.

## Related Tickets & Documents
* `bqetl_search_dashboard` DAG schedule was changed here https://github.com/mozilla/bigquery-etl/pull/6586
