### PR TITLE
fix: Fix GKE pod extra link for GKEPodOperator

### DIFF
--- a/operators/gcp_container_operator.py
+++ b/operators/gcp_container_operator.py
@@ -1,8 +1,10 @@
 import kubernetes.client as k8s
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback
+from airflow.providers.google.cloud.links.kubernetes_engine import KubernetesEnginePodLink
 from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEStartPodOperator as UpstreamGKEPodOperator,
 )
+from airflow.utils.context import Context
 
 
 class GKEPodOperatorCallbacks(KubernetesPodOperatorCallback):
@@ -79,3 +81,14 @@ class GKEPodOperator(UpstreamGKEPodOperator):
             callbacks=GKEPodOperatorCallbacks,
             **kwargs,
         )
+
+    def get_or_create_pod(self, pod_request_obj: k8s.V1Pod, context: Context) -> k8s.V1Pod:
+        """Set GKE pod link during pod creation.
+
+        Workaround for https://github.com/apache/airflow/issues/46658
+        This is meant for apache-airflow-providers-google==14.0.0
+        """
+        pod = super().get_or_create_pod(pod_request_obj, context)
+        self.pod = pod
+        KubernetesEnginePodLink.persist(context=context, task_instance=self)
+        return pod


### PR DESCRIPTION
## Description

This makes the gke pod link in the task instance details work.  This is a workaround for https://github.com/apache/airflow/issues/46658 pending that being fixed and us upgrading the provider version.  I tested this with a sandbox gke cluster with both deferrable and non-deferrable operators.

I'm open to opinions on whether this is worth doing