### PR TITLE
[DENG-8344] Use mozilla-schema-generator image from GAR

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -310,7 +310,7 @@ with DAG(
         ],
         task_id="mozilla_schema_generator",
         name="schema-generator-1",
-        image="mozilla/mozilla-schema-generator:latest",
+        image="gcr.io/moz-fx-data-airflow-prod-88e0/mozilla-schema-generator:latest",
         env_vars={
             "MPS_REPO_URL": "git@github.com:mozilla-services/mozilla-pipeline-schemas.git",
             "MPS_BRANCH_SOURCE": "main",


### PR DESCRIPTION
## Description

https://mozilla-hub.atlassian.net/browse/DENG-8344

Use mozilla-schema-generator image from GAR.

See also https://github.com/mozilla/mozilla-schema-generator/pull/288

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
