### PR TITLE
chore(glam): Split histogram_aggregates into sample-based jobs

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -163,9 +163,33 @@ with DAG(
         clients_histogram_aggregates_init = init(
             task_name=f"{product}__clients_histogram_aggregates_v1"
         )
-        clients_histogram_aggregates = query(
-            task_name=f"{product}__clients_histogram_aggregates_v1"
+        clients_histogram_aggregates_snapshot_init = init(
+            task_name=f"{product}__clients_histogram_aggregates_snapshot_v1"
         )
+        if is_release:
+            with TaskGroup(
+                group_id=f"{product}__clients_histogram_aggregates_v1", dag=dag, default_args=default_args
+            ) as clients_histogram_aggregates:
+                prev_task = None
+                for sample_range in (
+                    [0, 2], [3, 5], [6, 9], [10, 49], [50, 99]
+                ):
+                    clients_histogram_aggregates_sampled = query(
+                        task_name=(
+                            f"{product}__clients_histogram_aggregates_v1_sampled_"
+                            f"{sample_range[0]}_{sample_range[1]}"
+                        ),
+                        min_sample_id=sample_range[0],
+                        max_sample_id=sample_range[1],
+                        replace_table=(sample_range[0] == 0)
+                    )
+                    if prev_task:
+                        clients_histogram_aggregates_sampled.set_upstream(prev_task)
+                    prev_task = clients_histogram_aggregates_sampled
+        else:
+            clients_histogram_aggregates = query(
+                task_name=f"{product}__clients_histogram_aggregates_v1"
+            )
 
         # set all of the dependencies for all of the tasks
         # get the dependencies for the logical mapping, or just pass through the
@@ -191,6 +215,7 @@ with DAG(
             >> clients_histogram_aggregates_new_init
             >> clients_histogram_aggregates_new
             >> clients_histogram_aggregates_init
+            >> clients_histogram_aggregates_snapshot_init
             >> clients_histogram_aggregates
         )
         if is_release:

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -163,10 +163,10 @@ with DAG(
         clients_histogram_aggregates_init = init(
             task_name=f"{product}__clients_histogram_aggregates_v1"
         )
-        clients_histogram_aggregates_snapshot_init = init(
-            task_name=f"{product}__clients_histogram_aggregates_snapshot_v1"
-        )
         if is_release:
+            clients_histogram_aggregates_snapshot_init = init(
+                task_name=f"{product}__clients_histogram_aggregates_snapshot_v1"
+            )
             with TaskGroup(
                 group_id=f"{product}__clients_histogram_aggregates_v1", dag=dag, default_args=default_args
             ) as clients_histogram_aggregates:
@@ -215,13 +215,14 @@ with DAG(
             >> clients_histogram_aggregates_new_init
             >> clients_histogram_aggregates_new
             >> clients_histogram_aggregates_init
-            >> clients_histogram_aggregates_snapshot_init
-            >> clients_histogram_aggregates
         )
         if is_release:
+            clients_histogram_aggregates_init >> clients_histogram_aggregates_snapshot_init
+            clients_histogram_aggregates_snapshot_init >> clients_histogram_aggregates
             clients_histogram_aggregates >> done
             clients_scalar_aggregates >> done
         else:
+            clients_histogram_aggregates_init >> clients_histogram_aggregates
             # stage 2 - downstream for export
             scalar_bucket_counts = query(task_name=f"{product}__scalar_bucket_counts_v1")
             scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -147,10 +147,10 @@ with DAG(
         clients_histogram_aggregates_init = init(
             task_name=f"{product}__clients_histogram_aggregates_v1"
         )
-        clients_histogram_aggregates_snapshot_init = init(
-            task_name=f"{product}__clients_histogram_aggregates_snapshot_v1"
-        )
         if is_release:
+            clients_histogram_aggregates_snapshot_init = init(
+                task_name=f"{product}__clients_histogram_aggregates_snapshot_v1"
+            )
             with TaskGroup(
                 group_id=f"{product}__clients_histogram_aggregates_v1", dag=dag, default_args=default_args
             ) as clients_histogram_aggregates:
@@ -200,14 +200,15 @@ with DAG(
             >> clients_histogram_aggregates_new_init
             >> clients_histogram_aggregates_new
             >> clients_histogram_aggregates_init
-            >> clients_histogram_aggregates_snapshot_init
-            >> clients_histogram_aggregates
         )
 
         if is_release:
+            clients_histogram_aggregates_init >> clients_histogram_aggregates_snapshot_init
+            clients_histogram_aggregates_snapshot_init >> clients_histogram_aggregates
             clients_histogram_aggregates >> daily_release_done
             clients_scalar_aggregates >> daily_release_done
         else:
+            clients_histogram_aggregates_init >> clients_histogram_aggregates
             # stage 2 - downstream for export
             scalar_bucket_counts = query(task_name=f"{product}__scalar_bucket_counts_v1")
             scalar_probe_counts = query(task_name=f"{product}__scalar_probe_counts_v1")

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -147,9 +147,33 @@ with DAG(
         clients_histogram_aggregates_init = init(
             task_name=f"{product}__clients_histogram_aggregates_v1"
         )
-        clients_histogram_aggregates = query(
-            task_name=f"{product}__clients_histogram_aggregates_v1"
+        clients_histogram_aggregates_snapshot_init = init(
+            task_name=f"{product}__clients_histogram_aggregates_snapshot_v1"
         )
+        if is_release:
+            with TaskGroup(
+                group_id=f"{product}__clients_histogram_aggregates_v1", dag=dag, default_args=default_args
+            ) as clients_histogram_aggregates:
+                prev_task = None
+                for sample_range in (
+                    [0, 2], [3, 5], [6, 9], [10, 49], [50, 99]
+                ):
+                    clients_histogram_aggregates_sampled = query(
+                        task_name=(
+                            f"{product}__clients_histogram_aggregates_v1_sampled_"
+                            f"{sample_range[0]}_{sample_range[1]}"
+                        ),
+                        min_sample_id=sample_range[0],
+                        max_sample_id=sample_range[1],
+                        replace_table=(sample_range[0] == 0)
+                    )
+                    if prev_task:
+                        clients_histogram_aggregates_sampled.set_upstream(prev_task)
+                    prev_task = clients_histogram_aggregates_sampled
+        else:
+            clients_histogram_aggregates = query(
+                task_name=f"{product}__clients_histogram_aggregates_v1"
+            )
 
         # set all of the dependencies for all of the tasks
 
@@ -176,6 +200,7 @@ with DAG(
             >> clients_histogram_aggregates_new_init
             >> clients_histogram_aggregates_new
             >> clients_histogram_aggregates_init
+            >> clients_histogram_aggregates_snapshot_init
             >> clients_histogram_aggregates
         )
 


### PR DESCRIPTION
## Description

GLAM ETL will take a snapshot of `clients_histogram_aggregates` to read from in release, instead of updating the table "in place".
This allows us to split the job into tasks that process a chunk of samples each time with the first job overwriting the destination table and the subsequent ones appending to it.
Will be merged with https://github.com/mozilla/bigquery-etl/pull/7775

## Related Tickets & Documents
* DENG-9113

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
