### PR TITLE
[DISCO-3633] merino: add polygon image ingestion job

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -86,6 +86,13 @@ elasticsearch_prod_apikey_secret = Secret(
     key="merino_elasticsearch_secret__prod_api_key",
 )
 
+polygon_prod_apikey_secret = Secret(
+    deploy_type="env",
+    deploy_target="MERINO_POLYGON__API_KEY",
+    secret="airflow-gke-secrets",
+    key="merino_polygon_secret__prod_api_key",
+)
+
 # Run weekly on Tuesdays at 5am UTC
 with DAG(
     "merino_jobs",
@@ -220,6 +227,6 @@ with DAG(
             "polygon-ingestion",
             "ingest",
         ],
-        secrets=[], #TODO - populate with polygon secret
+        secrets=[polygon_prod_apikey_secret],
     )
 

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -212,3 +212,14 @@ with DAG(
     )
 
     [prepare_domain_metadata_stage, prepare_domain_metadata_prod] >> on_domain_success
+
+    # polygon image ingestion task
+    polygon_ingestion_prod = merino_job(
+        name="polygon_ingestion_prod",
+        arguments=[
+            "polygon-ingestion",
+            "ingest",
+        ],
+        secrets=[], #TODO - populate with polygon secret
+    )
+


### PR DESCRIPTION
## Description
This PR adds the Polygon image ingestion pipeline to the `merino_jobs` Airflow DAG. This schedules the ingestion task weekly to download ticker logos, upload them to GCS, and generate a finance manifest.

## Related Tickets & Documents
[DISCO-3633](https://mozilla-hub.atlassian.net/browse/DISCO-3633)

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[DISCO-3633]: https://mozilla-hub.atlassian.net/browse/DISCO-3633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ