### PR TITLE
chore(glam): split tasks on glam_fog and glam_fenix

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -131,16 +131,58 @@ with DAG(
         clients_scalar_aggregates_init = init(
             task_name=f"{product}__clients_scalar_aggregates_v1"
         )
-        clients_scalar_aggregates = query(
-            task_name=f"{product}__clients_scalar_aggregates_v1"
-        )
+        if is_release:
+            with TaskGroup(
+                group_id=f"{product}__clients_scalar_aggregates_v1", dag=dag, default_args=default_args
+            ) as clients_scalar_aggregates:
+                prev_task = None
+                for sample_range in (
+                    [0, 2], [3, 5], [6, 9], [10, 49], [50, 99]
+                ):
+                    clients_scalar_aggregates_sampled = query(
+                        task_name=(
+                            f"{product}__clients_scalar_aggregates_v1_sampled_"
+                            f"{sample_range[0]}_{sample_range[1]}"
+                        ),
+                        min_sample_id=sample_range[0],
+                        max_sample_id=sample_range[1],
+                        replace_table=(sample_range[0] == 0)
+                    )
+                    if prev_task:
+                        clients_scalar_aggregates_sampled.set_upstream(prev_task)
+                    prev_task = clients_scalar_aggregates_sampled
+        else:
+            clients_scalar_aggregates = query(
+                task_name=f"{product}__clients_scalar_aggregates_v1"
+            )
 
         clients_histogram_aggregates_init = init(
             task_name=f"{product}__clients_histogram_aggregates_v1"
         )
-        clients_histogram_aggregates = query(
-            task_name=f"{product}__clients_histogram_aggregates_v1"
-        )
+        if is_release:
+            with TaskGroup(
+                group_id=f"{product}__clients_histogram_aggregates_v1", dag=dag, default_args=default_args
+            ) as clients_histogram_aggregates:
+                prev_task = None
+                for sample_range in (
+                    [0, 2], [3, 5], [6, 9], [10, 49], [50, 99]
+                ):
+                    clients_histogram_aggregates_sampled = query(
+                        task_name=(
+                            f"{product}__clients_histogram_aggregates_v1_sampled_"
+                            f"{sample_range[0]}_{sample_range[1]}"
+                        ),
+                        min_sample_id=sample_range[0],
+                        max_sample_id=sample_range[1],
+                        replace_table=(sample_range[0] == 0)
+                    )
+                    if prev_task:
+                        clients_histogram_aggregates_sampled.set_upstream(prev_task)
+                    prev_task = clients_histogram_aggregates_sampled
+        else:
+            clients_histogram_aggregates = query(
+                task_name=f"{product}__clients_histogram_aggregates_v1"
+            )
 
         # set all of the dependencies for all of the tasks
         # get the dependencies for the logical mapping, or just pass through the

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -115,16 +115,58 @@ with DAG(
         clients_scalar_aggregates_init = init(
             task_name=f"{product}__clients_scalar_aggregates_v1"
         )
-        clients_scalar_aggregates = query(
-            task_name=f"{product}__clients_scalar_aggregates_v1"
-        )
+        if is_release:
+            with TaskGroup(
+                group_id=f"{product}__clients_scalar_aggregates_v1", dag=dag, default_args=default_args
+            ) as clients_scalar_aggregates:
+                prev_task = None
+                for sample_range in (
+                    [0, 2], [3, 5], [6, 9], [10, 49], [50, 99]
+                ):
+                    clients_scalar_aggregates_sampled = query(
+                        task_name=(
+                            f"{product}__clients_scalar_aggregates_v1_sampled_"
+                            f"{sample_range[0]}_{sample_range[1]}"
+                        ),
+                        min_sample_id=sample_range[0],
+                        max_sample_id=sample_range[1],
+                        replace_table=(sample_range[0] == 0)
+                    )
+                    if prev_task:
+                        clients_scalar_aggregates_sampled.set_upstream(prev_task)
+                    prev_task = clients_scalar_aggregates_sampled
+        else:
+            clients_scalar_aggregates = query(
+                task_name=f"{product}__clients_scalar_aggregates_v1"
+            )
 
         clients_histogram_aggregates_init = init(
             task_name=f"{product}__clients_histogram_aggregates_v1"
         )
-        clients_histogram_aggregates = query(
-            task_name=f"{product}__clients_histogram_aggregates_v1"
-        )
+        if is_release:
+            with TaskGroup(
+                group_id=f"{product}__clients_histogram_aggregates_v1", dag=dag, default_args=default_args
+            ) as clients_histogram_aggregates:
+                prev_task = None
+                for sample_range in (
+                    [0, 2], [3, 5], [6, 9], [10, 49], [50, 99]
+                ):
+                    clients_histogram_aggregates_sampled = query(
+                        task_name=(
+                            f"{product}__clients_histogram_aggregates_v1_sampled_"
+                            f"{sample_range[0]}_{sample_range[1]}"
+                        ),
+                        min_sample_id=sample_range[0],
+                        max_sample_id=sample_range[1],
+                        replace_table=(sample_range[0] == 0)
+                    )
+                    if prev_task:
+                        clients_histogram_aggregates_sampled.set_upstream(prev_task)
+                    prev_task = clients_histogram_aggregates_sampled
+        else:
+            clients_histogram_aggregates = query(
+                task_name=f"{product}__clients_histogram_aggregates_v1"
+            )
 
         # set all of the dependencies for all of the tasks
 


### PR DESCRIPTION
## Description

Splits `clients_histogram_aggregates` and `clients_scalar_aggregates` release into TaskGroups to mitigate resource contention on `glam_fog` and `glam_fenix` DAGs.

## Related Tickets & Documents
* DENG-8731

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
