### PR TITLE
fix(dags): Peopleintegration use airflow gke connection id.

### DIFF
--- a/dags/peopleintegration_workday_report.py
+++ b/dags/peopleintegration_workday_report.py
@@ -99,6 +99,7 @@ WHERE
 
 upload_to_bucket = bigquery.BigQueryInsertJobOperator(
     task_id="upload-to-bucket",
+    gcp_conn_id="google_cloud_airflow_gke",
     configuration={
         "query": {
             "query": WORKER_TO_TA_QUERY,
@@ -110,6 +111,7 @@ upload_to_bucket = bigquery.BigQueryInsertJobOperator(
 
 transfer_to_tripactions = gcs_to_sftp.GCSToSFTPOperator(
     task_id="workday-to-tripaction",
+    gcp_conn_id="google_cloud_airflow_gke",
     sftp_conn_id="tripactions_sftp",
     source_bucket=BUCKET,
     source_object=GCS_OBJECT,


### PR DESCRIPTION
## Description
Use the right service account for GCS.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* https://github.com/mozilla/telemetry-airflow/pull/2247

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
