### PR TITLE
chore(shredder): [DENG-8672] Use per sample_id shredding for firefox_desktop metrics

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -134,6 +134,7 @@ flat_rate = GKEPodOperator(
         "telemetry_stable.main_use_counter_v4",
         "telemetry_derived.event_events_v1",
         "firefox_desktop_derived.events_stream_v1",
+        "firefox_desktop_stable.metrics_v1",
     ],
     container_resources=k8s.V1ResourceRequirements(
         requests={"memory": "3072Mi"},
@@ -175,6 +176,7 @@ with_sampling = GKEPodOperator(
         "--sampling-tables",
         "telemetry_derived.event_events_v1",
         "firefox_desktop_derived.events_stream_v1",
+        "firefox_desktop_stable.metrics_v1",
     ],
     container_resources=k8s.V1ResourceRequirements(
         requests={"memory": "512Mi"},


### PR DESCRIPTION
## Description

`firefox_desktop_stable.metrics_v1` shredder jobs are timing out after 6 hours so this changes it to per sample_id shredding.  This comes with some extra storage costs but it should at least work until I have have more time to look at this

The default table expiration on the `shredder_tmp` table should also be increased so jobs have more time to finish: https://github.com/mozilla-services/cloudops-infra/pull/6444

## Related Tickets & Documents
* DENG-8672