### PR TITLE
fix(code): change delay to three days instead of 2

### DIFF
--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -81,7 +81,7 @@ with DAG(
             arguments=[
                 "python",
                 f"sql/moz-fx-data-shared-prod/microsoft_derived/{table}_v1/query.py",
-                "--date={{ macros.ds_add(ds, -2) }}",
+                "--date={{ macros.ds_add(ds, -3) }}",
             ],
             image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
             owner="mhirose@mozilla.com",


### PR DESCRIPTION
## Description
Data sometimes does not populate with a 2 day delay and a manual run is required. Changing the delay from 2 days to 3.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* DENG-7011
* DSRE-XXXX

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
