### PR TITLE
chore(backfill): [DENG-7807] Set reattach_on_restart on managed backfill tasks

### DIFF
--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -70,6 +70,7 @@ with DAG(
             cmds=["sh", "-cx"],
             arguments=prepare_pod_parameters(backfill),
             image=DOCKER_IMAGE,
+            reattach_on_restart=True,
         )
 
         @task

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -70,6 +70,7 @@ with DAG(
             cmds=["sh", "-cx"],
             arguments=prepare_pod_parameters(backfill),
             image=DOCKER_IMAGE,
+            reattach_on_restart=True,
         )
 
         @task


### PR DESCRIPTION
## Description

These tasks are expected to run long and we've had a couple recent issues where airflow lost connection to the pod and attempted to start a new backfill while the existing one was still running

## Related Tickets & Documents
* [DENG-7807](https://mozilla-hub.atlassian.net/browse/DENG-7807)

[DENG-7807]: https://mozilla-hub.atlassian.net/browse/DENG-7807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ