### PR TITLE
chore(artifact_deployment): [DENG-7845] Add task timeout to publish_views

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -162,6 +162,7 @@ with DAG(
     publish_views = GKEPodOperator(
         task_id="publish_views",
         cmds=["bash", "-x", "-c"],
+        execution_timeout=timedelta(hours=2),
         arguments=[
             generate_sql_cmd_template
             + "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod && "


### PR DESCRIPTION

## Description

Following up on https://github.com/mozilla/telemetry-airflow/pull/2158, adding the timeout to publish views as well since it's also timing out. [most recent run](https://workflow.telemetry.mozilla.org/dags/bqetl_artifact_deployment/grid?dag_run_id=manual__2025-02-26T04%3A12%3A06.875837%2B00%3A00&tab=logs&task_id=publish_views)

## Related Tickets & Documents
* DENG-7845
