### PR TITLE
chore(glam): move glam etls to moz-fx-glam-prod

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -151,6 +151,8 @@ with DAG(
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-marketing-prod && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-glam-prod-fca7 && "
+            "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-glam-prod && "
+            "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-glam-prod && "
             "script/bqetl query schema update '*' --use-cloud-function=false --ignore-dryrun-skip --project-id=moz-fx-data-bq-people && "
             "script/bqetl query schema deploy '*' --use-cloud-function=false --force --ignore-dryrun-skip --project-id=moz-fx-data-bq-people"
         ],

--- a/dags/glam.py
+++ b/dags/glam.py
@@ -26,7 +26,7 @@ from utils.tags import Tag
 
 project_id = "moz-fx-data-shared-prod"
 table_project_id = "moz-fx-data-shared-prod"
-billing_project_id = "moz-fx-data-glam-prod-fca7"
+billing_project_id = "moz-fx-glam-prod"
 dataset_id = "telemetry_derived"
 fully_qualified_dataset = f"{table_project_id}:{dataset_id}"
 tmp_project = "moz-fx-data-shared-prod"  # for temporary tables in analysis dataset

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -40,7 +40,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-PROJECT = "moz-fx-data-glam-prod-fca7"
+PROJECT = "moz-fx-glam-prod"
 BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
 
 # Fenix as a product has a convoluted app_id history. The comments note the

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -30,7 +30,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-PROJECT = "moz-fx-data-glam-prod-fca7"
+PROJECT = "moz-fx-glam-prod"
 BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
 
 # Fenix as a product has a convoluted app_id history. The comments note the

--- a/dags/glam_fog_release.py
+++ b/dags/glam_fog_release.py
@@ -29,7 +29,7 @@ default_args = {
     "retry_delay": timedelta(minutes=30),
 }
 
-PROJECT = "moz-fx-data-glam-prod-fca7"
+PROJECT = "moz-fx-glam-prod"
 BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
 
 tags = [Tag.ImpactTier.tier_2]


### PR DESCRIPTION
## Description

This PR (along with https://github.com/mozilla/bigquery-etl/pull/6819) replaces references to `moz-fx-data-glam-prod-fca7` with `moz-fx-glam-prod` in order to move GLAM ETLs to GCP V2. 

## Related Tickets & Documents
* DSRE-1783

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
