### PR TITLE
feat(DENG-8272): Move chrome extensions to run via docker-etl

### DIFF
--- a/dags/extensions.py
+++ b/dags/extensions.py
@@ -26,7 +26,7 @@ default_args = {
     "retries": 2,
 }
 
-tags = ["impact/tier_3", "repo/docker-etl"]
+tags = ["impact/tier_3", "repo/telemetry-airflow"]
 SERVER = "moz-fx-data-airflow-prod-88e0"
 IMAGE_NAME = "extensions_docker_etl:latest"
 


### PR DESCRIPTION
## Description

This PR creates a new DAG called "extensions" that runs daily at 3pm UTC.  It takes the latest Docker image from the Docker ETL job "extensions" and runs it. 

## Related Tickets & Documents
* [DENG-8272](https://mozilla-hub.atlassian.net/browse/DENG-8272)


[DENG-8272]: https://mozilla-hub.atlassian.net/browse/DENG-8272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ