### PR TITLE
chore: Upgrade `acryl-datahub-airflow-plugin` to v1.0.0.3

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -16,7 +16,7 @@ apache-airflow-providers-slack
 airflow-provider-fivetran-async==2.0.2
 
 # Acryl DataHub integration
-acryl-datahub-airflow-plugin==1.0.0.2
+acryl-datahub-airflow-plugin==1.0.0.3
 gql
 
 # dbt integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@
 #
 #    pip-compile --no-annotate --strip-extras requirements.in
 #
-acryl-datahub==1.0.0.2
-acryl-datahub-airflow-plugin==1.0.0.2
+acryl-datahub==1.0.0.3
+acryl-datahub-airflow-plugin==1.0.0.3
 aiofiles==23.2.1
 aiohappyeyeballs==2.4.4
 aiohttp==3.11.11


### PR DESCRIPTION
## Description
We received the following message from Acryl on May 19:
> We have upgraded your prod [instance](https://mozilla.acryl.io/) to the Acryl DataHub SaaS release v0.3.11-acryl. This release brings in a lot of fixes and new features from OSS DataHub to you. Full changelog can be found in the release notes [here](https://datahubproject.io/docs/next/managed-datahub/release-notes/v_0_3_11) for v0.3.11-acryl release.
> If you are using remote executor please upgrade your image version to be v0.3.11-acryl. This is required so you are running the latest versions and do not face issues in Ingestion or Observability.
> The recommended CLI to use with this release is 1.0.0.3. This applies for all CLI usages, if you are using it through your terminal, github actions, airflow, in python SDK somewhere etc. This is a strong recommendation to upgrade as we keep on pushing fixes in the CLI and it helps us support you better.

## Related Tickets & Documents
N/A
