### PR TITLE
chore(shredder): Set memory requests for shredder pods

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -100,6 +100,9 @@ telemetry_main = GKEPodOperator(
         "--billing-project=moz-fx-data-shredder",
         "--only=telemetry_stable.main_v5",
     ],
+    container_resources=k8s.V1ResourceRequirements(
+        requests={"memory": "512Mi"},
+    ),
     **common_task_args,
 )
 
@@ -112,6 +115,9 @@ telemetry_main_use_counter = GKEPodOperator(
         "--billing-project=moz-fx-data-shredder",
         "--only=telemetry_stable.main_use_counter_v4",
     ],
+    container_resources=k8s.V1ResourceRequirements(
+        requests={"memory": "512Mi"},
+    ),
     **common_task_args,
 )
 
@@ -129,14 +135,9 @@ flat_rate = GKEPodOperator(
         "telemetry_derived.event_events_v1",
         "firefox_desktop_derived.events_stream_v1",
     ],
-    # Needed to scale the highmem pool from 0 -> 1, because cluster autoscaling
-    # works on pod resource requests, instead of usage
     container_resources=k8s.V1ResourceRequirements(
-        requests={"memory": "13312Mi"},
-        limits={"memory": "20480Mi"},
+        requests={"memory": "3072Mi"},
     ),
-    # This job was being killed by Kubernetes for using too much memory, thus the highmem node pool
-    node_selector={"nodepool": "highmem"},
     # Give additional time since we may need to scale up when running this job
     startup_timeout_seconds=360,
     **common_task_args,
@@ -151,6 +152,9 @@ experiments = GKEPodOperator(
         "--billing-project=moz-fx-data-bq-batch-prod",
         "--environment=experiments",
     ],
+    container_resources=k8s.V1ResourceRequirements(
+        requests={"memory": "1024Mi"},
+    ),
     **common_task_args,
 )
 
@@ -172,5 +176,8 @@ with_sampling = GKEPodOperator(
         "telemetry_derived.event_events_v1",
         "firefox_desktop_derived.events_stream_v1",
     ],
+    container_resources=k8s.V1ResourceRequirements(
+        requests={"memory": "512Mi"},
+    ),
     **common_task_args,
 )


### PR DESCRIPTION
## Description

https://github.com/mozilla/bigquery-etl/pull/6726 reduced the memory usage of shredder-all from ~20GiB to ~1.2GiB ([metrics explorer](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P30D?pageState=%7B%22domainObjectDeprecationId%22:%22ABC5E843-216A-443B-853F-1DCF416BCCBC%22,%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22legendTemplate%22:%22$%7Bresource.labels.pod_name%7D%20mem$%7Bmetric.labels.memory_type%7D%22,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22crossSeriesReducer%22:%22REDUCE_MAX%22,%22groupByFields%22:%5B%22metric.label.%5C%22memory_type%5C%22%22,%22resource.label.%5C%22pod_name%5C%22%22%5D,%22perSeriesAligner%22:%22ALIGN_MAX%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_MAX%22,%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fmemory%2Fused_bytes%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metric.label.%5C%22memory_type%5C%22%3D%5C%22non-evictable%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22moz-fx-data-airflow-gke-prod%5C%22%20resource.label.%5C%22location%5C%22%3D%5C%22us-west1%5C%22%20resource.label.%5C%22cluster_name%5C%22%3D%5C%22workloads-prod-v1%5C%22%20resource.label.%5C%22namespace_name%5C%22%3D%5C%22default%5C%22%20resource.label.%5C%22pod_name%5C%22%3Dmonitoring.regex.full_match(%5C%22shredder-.*%5C%22)%22,%22groupByFields%22:%5B%22metric.label.%5C%22memory_type%5C%22%22,%22resource.label.%5C%22pod_name%5C%22%22%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_MAX%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D&project=moz-fx-data-airflow-gke-prod)) so a high memory request isn't needed.  I'm also setting requests for the other tasks.

As far as I can tell, this was the only explicit usage of the highmem pool so it might actually scale down to 0 now.  I'm not sure how this will impact pool scaling/pod startups

## Related Tickets & Documents
* DENG-6891
