### PR TITLE
chore(merino): Make sure to always pull the latest docker image

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -30,6 +30,7 @@ def merino_job(
         task_id=name,
         name=name,
         image="mozilla/merino-py:latest",
+        image_pull_policy="Always",
         project_id="moz-fx-data-airflow-gke-prod",
         gcp_conn_id="google_cloud_airflow_gke",
         cluster_name="workloads-prod-v1",


### PR DESCRIPTION
## Description

We have a use case where even re-starting a DAG workflow doesn't use the latest docker image.