### PR TITLE
chore(firefox_public_data_report): update docker URL

### DIFF
--- a/dags/firefox_public_data_report.py
+++ b/dags/firefox_public_data_report.py
@@ -69,7 +69,7 @@ hardware_report_query = bigquery_etl_query(
 hardware_report_export = GKEPodOperator(
     task_id="hardware_report_export",
     name="hardware_report_export",
-    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",
@@ -114,7 +114,7 @@ user_activity = bigquery_etl_query(
 user_activity_usage_behavior_export = GKEPodOperator(
     task_id="user_activity_export",
     name="user_activity_export",
-    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",
@@ -133,7 +133,7 @@ user_activity_usage_behavior_export = GKEPodOperator(
 annotations_export = GKEPodOperator(
     task_id="annotations_export",
     name="annotations_export",
-    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest",
+    image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest",
     arguments=[
         "-m",
         "public_data_report.cli",


### PR DESCRIPTION
## Description

See also https://github.com/mozilla/firefox-public-data-report-etl/pull/36

The URL of the docker image has changed

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
