### PR TITLE
fix(bhr): Lower sample rate for bhr-collection-child

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -80,8 +80,8 @@ with DAG(
         },
         "additional_properties": {
             "spark:spark.jars": "gs://spark-lib/bigquery/spark-bigquery-latest_2.12.jar",
-            "spark:spark.driver.memory": "30g",
-            "spark:spark.executor.memory": "20g",
+            "spark:spark.driver.memory": "40g",
+            "spark:spark.executor.memory": "21g",
         },
         "idle_delete_ttl": 14400,
         # supported machine types depends on dataproc image version:
@@ -129,7 +129,7 @@ with DAG(
                 "--date",
                 "{{ ds }}",
                 "--sample-size",
-                "0.08",  # there are usually 12-15x more hangs in the child process than main
+                "0.06",  # there are usually 17x more hangs in the child process than main
                 "--use_gcs",
                 "--thread-filter",
                 "Gecko_Child",


### PR DESCRIPTION
## Description

Job is running out of memory again so lowering the sample rate by 25% to see if it works without adding more workers.  Also increasing the configured memory by a bit which I think will be just below the limit based on https://github.com/mozilla/telemetry-airflow/pull/2003

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=1989352

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
