### PR TITLE
fix(dags): Peopleintegration use airflow shared prod connection id.

### DIFF
--- a/dags/peopleintegration_workday_report.py
+++ b/dags/peopleintegration_workday_report.py
@@ -99,7 +99,7 @@ WHERE
 
 upload_to_bucket = bigquery.BigQueryInsertJobOperator(
     task_id="upload-to-bucket",
-    gcp_conn_id="google_cloud_airflow_gke",
+    gcp_conn_id="google_cloud_shared_prod",
     configuration={
         "query": {
             "query": WORKER_TO_TA_QUERY,
@@ -111,7 +111,7 @@ upload_to_bucket = bigquery.BigQueryInsertJobOperator(
 
 transfer_to_tripactions = gcs_to_sftp.GCSToSFTPOperator(
     task_id="workday-to-tripaction",
-    gcp_conn_id="google_cloud_airflow_gke",
+    gcp_conn_id="google_cloud_shared_prod",
     sftp_conn_id="tripactions_sftp",
     source_bucket=BUCKET,
     source_object=GCS_OBJECT,


### PR DESCRIPTION
## Description
Use the right service account for GCS. See related cloudops-infra PR for tf code granting the correct role to the shared-prod service account.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* https://github.com/mozilla/telemetry-airflow/pull/2247
* https://github.com/mozilla-services/cloudops-infra/pull/6557/commits/9d0452409ef73f60121c817ec8698e4e743c33e6

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
