### PR TITLE
fix(glam_fenix): fix external_task_id

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -169,7 +169,7 @@ with DAG(
         if is_release:
             histogram_wait_for_yesterdays_aggregates = (
                 histogram_wait_for_yesterdays_aggregates_partial(
-                    external_task_id="daily_release_done",
+                    external_task_id="org_mozilla_fenix_glam_release_done}",
                 )
             )
             clients_histogram_aggregates_snapshot_init = init(


### PR DESCRIPTION
## Description

Fixes the `external_task_id` for a TaskSensor

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
