### PR TITLE
chore: Upgrade `acryl-datahub-airflow-plugin` to v1.0.0.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ x-airflow-common:
     # Opt out of Airflow's usage telemetry.
     SCARF_ANALYTICS: 'false'
     AIRFLOW__DATAHUB__ENABLED: 'false'
+    AIRFLOW__DATAHUB__RENDER_TEMPLATES: 'false'
   volumes:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs

--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ apache-airflow-providers-slack
 airflow-provider-fivetran-async==2.0.2
 
 # Acryl DataHub integration
-acryl-datahub-airflow-plugin
+acryl-datahub-airflow-plugin==1.0.0.2
 gql
 
 # dbt integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --no-annotate --strip-extras requirements.in
 #
-acryl-datahub==0.13.2.4
-acryl-datahub-airflow-plugin==0.13.2.4
+acryl-datahub==1.0.0.2
+acryl-datahub-airflow-plugin==1.0.0.2
 aiofiles==23.2.1
 aiohappyeyeballs==2.4.4
 aiohttp==3.11.11
@@ -44,7 +44,7 @@ atlassian-python-api==3.41.19
 attrs==25.1.0
 authlib==1.3.1
 avro==1.11.3
-avro-gen3==0.7.12
+avro-gen3==0.7.16
 babel==2.17.0
 backoff==2.2.1
 bcrypt==4.2.1
@@ -211,6 +211,10 @@ multidict==6.1.0
 mypy-extensions==1.0.0
 numpy==1.26.4
 oauthlib==3.2.2
+openlineage-airflow==1.27.0
+openlineage-integration-common==1.27.0
+openlineage-python==1.27.0
+openlineage-sql==1.27.0
 opentelemetry-api==1.27.0
 opentelemetry-exporter-otlp==1.27.0
 opentelemetry-exporter-otlp-proto-common==1.27.0
@@ -223,6 +227,7 @@ ordered-set==4.1.0
 packaging==24.2
 pandas==2.1.4
 pandas-gbq==0.26.1
+patchy==2.8.0
 pathspec==0.12.1
 pendulum==3.0.0
 pluggy==1.5.0
@@ -284,6 +289,8 @@ sqlalchemy-bigquery==1.12.1
 sqlalchemy-jsonfield==1.0.2
 sqlalchemy-spanner==1.8.0
 sqlalchemy-utils==0.41.2
+sqlglot==26.6.0
+sqlglotrs==0.3.14
 sqlparse==0.5.3
 statsd==4.0.1
 tabulate==0.9.0


### PR DESCRIPTION
## Description
We received the following message from Acryl today (emphasis mine):
> We have upgraded your instance to the Acryl DataHub SaaS release v0.3.10.2-acryl. This release brings in a lot of fixes and new features from OSS DataHub to you. Full changelog can be found in the release notes [here](https://datahubproject.io/docs/next/managed-datahub/release-notes/v_0_3_10) for v0.3.10.2-acryl release.
> If you are using remote executor please upgrade your image version to be v0.3.10.2-acryl. This is required so you are running the latest versions and do not face issues in Ingestion or Observability.
> **The recommended CLI to use with this release is 1.0.0.2. This applies for all CLI usages, if you are using it through your terminal, github actions, airflow, in python SDK somewhere etc.** This is a strong recommendation to upgrade as we keep on pushing fixes in the CLI and it helps us support you better

Also, after upgrading WTMO to Airflow 2.10 (#2179) there's been an issue with some task tries not showing in the main UI, and I believe I've identified that the `acryl-datahub-airflow-plugin`'s custom retry handler code is somehow the culprit.  I'm hoping upgrading to this newer version of `acryl-datahub-airflow-plugin` might solve that issue, as it doesn't add a custom retry handler.

It's worth noting that when I previously tried upgrading `acryl-datahub-airflow-plugin` to v0.15.0.5 (#2181) it had dependency conflicts with Airflow and seemed to cause an Airflow outage when deployed, so I reverted that attempt (#2183).

However, with this PR there were no dependency conflicts with Airflow, and when testing in stage the `bqetl_status_check`, `bqetl_cjms_nonprod`, and `bqetl_google_search_console` DAGs all ended up running fine, except for a non-critical DataHub plugin error about not being able to render templates, and with https://github.com/mozilla-it/dataservices-infra/pull/725 we'll avoid such errors.

## Related Tickets & Documents
* DENG-5881: Upgrade WTMO to Airflow 2.10
* https://github.com/mozilla/telemetry-airflow/pull/2181
* https://github.com/mozilla/telemetry-airflow/pull/2183
* https://github.com/mozilla-it/dataservices-infra/pull/725
