### PR TITLE
fix: Replace broken https://go.corp.mozilla.com/wtmodev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ You'll likely want to toggle the DAG back to "Off" as soon as your desired task 
 
 #### Testing GKE Jobs (including BigQuery-etl changes)
 
-See https://go.corp.mozilla.com/wtmodev for more details.
+See https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922811/WTMO+Developer+Guide for more details.
 
 ```
 make build && make up

--- a/bin/start_gke
+++ b/bin/start_gke
@@ -50,4 +50,4 @@ else
            --conn-extra "$JSON_CREDS"
 fi
 
-echo "visit https://go.corp.mozilla.com/wtmodev for more info"
+echo "visit https://mozilla-hub.atlassian.net/wiki/spaces/SRE/pages/27922811/WTMO+Developer+Guide for more info"


### PR DESCRIPTION
## Description
https://go.corp.mozilla.com/ is being decommissioned and no longer works ([SVCSE-3140](https://mozilla-hub.atlassian.net/browse/SVCSE-3140)).

## Related Tickets & Documents
* [SVCSE-3140](https://mozilla-hub.atlassian.net/browse/SVCSE-3140): Delete gourl service


[SVCSE-3140]: https://mozilla-hub.atlassian.net/browse/SVCSE-3140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SVCSE-3140]: https://mozilla-hub.atlassian.net/browse/SVCSE-3140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ