### PR TITLE
chore(glean_dictionary): building  glean dictionary whether upstream fails or succeeds

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -396,6 +396,7 @@ with DAG(
             "telemetry-alerts@mozilla.com",
         ],
         task_id="glean_dictionary_build",
+        # Glean Dictionary utilizes data from generated LookML namespaces. If Looker DAG fails we want to run the Dictionary build anyway to load updated generated schemas
         trigger_rule="all_done",
         dag=dag,
     )

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -396,6 +396,7 @@ with DAG(
             "telemetry-alerts@mozilla.com",
         ],
         task_id="glean_dictionary_build",
+        trigger_rule="all_done",
         dag=dag,
     )
 


### PR DESCRIPTION
## Description

Discussed in the Glean Platform Working Group meeting.

Sometimes the `trigger_looker` step that is the immediate upstream of `glean_dictionary_netlify_build` fails and we don't want it to block the Glean Dictionary daily build, because that prevents users from seeing newly added metrics.

## Related Tickets & Documents
* DENG-8049

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
