### PR TITLE
chore(shredder): [DENG-8672] Use per sample_id shredding for firefox_desktop metrics

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -173,6 +173,7 @@ with_sampling = GKEPodOperator(
         "--only",
         "telemetry_derived.event_events_v1",
         "firefox_desktop_derived.events_stream_v1",
+        "firefox_desktop_stable.metrics_v1",
         "--sampling-tables",
         "telemetry_derived.event_events_v1",
         "firefox_desktop_derived.events_stream_v1",


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mozilla/telemetry-airflow/pull/2210.  I missed a line

## Related Tickets & Documents
* DENG-8672