### PR TITLE
Fix ff public data report url

### DIFF
--- a/dags/bugzilla.py
+++ b/dags/bugzilla.py
@@ -1,0 +1,93 @@
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.models import Variable
+from datetime import datetime, timedelta
+import requests
+import time
+import logging
+
+from utils.tags import Tag
+
+docs = """
+### Bugzilla
+Runs daily scheduled jobs on Bugzilla.
+Tags bugs in Bugzilla for the product "Data Platform and Tools" and component "General"
+with the whiteboard tag `[dataplatform]` if not already present. This will trigger a sync to Jira.
+
+#### Owner
+ascholtz@mozilla.com
+"""
+
+tags = [Tag.ImpactTier.tier_3]
+
+BUGZILLA_URL = "https://bugzilla.mozilla.org/rest"
+PRODUCT = "Data Platform and Tools"
+COMPONENT = "General"
+WHITEBOARD_TAG = "[dataplatform]"
+API_KEY_VAR = "BUGZILLA_API_KEY"
+
+default_args = {
+    "retries": 1,
+    "retry_delay": timedelta(minutes=30),
+    "owner": "ascholtz@mozilla.com",
+    "email": [
+        "telemetry-alerts@mozilla.com",
+        "ascholtz@mozilla.com",
+    ],
+    "depends_on_past": False,
+    "start_date": datetime(2025, 8, 3),
+    "email_on_failure": True,
+    "email_on_retry": True,
+}
+
+with DAG(
+    "bugzilla",
+    default_args=default_args,
+    schedule_interval="@daily",
+    tags=tags,
+    doc_md=docs,
+) as dag:
+
+    def fetch_and_tag_bugs():
+        api_key = Variable.get(API_KEY_VAR)
+
+        def get_bugs():
+            params = {
+                "product": PRODUCT,
+                "component": COMPONENT,
+                "include_fields": "id,whiteboard",
+                "status": ["NEW", "ASSIGNED", "REOPENED"],
+                "limit": 500,
+            }
+            response = requests.get(f"{BUGZILLA_URL}/bug", params=params)
+            response.raise_for_status()
+            return response.json()["bugs"]
+
+        def update_whiteboard(bug_id, new_whiteboard):
+            payload = {"whiteboard": new_whiteboard, "api_key": api_key}
+            response = requests.put(f"{BUGZILLA_URL}/bug/{bug_id}", data=payload)
+            if response.status_code == 200:
+                logging.info(f"✔ Bug {bug_id} updated successfully.")
+            else:
+                logging.error(f"✖ Failed to update bug {bug_id}: {response.text}")
+
+        bugs = get_bugs()
+        logging.info(f"Found {len(bugs)} bugs in {PRODUCT} > {COMPONENT}")
+
+        for bug in bugs:
+            bug_id = bug["id"]
+            whiteboard = bug.get("whiteboard", "")
+
+            if whiteboard.strip() == "":
+                new_whiteboard = (whiteboard + " " + WHITEBOARD_TAG).strip()
+                logging.info(
+                    f"Updating bug {bug_id} with new whiteboard: {new_whiteboard}"
+                )
+                update_whiteboard(bug_id, new_whiteboard)
+                time.sleep(0.5)
+            else:
+                logging.info(f"Skipping bug {bug_id}: already tagged.")
+
+    tag_bugs_task = PythonOperator(
+        task_id="tag_bugs_with_dataplatform", python_callable=fetch_and_tag_bugs
+    )

--- a/dags/bugzilla.py
+++ b/dags/bugzilla.py
@@ -24,7 +24,7 @@ BUGZILLA_URL = "https://bugzilla.mozilla.org/rest"
 PRODUCT = "Data Platform and Tools"
 COMPONENT = "General"
 WHITEBOARD_TAG = "[dataplatform]"
-API_KEY_VAR = "BUGZILLA_API_KEY"
+API_KEY_VAR = "bugzilla_probe_expiry_bot_api_key"
 
 default_args = {
     "retries": 1,

--- a/dags/bugzilla.py
+++ b/dags/bugzilla.py
@@ -12,7 +12,7 @@ docs = """
 ### Bugzilla
 Runs daily scheduled jobs on Bugzilla.
 Tags bugs in Bugzilla for the product "Data Platform and Tools" and component "General"
-with the whiteboard tag `[dataplatform]` if not already present. This will trigger a sync to Jira.
+with the whiteboard tag `[dataplatform]` if do not already have a tag. This will trigger a sync to Jira.
 
 #### Owner
 ascholtz@mozilla.com

--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -69,7 +69,7 @@ hardware_report_query = bigquery_etl_query(
 hardware_report_export = GKEPodOperator(
     task_id="hardware_report_export",
     name="hardware_report_export",
-    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",
@@ -114,7 +114,7 @@ user_activity = bigquery_etl_query(
 user_activity_usage_behavior_export = GKEPodOperator(
     task_id="user_activity_export",
     name="user_activity_export",
-    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",
@@ -133,7 +133,7 @@ user_activity_usage_behavior_export = GKEPodOperator(
 annotations_export = GKEPodOperator(
     task_id="annotations_export",
     name="annotations_export",
-    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",

--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -69,7 +69,7 @@ hardware_report_query = bigquery_etl_query(
 hardware_report_export = GKEPodOperator(
     task_id="hardware_report_export",
     name="hardware_report_export",
-    image="gcr.io/moz-fx-data-airflow-prod-88e0/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",
@@ -114,7 +114,7 @@ user_activity = bigquery_etl_query(
 user_activity_usage_behavior_export = GKEPodOperator(
     task_id="user_activity_export",
     name="user_activity_export",
-    image="gcr.io/moz-fx-data-airflow-prod-88e0/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",
@@ -133,7 +133,7 @@ user_activity_usage_behavior_export = GKEPodOperator(
 annotations_export = GKEPodOperator(
     task_id="annotations_export",
     name="annotations_export",
-    image="gcr.io/moz-fx-data-airflow-prod-88e0/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -86,6 +86,13 @@ elasticsearch_prod_apikey_secret = Secret(
     key="merino_elasticsearch_secret__prod_api_key",
 )
 
+polygon_prod_apikey_secret = Secret(
+    deploy_type="env",
+    deploy_target="MERINO_POLYGON__API_KEY",
+    secret="airflow-gke-secrets",
+    key="merino_polygon_secret__prod_api_key",
+)
+
 # Run weekly on Tuesdays at 5am UTC
 with DAG(
     "merino_jobs",
@@ -212,3 +219,14 @@ with DAG(
     )
 
     [prepare_domain_metadata_stage, prepare_domain_metadata_prod] >> on_domain_success
+
+    # polygon image ingestion task
+    polygon_ingestion_prod = merino_job(
+        name="polygon_ingestion_prod",
+        arguments=[
+            "polygon-ingestion",
+            "ingest",
+        ],
+        secrets=[polygon_prod_apikey_secret],
+    )
+


### PR DESCRIPTION
## Description
See also https://github.com/mozilla/firefox-public-data-report-etl/pull/36

The URL of the docker image has changed

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
