### PR TITLE
chore(glam): remove unused constants

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -41,7 +41,6 @@ default_args = {
 }
 
 PROJECT = "moz-fx-data-glam-prod-fca7"
-BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
 
 # Fenix as a product has a convoluted app_id history. The comments note the
 # start and end dates of the id in the app store.

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -31,7 +31,6 @@ default_args = {
 }
 
 PROJECT = "moz-fx-data-glam-prod-fca7"
-BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
 
 # Fenix as a product has a convoluted app_id history. The comments note the
 # start and end dates of the id in the app store.

--- a/dags/glam_fog_release.py
+++ b/dags/glam_fog_release.py
@@ -30,7 +30,6 @@ default_args = {
 }
 
 PROJECT = "moz-fx-data-glam-prod-fca7"
-BUCKET = "moz-fx-data-glam-prod-fca7-etl-data"
 
 tags = [Tag.ImpactTier.tier_2]
 


### PR DESCRIPTION
## Description

This PR removes the `BUCKET` constant from `glam` dags. The constant is no longer used after https://github.com/mozilla/telemetry-airflow/pull/2141

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
