### PR TITLE
fix(shredder): Create new task to force no dml on some tables

### DIFF
--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -191,6 +191,8 @@ with_sampling = GKEPodOperator(
     **common_task_args,
 )
 
+# the following tables will be shredded per-partition with a join query instead of a delete
+# this is for tables that are small but can be much more efficiently shredded per-partition
 force_no_dml = GKEPodOperator(
     task_id="force-no-dml",
     name="shredder-force-no-dml",

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -130,11 +130,16 @@ flat_rate = GKEPodOperator(
         "--parallelism={{ var.value.get('shredder_all_parallelism', 3) }}",
         "--billing-project=moz-fx-data-bq-batch-prod",
         "--except",
+        # main
         "telemetry_stable.main_v5",
         "telemetry_stable.main_use_counter_v4",
+        # sampling
         "telemetry_derived.event_events_v1",
         "firefox_desktop_derived.events_stream_v1",
         "firefox_desktop_stable.metrics_v1",
+        # force no dml
+        "telemetry_derived.cohort_weekly_active_clients_staging_v1",
+        "glean_telemetry_derived.cohort_weekly_active_clients_staging_v1",
     ],
     container_resources=k8s.V1ResourceRequirements(
         requests={"memory": "3072Mi"},
@@ -183,5 +188,20 @@ with_sampling = GKEPodOperator(
     container_resources=k8s.V1ResourceRequirements(
         requests={"memory": "512Mi"},
     ),
+    **common_task_args,
+)
+
+force_no_dml = GKEPodOperator(
+    task_id="force-no-dml",
+    name="shredder-force-no-dml",
+    arguments=[
+        *base_command,
+        "--parallelism=1",
+        "--billing-project=moz-fx-data-bq-batch-prod",
+        "--max-single-dml-bytes=1",
+        "--only",
+        "telemetry_derived.cohort_weekly_active_clients_staging_v1",
+        "glean_telemetry_derived.cohort_weekly_active_clients_staging_v1",
+    ],
     **common_task_args,
 )


### PR DESCRIPTION
## Description

Details in DENG-9795.  The full delete statement is timing out after 6 hours and costing a lot.  Running them per partition makes it a lot more efficient so this creates a new task with `--max-single-dml-bytes=1`.  It's possible that setting a lower byte limit for the shredder-all will have improvements across the board but I haven't taken the time to test that.

## Related Tickets & Documents
* DENG-9795

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
