### PR TITLE
fix(dags): Use column_name_character_map V1 in peopleteam_monthly.

### DIFF
--- a/dags/peopleteam_monthly.py
+++ b/dags/peopleteam_monthly.py
@@ -99,7 +99,7 @@ for report_name in ["hires", "terminations", "promotions", "headcount"]:
         cmds=[
             "bash",
             "-c",
-            "bq load --location=US --source_format CSV --autodetect --skip_leading_rows=1 --replace moz-fx-data-bq-people:composer_workday_staging."
+            "bq load --location=US --source_format CSV --autodetect --column_name_character_map=V1 --skip_leading_rows=1 --replace moz-fx-data-bq-people:composer_workday_staging."
             + report_name
             + " gs://"
             + INCOMING_BUCKET


### PR DESCRIPTION
## Description
BigQuery introduced `ColumnNameCharacterMap` ([ref](https://cloud.google.com/bigquery/docs/release-notes#June_24_2024)). This enables flexible column names by default which stopped converting `_-_` to `___` in BigQuery. This broke the merge queries because they expect `___` in the column names. This uses [load options](https://cloud.google.com/bigquery/docs/reference/standard-sql/load-statements#load_option_list) with `column_name_character_map=V1` to keep replacing `_-_` with `___` in the column names.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* https://github.com/mozilla/telemetry-airflow/pull/2245

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
