### PR TITLE
fix: Create logs folder on root for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ stop:
 up:
 	grep -qF 'AIRFLOW_UID=' .env || echo "AIRFLOW_UID=$$(id -u)" >> .env
 	grep -qF 'FERNET_KEY=' .env || echo "FERNET_KEY=$$(python3 -c "from cryptography.fernet import Fernet; fernet_key = Fernet.generate_key(); print(fernet_key.decode())")" >> .env
+	mkdir -p logs
 	docker-compose up --wait
 	docker-compose exec airflow-webserver airflow variables import dev_variables.json
 	docker-compose exec airflow-webserver airflow connections import dev_connections.json


### PR DESCRIPTION
## Description

This PR fixes the following error while running `make up` which affects CI:
```
Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /home/circleci/project/logs
make: *** [Makefile:46: up] Error 1
```

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
