### PR TITLE
fix(adm_exports): use execution date without offset

### DIFF
--- a/dags/adm_dma_export.py
+++ b/dags/adm_dma_export.py
@@ -69,9 +69,8 @@ with DAG(
             "SRC_TABLE": "moz-fx-data-shared-prod.search_terms_derived.adm_daily_dma_aggregates_v1",
             # The run for submission_date=2022-03-04 will be named:
             # Aggregated-DMA-Query-Data-03042022.csv.gz
-            "DST_PATH": 'files/Aggregated-DMA-Query-Data-{{ macros.ds_format(macros.ds_add(ds, -1), "%Y-%m-%d", "%m%d%Y") }}.csv.gz',
-            # Subtract 1 day from execution date to match the upstream date_partition_offset: -1
-            "SUBMISSION_DATE": '{{ macros.ds_add(ds, -1) }}',
+            "DST_PATH": 'files/Aggregated-DMA-Query-Data-{{ macros.ds_format(ds, "%Y-%m-%d", "%m%d%Y") }}.csv.gz',
+            "SUBMISSION_DATE": "{{ ds }}",
         },
         secrets=[adm_sftp_secret],
         email=[

--- a/dags/adm_export.py
+++ b/dags/adm_export.py
@@ -68,9 +68,8 @@ with DAG(
             "SRC_TABLE": "moz-fx-data-shared-prod.search_terms_derived.adm_daily_aggregates_v1",
             # The run for submission_date=2022-03-04 will be named:
             # Aggregated-Query-Data-03042022.csv.gz
-            "DST_PATH": 'files/Aggregated-Query-Data-{{ macros.ds_format(macros.ds_add(ds, -1), "%Y-%m-%d", "%m%d%Y") }}.csv.gz',
-            # Subtract 1 day from execution date to match the upstream date_partition_offset: -1
-            "SUBMISSION_DATE": '{{ macros.ds_add(ds, -1) }}',
+            "DST_PATH": 'files/Aggregated-Query-Data-{{ macros.ds_format(ds, "%Y-%m-%d", "%m%d%Y") }}.csv.gz',
+            "SUBMISSION_DATE": "{{ ds }}",
         },
         secrets=[adm_sftp_secret],
         email=[


### PR DESCRIPTION
## Description
This PR reverts the execution date back to what it was previously. See:
- https://github.com/mozilla/telemetry-airflow/pull/2326
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* [AD-1342](https://mozilla-hub.atlassian.net/browse/AD-1342)

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[AD-1342]: https://mozilla-hub.atlassian.net/browse/AD-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ