### PR TITLE
fix: Rebuild `requirements.txt` to fix dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ asyncpg==0.30.0
 atlassian-python-api==3.41.19
 attrs==25.1.0
 authlib==1.3.1
-avro==1.11.3
+avro==1.12.0
 avro-gen3==0.7.16
 babel==2.17.0
 backoff==2.2.1
@@ -53,7 +53,7 @@ billiard==4.2.1
 blinker==1.9.0
 boto3==1.36.3
 botocore==1.36.3
-cached-property==1.5.2
+cached-property==2.0.1
 cachelib==0.9.0
 cachetools==5.5.1
 cattrs==24.1.2
@@ -85,7 +85,7 @@ docker==7.1.0
 docstring-parser==0.16
 email-validator==2.2.0
 eventlet==0.39.0
-expandvars==0.12.0
+expandvars==1.1.1
 flask==2.2.5
 flask-appbuilder==4.5.2
 flask-babel==2.0.0
@@ -158,7 +158,7 @@ google-crc32c==1.6.0
 google-re2==1.1.20240702
 google-resumable-media==2.7.2
 googleapis-common-protos==1.66.0
-gql==3.5.0
+gql==4.0.0
 graphql-core==3.2.6
 greenlet==3.1.1
 grpc-google-iam-v1==0.14.0
@@ -205,7 +205,7 @@ marshmallow-sqlalchemy==0.28.2
 mdit-py-plugins==0.4.2
 mdurl==0.1.2
 methodtools==0.4.7
-mixpanel==4.10.1
+mixpanel==4.10.0
 more-itertools==10.6.0
 multidict==6.1.0
 mypy-extensions==1.0.0
@@ -233,7 +233,7 @@ pendulum==3.0.0
 pluggy==1.5.0
 ply==3.11
 prison==0.2.1
-progressbar2==4.4.2
+progressbar2==4.5.0
 prometheus-client==0.21.1
 prompt-toolkit==3.0.50
 propcache==0.2.1
@@ -257,7 +257,7 @@ python-daemon==3.1.2
 python-dateutil==2.9.0.post0
 python-nvd3==0.16.0
 python-slugify==8.0.4
-python-utils==3.8.2
+python-utils==3.9.1
 python3-saml==1.16.0
 pytz==2025.1
 pyyaml==6.0.2
@@ -273,8 +273,8 @@ rich==13.9.4
 rich-argparse==1.6.0
 rpds-py==0.22.3
 rsa==4.9
-ruamel-yaml==0.18.6
-ruamel-yaml-clib==0.2.8
+ruamel-yaml==0.18.15
+ruamel-yaml-clib==0.2.12
 s3transfer==0.11.2
 scramp==1.4.5
 sentry-sdk==2.20.0


### PR DESCRIPTION
## Description
In particular, `pip-compile` now picks `mixpanel` v4.10.0 rather than v4.10.1, because v4.10.1 has apparently had its requirements retroactively changed to specify `requests>=2.32.5` which conflicts with Airflow's own `requests==2.32.3` requirement.

## Related Tickets & Documents
* [#data-platform-infra-wg Slack thread](https://mozilla.slack.com/archives/C01E8GDG80N/p1756144798488429)
