### PR TITLE
fix(artifact_deployment): continue view deploy if tables fail

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -33,6 +33,7 @@ found at the start of the logs in Airflow, e.g. `INFO - Found matching pod publi
 To find logs for specific datasets/views, add a string to search for to the end of the query.
 """
 
+import textwrap
 from datetime import datetime, timedelta
 
 from airflow import DAG
@@ -162,23 +163,25 @@ with DAG(
         execution_timeout=timedelta(hours=6),
         arguments=[
             generate_sql_cmd_template
-            + """
-script/bqetl generate derived_view_schemas --use-cloud-function=false &&
-set +e;
-failed=0;
-script/bqetl query initialize '*' --file=materialized_view.sql --skip_existing --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-data-bq-people || failed=1;
-script/bqetl deploy '*' --tables --views --use-cloud-function=false --table-skip-existing-schemas --table-force --ignore-dryrun-skip --view-add-managed-label --view-skip-authorized --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-glam-prod --project-id=moz-fx-data-bq-people || failed=1;
-script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod --target-project=mozdata --user-facing-only &&
-script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod &&
-script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments &&
-script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod &&
-script/bqetl view clean --skip-authorized --target-project=moz-fx-glam-prod --project-id=moz-fx-glam-prod &&
-script/bqetl view clean --skip-authorized --target-project=mozdata --user-facing-only &&
-script/bqetl view clean --skip-authorized --target-project=moz-fx-data-bq-people --project-id=moz-fx-data-bq-people &&
-script/publish_public_data_views --target-project=moz-fx-data-shared-prod &&
-script/publish_public_data_views --target-project=mozdata || failed=1;
-exit $failed
-            """
+            + textwrap.dedent(
+                """
+                script/bqetl generate derived_view_schemas --use-cloud-function=false &&
+                set +e;
+                failed=0;
+                script/bqetl query initialize '*' --file=materialized_view.sql --skip_existing --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-data-bq-people || failed=1;
+                script/bqetl deploy '*' --tables --views --use-cloud-function=false --table-skip-existing-schemas --table-force --ignore-dryrun-skip --view-add-managed-label --view-skip-authorized --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-glam-prod --project-id=moz-fx-data-bq-people || failed=1;
+                script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod --target-project=mozdata --user-facing-only &&
+                script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod &&
+                script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments &&
+                script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod &&
+                script/bqetl view clean --skip-authorized --target-project=moz-fx-glam-prod --project-id=moz-fx-glam-prod &&
+                script/bqetl view clean --skip-authorized --target-project=mozdata --user-facing-only &&
+                script/bqetl view clean --skip-authorized --target-project=moz-fx-data-bq-people --project-id=moz-fx-data-bq-people &&
+                script/publish_public_data_views --target-project=moz-fx-data-shared-prod &&
+                script/publish_public_data_views --target-project=mozdata || failed=1;
+                exit $failed
+                """
+            )
         ],
         image=docker_image,
         container_resources=generate_sql_container_resources,

--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -162,18 +162,23 @@ with DAG(
         execution_timeout=timedelta(hours=6),
         arguments=[
             generate_sql_cmd_template
-            + "script/bqetl generate derived_view_schemas --use-cloud-function=false && "
-            + "script/bqetl query initialize '*' --file=materialized_view.sql --skip_existing --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-data-bq-people && "
-            + "script/bqetl deploy '*' --tables --views --use-cloud-function=false --table-skip-existing-schemas --table-force --ignore-dryrun-skip --view-add-managed-label --view-skip-authorized --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-glam-prod --project-id=moz-fx-data-bq-people && "
-            "script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod --target-project=mozdata --user-facing-only && "
-            "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod && "
-            "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments && "
-            "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod && "
-            "script/bqetl view clean --skip-authorized --target-project=moz-fx-glam-prod --project-id=moz-fx-glam-prod && "
-            "script/bqetl view clean --skip-authorized --target-project=mozdata --user-facing-only && "
-            "script/bqetl view clean --skip-authorized --target-project=moz-fx-data-bq-people --project-id=moz-fx-data-bq-people && "
-            "script/publish_public_data_views --target-project=moz-fx-data-shared-prod && "
-            "script/publish_public_data_views --target-project=mozdata"
+            + """
+script/bqetl generate derived_view_schemas --use-cloud-function=false &&
+set +e;
+failed=0;
+script/bqetl query initialize '*' --file=materialized_view.sql --skip_existing --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-data-bq-people || failed=1;
+script/bqetl deploy '*' --tables --views --use-cloud-function=false --table-skip-existing-schemas --table-force --ignore-dryrun-skip --view-add-managed-label --view-skip-authorized --project-id=moz-fx-data-shared-prod --project-id=moz-fx-data-experiments --project-id=moz-fx-data-marketing-prod --project-id=moz-fx-glam-prod --project-id=moz-fx-data-bq-people || failed=1;
+script/bqetl view publish --add-managed-label --skip-authorized --project-id=moz-fx-data-shared-prod --target-project=mozdata --user-facing-only &&
+script/bqetl view clean --skip-authorized --target-project=moz-fx-data-shared-prod &&
+script/bqetl view clean --skip-authorized --target-project=moz-fx-data-experiments --project-id=moz-fx-data-experiments &&
+script/bqetl view clean --skip-authorized --target-project=moz-fx-data-marketing-prod --project-id=moz-fx-data-marketing-prod &&
+script/bqetl view clean --skip-authorized --target-project=moz-fx-glam-prod --project-id=moz-fx-glam-prod &&
+script/bqetl view clean --skip-authorized --target-project=mozdata --user-facing-only &&
+script/bqetl view clean --skip-authorized --target-project=moz-fx-data-bq-people --project-id=moz-fx-data-bq-people &&
+script/publish_public_data_views --target-project=moz-fx-data-shared-prod &&
+script/publish_public_data_views --target-project=mozdata || failed=1;
+exit $failed
+            """
         ],
         image=docker_image,
         container_resources=generate_sql_container_resources,


### PR DESCRIPTION
## Description

This separates materialized view, table, and view deploys with `;` so the following commands run if any of them fail. This matches the previous behaviour of the publish_views task which had `trigger_rule=TriggerRule.ALL_DONE`

mozdata views currently don't get deployed if there are table deploy errors.

[verified in dev](https://dev.telemetry-airflow.nonprod.dataservices.mozgcp.net/log?dag_id=bqetl_artifact_deployment&task_id=publish_tables_and_views&execution_date=2026-04-06T17%3A46%3A38.869514%2B00%3A00) that the bash is valid