### PR TITLE
feat(bugzilla_link): Add a link to open a Bugzilla issue

### DIFF
--- a/plugins/extra_link.py
+++ b/plugins/extra_link.py
@@ -1,0 +1,59 @@
+from typing import ClassVar
+from urllib.parse import quote
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.baseoperatorlink import BaseOperatorLink
+from airflow.models.taskinstancekey import TaskInstanceKey
+from airflow.operators.bash import BashOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.operators.python import PythonOperator
+from airflow.plugins_manager import AirflowPlugin
+
+from operators.gcp_container_operator import GKEPodOperator
+
+
+class BugzillaLink(BaseOperatorLink):
+    name = "Create Bugzilla Issue"
+
+    operators: ClassVar[list[str]] = [GKEPodOperator, BashOperator, PythonOperator, EmptyOperator]
+
+    def get_link(self, operator: BaseOperator, *, ti_key: TaskInstanceKey):
+        comment = quote(
+            f"""Airflow task `{operator.dag_id}.{operator.task_id}` failed for run `{ti_key.run_id}`
+
+Task link:
+https://workflow.telemetry.mozilla.org/dags/{operator.dag_id}/grid?dag_run_id={ti_key.run_id}&task_id={operator.task_id}
+
+Log extract:
+```
+<extract of error log>
+```"""
+        )
+
+        bug_title = quote(
+            f"Airflow task `{operator.dag_id}.{operator.task_id}` failed for run `{ti_key.run_id}`"
+        )
+
+        return (
+            "https://bugzilla.mozilla.org/enter_bug.cgi?"
+            + f"assigned_to={operator.owner}&"
+            + "bug_ignored=0&bug_severity=--&bug_status=NEW&"
+            + "bug_type=defect&cf_fx_iteration=---&cf_fx_points=---&"
+            + f"comment={comment}&component=General&contenttypemethod=list&"
+            + "contenttypeselection=text%2Fplain&defined_groups=1&"
+            + "filed_via=standard_form&flag_type-4=X&flag_type-607=X&"
+            + "flag_type-800=X&flag_type-803=X&flag_type-936=X&"
+            + "form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&"
+            + "op_sys=Unspecified&priority=--&"
+            + "product=Data%20Platform%20and%20Tools&rep_platform=Unspecified&"
+            + f"short_desc={bug_title}&status_whiteboard=%5Bairflow-triage%5D&"
+            + "target_milestone=---&version=unspecified"
+        )
+
+
+# Defining the plugin class
+class AirflowExtraLinkPlugin(AirflowPlugin):
+    name = "extra_link_plugin"
+    operator_extra_links: ClassVar[list] = [
+        BugzillaLink(),
+    ]


### PR DESCRIPTION
This PR adds a plugin which will display an additional link in the task details to open an issue in Bugzilla. This is to simplify the Airflow Triage process. 

<img width="312" alt="Screenshot 2025-06-09 at 4 15 16 PM" src="https://github.com/user-attachments/assets/8778d657-3c56-4768-8530-8fd723bdf73e" />


The Bugzilla issue looks something like this and has task name, DAG and execution time pre-populated: https://bugzilla.mozilla.org/enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_ignored=0&bug_severity=--&bug_status=NEW&bug_type=defect&cf_fx_iteration=---&cf_fx_points=---&comment=Airflow%20task%20%60looker.lookml_generator_staging%60%20failed%20for%20run%20%60manual__2024-08-21T21%3A41%3A56.966438%2B00%3A00%60%0A%0ATask%20link%3A%0Ahttps%3A//workflow.telemetry.mozilla.org/dags/looker/grid%3Fdag_run_id%3Dmanual__2024-08-21T21%3A41%3A56.966438%2B00%3A00%26task_id%3Dlookml_generator_staging%0A%0ALog%20extract%3A%0A%60%60%60%0A%3Cextract%20of%20error%20log%3E%0A%60%60%60&component=General&contenttypemethod=list&contenttypeselection=text%2Fplain&defined_groups=1&filed_via=standard_form&flag_type-4=X&flag_type-607=X&flag_type-800=X&flag_type-803=X&flag_type-936=X&form_name=enter_bug&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=--&product=Data%20Platform%20and%20Tools&rep_platform=Unspecified&short_desc=Airflow%20task%20%60looker.lookml_generator_staging%60%20failed%20for%20run%20%60manual__2024-08-21T21%3A41%3A56.966438%2B00%3A00%60&status_whiteboard=%5Bairflow-triage%5D&target_milestone=---&version=unspecified

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
