### PR TITLE
[DISCO-3716] merino: add flightaware schedules job

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -93,6 +93,13 @@ polygon_prod_apikey_secret = Secret(
     key="merino_polygon_secret__prod_api_key",
 )
 
+flightaware_prod_apikey_secret = Secret(
+    deploy_type="env",
+    deploy_target="MERINO_FLIGHTAWARE__API_KEY",
+    secret="airflow-gke-secrets",
+    key="merino_flightaware_secret__prod_api_key",
+)
+
 # Run weekly on Tuesdays at 5am UTC
 with DAG(
     "merino_jobs",
@@ -228,5 +235,18 @@ with DAG(
             "ingest",
         ],
         secrets=[polygon_prod_apikey_secret],
+    )
+
+with DAG(
+    "merino_flightaware_schedules",
+    schedule_interval="0 */6 * * *",  # every 6 hours
+    doc_md=DOCS,
+    default_args=default_args,
+    tags=tags,
+) as dag:
+    schedules_job = merino_job(
+        name="fetch_flightaware_schedules_prod",
+        arguments=["fetch_flights", "fetch-and-store"],
+        secrets=[flightaware_prod_apikey_secret],
     )
 


### PR DESCRIPTION
## Description
This PR adds the FlightAware fetch schedules pipeline to the merino_jobs Airflow DAG. This schedules the fetch and store task every 6 hours to accumulate a cache of flight numbers for the flightaware integration.


## Related Tickets & Documents
* [DISCO-3716](https://mozilla-hub.atlassian.net/browse/DISCO-3716)

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[DISCO-3716]: https://mozilla-hub.atlassian.net/browse/DISCO-3716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ