### PR TITLE
fix(glam_fog_release): redistribute bucket_counts sample processing

### DIFF
--- a/dags/glam_fog_release.py
+++ b/dags/glam_fog_release.py
@@ -78,7 +78,7 @@ with DAG(
         ) as histogram_bucket_counts:
             prev_task = None
             # Windows + Release data is in [0-9] so we're further splitting that range.
-            for sample_range in ([0, 0], [1, 2], [3, 5], [6, 9], [10, 49], [50, 99]):
+            for sample_range in ([0, 0], [1, 1], [2, 3], [4, 6], [7, 9], [10, 49], [50, 99]):
                 histogram_bucket_counts_sampled = query(
                     task_name=f"{product}__histogram_bucket_counts_v1_sampled_{sample_range[0]}_{sample_range[1]}",
                     min_sample_id=sample_range[0],

--- a/dags/glam_fog_release.py
+++ b/dags/glam_fog_release.py
@@ -78,9 +78,16 @@ with DAG(
         ) as histogram_bucket_counts:
             prev_task = None
             # Windows + Release data is in [0-9] so we're further splitting that range.
-            for sample_range in ([0, 0], [1, 1], [2, 3], [4, 6], [7, 9], [10, 49], [50, 99]):
+            for sample_range in (
+                [0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6],
+                [7, 7], [8, 8], [9, 9], [10, 19], [20, 29], [30, 39],
+                [40, 49], [50, 59], [60, 69], [70, 79], [80, 89], [90, 99]
+            ):
                 histogram_bucket_counts_sampled = query(
-                    task_name=f"{product}__histogram_bucket_counts_v1_sampled_{sample_range[0]}_{sample_range[1]}",
+                    task_name=(
+                        f"{product}__histogram_bucket_counts_v1_sampled_"
+                        f"{sample_range[0]}_{sample_range[1]}"
+                    ),
                     min_sample_id=sample_range[0],
                     max_sample_id=sample_range[1],
                     replace_table=(sample_range[0] == 0)


### PR DESCRIPTION
## Description

fixes [Bug 1944388](https://bugzilla.mozilla.org/show_bug.cgi?id=1944388)
This PR splits that 0 to 9 sample range for `histogram_bucket_counts` in an attempt to avoid running out of resources. This range has more data than the rest due to Windows + Release data being sampled at 10%.

## Related Tickets & Documents
* [Bug 1944388](https://bugzilla.mozilla.org/show_bug.cgi?id=1944388)

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
