### PR TITLE
fix(bqetl_backfill_<...>) Fix backfill command arguments

### DIFF
--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -37,12 +37,7 @@ with DAG(
         name="detect_backfills",
         cmds=["sh", "-cx"],
         arguments=[
-            "script/bqetl",
-            "backfill",
-            "scheduled",
-            "--status=Complete",
-            "--json_path=/airflow/xcom/return.json",
-            "--ignore-old-entries",
+            "script/bqetl backfill scheduled --status=Complete --json_path=/airflow/xcom/return.json --ignore-old-entries",
         ],
         image=DOCKER_IMAGE,
         do_xcom_push=True,

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -37,12 +37,7 @@ with DAG(
         name="detect_backfills",
         cmds=["sh", "-cx"],
         arguments=[
-            "script/bqetl",
-            "backfill",
-            "scheduled",
-            "--status=Initiate",
-            "--json_path=/airflow/xcom/return.json",
-            "--ignore-old-entries",
+            "script/bqetl backfill scheduled --status=Initiate --json_path=/airflow/xcom/return.json --ignore-old-entries"
         ],
         image=DOCKER_IMAGE,
         do_xcom_push=True,


### PR DESCRIPTION
## Description

This should fix the failing Airflow tasks: https://workflow.telemetry.mozilla.org/dags/bqetl_backfill_initiate/grid?tab=logs&dag_run_id=scheduled__2025-03-13T19%3A00%3A00%2B00%3A00&task_id=detect_backfills

Regression from https://github.com/mozilla/telemetry-airflow/pull/2166

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
