### PR TITLE
fix: Stop using deprecated `is_delete_operator_pod` parameter

### DIFF
--- a/dags/glam.py
+++ b/dags/glam.py
@@ -243,7 +243,6 @@ client_scalar_probe_counts = GKEPodOperator(
         dataset_id,
     ],
     image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
-    is_delete_operator_pod=False,
     dag=dag,
 )
 

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -4,7 +4,7 @@ from airflow import DAG
 from kubernetes.client import models as k8s
 from timetable import MultiWeekTimetable
 
-from operators.gcp_container_operator import GKEPodOperator
+from operators.gcp_container_operator import GKEPodOperator, OnFinishAction
 from utils.tags import Tag
 
 docs = """
@@ -82,7 +82,7 @@ base_command = [
 ]
 common_task_args = {
     "image": docker_image,
-    "is_delete_operator_pod": True,
+    "on_finish_action": OnFinishAction.DELETE_POD.value,
     "reattach_on_restart": True,
     "dag": dag,
 }

--- a/dags/shredder_backfill.py
+++ b/dags/shredder_backfill.py
@@ -4,7 +4,7 @@ from airflow import DAG
 from airflow.models.param import Param
 from airflow.operators.python import BranchPythonOperator
 
-from operators.gcp_container_operator import GKEPodOperator
+from operators.gcp_container_operator import GKEPodOperator, OnFinishAction
 from utils.tags import Tag
 
 docs = """
@@ -99,7 +99,7 @@ def base_backfill_operator(dry_run):
         # target_tables will be rendered as a python list
         arguments="{{ params.target_tables }}",
         image="gcr.io/moz-fx-data-airflow-prod-88e0/bigquery-etl:latest",
-        is_delete_operator_pod=True,
+        on_finish_action=OnFinishAction.DELETE_POD.value,
         reattach_on_restart=True,
     )
 

--- a/utils/gcp.py
+++ b/utils/gcp.py
@@ -207,7 +207,6 @@ def bigquery_etl_query(
     docker_image=BIGQUERY_ETL_DOCKER_IMAGE,
     date_partition_parameter="submission_date",
     multipart=False,
-    is_delete_operator_pod=False,
     table_partition_template="${{ds_nodash}}",
     **kwargs,
 ):
@@ -233,9 +232,6 @@ def bigquery_etl_query(
                                                    rather than partition
     :param Dict[str, Any] kwargs:                  Additional keyword arguments for
                                                    GKEPodOperator
-    :param is_delete_operator_pod                  Optional, What to do when the pod reaches its final
-                                                   state, or the execution is interrupted.
-                                                   If False (default): do nothing, If True: delete the pod
     :param str table_partition_template:           Template for the datestring that's used for
                                                    the partition table id. Defaults to "{{ds_nodash}}".
     :return: GKEPodOperator
@@ -270,7 +266,6 @@ def bigquery_etl_query(
         + ["--parameter=" + parameter for parameter in parameters]
         + list(arguments)
         + [sql_file_path],
-        is_delete_operator_pod=is_delete_operator_pod,
         **kwargs,
     )
 

--- a/utils/glam_subdags/generate_query.py
+++ b/utils/glam_subdags/generate_query.py
@@ -58,7 +58,6 @@ def generate_and_run_desktop_query(
         env_vars=env_vars,
         arguments=command,
         image=docker_image,
-        is_delete_operator_pod=False,
         **kwargs,
     )
 
@@ -104,7 +103,6 @@ def generate_and_run_glean_queries(
         env_vars=env_vars,
         arguments=["script/glam/generate_glean_sql && script/glam/run_glam_sql"],
         image=docker_image,
-        is_delete_operator_pod=False,
         **kwargs,
     )
 
@@ -169,6 +167,5 @@ def generate_and_run_glean_task(
             f'run_{task_type} {query_name} false {min_sample_id} {max_sample_id} "" {write_preference}'
         ],
         image=docker_image,
-        is_delete_operator_pod=False,
         **kwargs,
     )


### PR DESCRIPTION
## Description
Using the `is_delete_operator_pod` parameter is preventing the [fix](https://github.com/mozilla/telemetry-airflow/pull/2205) for DENG-8670 from working.

## Related Tickets & Documents
* DENG-8670: Clearing Airflow GKE pod operator tasks with `reattach_on_restart` enabled won't re-run the task's logic if a pod from a previous successful try exists
* https://github.com/mozilla/telemetry-airflow/pull/2205