### PR TITLE
fix(glam): further break down glam_fog_release bucket_counts

### DIFF
--- a/dags/glam_fog_release.py
+++ b/dags/glam_fog_release.py
@@ -78,7 +78,7 @@ with DAG(
         ) as histogram_bucket_counts:
             prev_task = None
             # Windows + Release data is in [0-9] so we're further splitting that range.
-            for sample_range in ([0, 2], [3, 5], [6, 9], [10, 49], [50, 99]):
+            for sample_range in ([0, 0], [1, 2], [3, 5], [6, 9], [10, 49], [50, 99]):
                 histogram_bucket_counts_sampled = query(
                     task_name=f"{product}__histogram_bucket_counts_v1_sampled_{sample_range[0]}_{sample_range[1]}",
                     min_sample_id=sample_range[0],


### PR DESCRIPTION
## Description

By processing less samples at a time we decrease the risk of having the job run out of slots

## Related Tickets & Documents
* DENG-7590

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
