### PR TITLE
fix(fxci): use 'fxci_derived' dataset

### DIFF
--- a/dags/fxci_metric_export.py
+++ b/dags/fxci_metric_export.py
@@ -26,7 +26,7 @@ tags = [Tag.ImpactTier.tier_3]
 
 env_vars = {
     "FXCI_ETL_BIGQUERY_PROJECT": "moz-fx-data-shared-prod",
-    "FXCI_ETL_BIGQUERY_DATASET": "fxci",
+    "FXCI_ETL_BIGQUERY_DATASET": "fxci_derived",
     "FXCI_ETL_STORAGE_PROJECT": "moz-fx-dev-releng",
     "FXCI_ETL_STORAGE_BUCKET": "fxci-etl",
 }

--- a/dags/fxci_pulse_export.py
+++ b/dags/fxci_pulse_export.py
@@ -29,7 +29,7 @@ tags = [Tag.ImpactTier.tier_3]
 
 env_vars = {
     "FXCI_ETL_BIGQUERY_PROJECT": "moz-fx-data-shared-prod",
-    "FXCI_ETL_BIGQUERY_DATASET": "fxci",
+    "FXCI_ETL_BIGQUERY_DATASET": "fxci_derived",
     "FXCI_ETL_STORAGE_PROJECT": "moz-fx-dev-releng",
     "FXCI_ETL_STORAGE_BUCKET": "fxci-etl",
     "FXCI_ETL_PULSE_USER": "fxci-etl",


### PR DESCRIPTION
I have a couple questions I'm hoping someone from the data org can answer before this lands:

1. My understanding is that these should go in the `fxci_derived` dataset instead of `fxci`. Then in bigquery-etl, there should be `view.sql` files that create the user facing views. Just want to verify, is this understanding correct?

2. Can we move the existing tables from the `fxci` dataset to `fxci_derived` right before this is deployed? What's the best way to do that? If this is tricky, I'd honestly be ok with losing that data. This ETL is just on the cusp of exiting the prototype phase, so there's nothing relying on this data quite yet.