### PR TITLE
fix(bhr): Increase bhr driver memory

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -86,13 +86,13 @@ with DAG(
         },
         "additional_properties": {
             "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
-            "spark:spark.driver.memory": "18g",
+            "spark:spark.driver.memory": "30g",
             "spark:spark.executor.memory": "20g",
         },
         "idle_delete_ttl": 14400,
         # supported machine types depends on dataproc image version:
         # https://cloud.google.com/dataproc/docs/concepts/compute/supported-machine-types
-        "master_machine_type": "n2-standard-8",
+        "master_machine_type": "n2-highmem-8",
         "worker_machine_type": "n2-highmem-4",
         "gcp_conn_id": params.conn_id,
         "service_account": params.client_email,


### PR DESCRIPTION
## Description

Last job recently failed with `Driver received SIGTERM/SIGKILL signal and exited with 137 code` which is a driver memory issue https://cloud.google.com/dataproc/docs/support/troubleshoot-oom-errors#master_node_or_driver_node_pool_job_terminations.  The highmem instance will have 64GB vs standard 32GB

This [process memory usage graph](https://console.cloud.google.com/monitoring/metrics-explorer;startTime=2025-01-20T04:37:34.595Z;endTime=2025-01-20T11:27:34.892Z?inv=1&invt=AbnXPQ&project=airflow-dataproc&pageState=%7B%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22groupByFields%22:%5B%5D,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_NONE%22,%22filter%22:%22metric.type%3D%5C%22agent.googleapis.com%2Fprocesses%2Fvm_usage%5C%22%20resource.type%3D%5C%22gce_instance%5C%22%20resource.label.%5C%22instance_id%5C%22%3Dmonitoring.regex.full_match(%5C%226643733348187399712%7C7722918420464821820%5C%22)%22,%22groupByFields%22:%5B%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_MEAN%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D) seems to suggest the instance wants to use 38 GB

links:
- [airflow task](https://workflow.telemetry.mozilla.org/dags/bhr_collection.bhr_collection_child/grid?execution_date=2025-01-19T05%3A00%3A00%2B00%3A00&dag_run_id=scheduled__2025-01-19T05%3A00%3A00%2B00%3A00&task_id=run_dataproc_pyspark)
- [dataproc job](https://console.cloud.google.com/dataproc/jobs/bhr-collection-child_8961e5d1/monitoring?region=us-west1&inv=1&invt=AbnXPQ&project=airflow-dataproc)