### PR TITLE
chore(GLAM): aggregates_new for scalar and histogram

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -131,7 +131,7 @@ with DAG(
         scalar_wait_for_yesterdays_aggregates = ExternalTaskSensor(
             task_id=f"{product}_wait_for_yesterdays_scalar_aggregates",
             external_dag_id="glam_fenix",
-            external_task_id=f"{product}__clients_scalar_aggregates_v1",
+            external_task_id=f"query_{product}__clients_scalar_aggregates_v1",
             execution_delta=timedelta(days=1),
             mode="reschedule",
         )
@@ -150,7 +150,7 @@ with DAG(
         histogram_wait_for_yesterdays_aggregates = ExternalTaskSensor(
             task_id=f"{product}_wait_for_yesterdays_histogram_aggregates",
             external_dag_id="glam_fenix",
-            external_task_id=f"{product}__clients_histogram_aggregates_v1",
+            external_task_id=f"query_{product}__clients_histogram_aggregates_v1",
             execution_delta=timedelta(days=1),
             mode="reschedule",
         )

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -128,13 +128,38 @@ with DAG(
         )
         latest_versions = query(task_name=f"{product}__latest_versions_v1")
 
+        scalar_wait_for_yesterdays_aggregates = ExternalTaskSensor(
+            task_id=f"{product}_wait_for_yesterdays_scalar_aggregates",
+            external_dag_id="glam_fenix",
+            external_task_id=f"{product}__clients_scalar_aggregates_v1",
+            execution_delta=timedelta(days=1),
+            mode="reschedule",
+        )
+        clients_scalar_aggregates_new_init = init(
+            task_name=f"{product}__clients_scalar_aggregates_new_v1"
+        )
+        clients_scalar_aggregates_new = query(
+            task_name=f"{product}__clients_scalar_aggregates_new_v1"
+        )
         clients_scalar_aggregates_init = init(
             task_name=f"{product}__clients_scalar_aggregates_v1"
         )
         clients_scalar_aggregates = query(
             task_name=f"{product}__clients_scalar_aggregates_v1"
         )
-
+        histogram_wait_for_yesterdays_aggregates = ExternalTaskSensor(
+            task_id=f"{product}_wait_for_yesterdays_histogram_aggregates",
+            external_dag_id="glam_fenix",
+            external_task_id=f"{product}__clients_histogram_aggregates_v1",
+            execution_delta=timedelta(days=1),
+            mode="reschedule",
+        )
+        clients_histogram_aggregates_new_init = init(
+            task_name=f"{product}__clients_histogram_aggregates_new_v1"
+        )
+        clients_histogram_aggregates_new = query(
+            task_name=f"{product}__clients_histogram_aggregates_new_v1"
+        )
         clients_histogram_aggregates_init = init(
             task_name=f"{product}__clients_histogram_aggregates_v1"
         )
@@ -148,18 +173,23 @@ with DAG(
         for dependency in LOGICAL_MAPPING.get(product, [product]):
             mapping[dependency] >> clients_daily_scalar_aggregates
             mapping[dependency] >> clients_daily_histogram_aggregates
-        # only the scalar aggregates are upstream of latest versions
         clients_daily_scalar_aggregates >> latest_versions
-        latest_versions >> clients_scalar_aggregates_init
-        latest_versions >> clients_histogram_aggregates_init
+        clients_daily_histogram_aggregates >> latest_versions
+
+        latest_versions >> scalar_wait_for_yesterdays_aggregates
+        latest_versions >> histogram_wait_for_yesterdays_aggregates
 
         (
-            clients_daily_scalar_aggregates
+            scalar_wait_for_yesterdays_aggregates
+            >> clients_scalar_aggregates_new_init
+            >> clients_scalar_aggregates_new
             >> clients_scalar_aggregates_init
             >> clients_scalar_aggregates
         )
         (
-            clients_daily_histogram_aggregates
+            histogram_wait_for_yesterdays_aggregates
+            >> clients_histogram_aggregates_new_init
+            >> clients_histogram_aggregates_new
             >> clients_histogram_aggregates_init
             >> clients_histogram_aggregates
         )

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -115,7 +115,7 @@ with DAG(
         scalar_wait_for_yesterdays_aggregates = ExternalTaskSensor(
             task_id=f"{product}_wait_for_yesterdays_scalar_aggregates",
             external_dag_id="glam_fog",
-            external_task_id=f"{product}__clients_scalar_aggregates_v1",
+            external_task_id=f"query_{product}__clients_scalar_aggregates_v1",
             execution_delta=timedelta(days=1),
             mode="reschedule",
         )
@@ -134,7 +134,7 @@ with DAG(
         histogram_wait_for_yesterdays_aggregates = ExternalTaskSensor(
             task_id=f"{product}_wait_for_yesterdays_histogram_aggregates",
             external_dag_id="glam_fog",
-            external_task_id=f"{product}__clients_histogram_aggregates_v1",
+            external_task_id=f"query_{product}__clients_histogram_aggregates_v1",
             execution_delta=timedelta(days=1),
             mode="reschedule",
         )


### PR DESCRIPTION
## Description

This PR complements https://github.com/mozilla/bigquery-etl/pull/7612

It creates clients_scalar_aggregates_new_v1 and clients_histogram_aggregates_new_v1 for the glam_fog and glam_fenix DAGs. The two tasks are extracted from clients_scalar_aggregates_v1 and clients_histogram_aggregates_v1 respectively. The intention behind this is to reduce resource contention on both DAGs. so if this refactor isn't enough I will add processing by samples on top of it.

## Related Tickets & Documents
* DENG-8798

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
