### PR TITLE
fix: Revert "chore: Upgrade `acryl-datahub-airflow-plugin` to v0.15.0.5"

### DIFF
--- a/requirements-override.txt
+++ b/requirements-override.txt
@@ -1,7 +1,3 @@
-# acryl-datahub-airflow-plugin 0.15 requires openlineage-integration-common 1.25.0,
-# while the Airflow 2.10.5 constraints specify openlineage-integration-common 1.27.0.
-acryl-datahub-airflow-plugin==0.15.0.5
-
 # There's a bug in apache-airflow-providers-google 12.0.0 where Dataproc operators fail to import
 # without OpenLineage installed, which was fixed in 14.0.0 (https://github.com/apache/airflow/pull/46561).
 apache-airflow-providers-google==14.0.0

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ apache-airflow-providers-slack
 airflow-provider-fivetran-async==2.0.2
 
 # Acryl DataHub integration
-acryl-datahub-airflow-plugin==0.14.1.12
+acryl-datahub-airflow-plugin
 gql
 
 # dbt integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --no-annotate --strip-extras requirements.in
 #
-acryl-datahub==0.14.1.12
-acryl-datahub-airflow-plugin==0.14.1.12
+acryl-datahub==0.13.2.4
+acryl-datahub-airflow-plugin==0.13.2.4
 aiofiles==23.2.1
 aiohappyeyeballs==2.4.4
 aiohttp==3.11.11
@@ -44,7 +44,7 @@ atlassian-python-api==3.41.19
 attrs==25.1.0
 authlib==1.3.1
 avro==1.11.3
-avro-gen3==0.7.16
+avro-gen3==0.7.12
 babel==2.17.0
 backoff==2.2.1
 bcrypt==4.2.1
@@ -53,7 +53,7 @@ billiard==4.2.1
 blinker==1.9.0
 boto3==1.36.3
 botocore==1.36.3
-cached-property==2.0.1
+cached-property==1.5.2
 cachelib==0.9.0
 cachetools==5.5.1
 cattrs==24.1.2
@@ -85,7 +85,7 @@ docker==7.1.0
 docstring-parser==0.16
 email-validator==2.2.0
 eventlet==0.39.0
-expandvars==1.0.0
+expandvars==0.12.0
 flask==2.2.5
 flask-appbuilder==4.5.2
 flask-babel==2.0.0
@@ -228,7 +228,7 @@ pendulum==3.0.0
 pluggy==1.5.0
 ply==3.11
 prison==0.2.1
-progressbar2==4.5.0
+progressbar2==4.4.2
 prometheus-client==0.21.1
 prompt-toolkit==3.0.50
 propcache==0.2.1
@@ -252,7 +252,7 @@ python-daemon==3.1.2
 python-dateutil==2.9.0.post0
 python-nvd3==0.16.0
 python-slugify==8.0.4
-python-utils==3.9.1
+python-utils==3.8.2
 python3-saml==1.16.0
 pytz==2025.1
 pyyaml==6.0.2
@@ -268,8 +268,8 @@ rich==13.9.4
 rich-argparse==1.6.0
 rpds-py==0.22.3
 rsa==4.9
-ruamel-yaml==0.18.10
-ruamel-yaml-clib==0.2.12
+ruamel-yaml==0.18.6
+ruamel-yaml-clib==0.2.8
 s3transfer==0.11.2
 scramp==1.4.5
 sentry-sdk==2.20.0


### PR DESCRIPTION
Reverts mozilla/telemetry-airflow#2181

In case this was the cause of the current Airflow outage.