### PR TITLE
feat(bqetl_artifact_deployment): set task timeout for publish_new_tables to 2h

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -137,6 +137,7 @@ with DAG(
     publish_new_tables = GKEPodOperator(
         task_id="publish_new_tables",
         cmds=["bash", "-x", "-c"],
+        execution_timeout=timedelta(hours=2),
         arguments=[
             generate_sql_cmd_template
             + "script/bqetl query initialize '*' --skip-existing --project-id=moz-fx-data-shared-prod && "


### PR DESCRIPTION
[DENG-7845](https://mozilla-hub.atlassian.net/browse/DENG-7845)

This automatically stops `publish_new_tables` tasks after 2 hours. We had some instances where these tasks ended up running for 7h+ and needed to be cleared manually. This should automate the process.
Normally the task runs for less than an hour

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[DENG-7845]: https://mozilla-hub.atlassian.net/browse/DENG-7845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ