### PR TITLE
feat: Ensure proper alerts email config for all Airflow DAGs (DENG-9783)

### DIFF
--- a/dags/backfill.py
+++ b/dags/backfill.py
@@ -75,7 +75,7 @@ doc_md = """
     catchup=False,
     start_date=datetime.datetime(2022, 11, 1),
     dagrun_timeout=datetime.timedelta(days=1),
-    tags=[Tag.ImpactTier.tier_3, Tag.Triage.record_only],
+    tags=[Tag.ImpactTier.tier_3, Tag.Triage.no_triage],
     render_template_as_native_obj=True,
     params={
         "dag_name": Param("dag_name", type="string"),

--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -27,6 +27,7 @@ default_args = {
         "ascholtz@mozilla.com",
         "benwu@mozilla.com",
         "wichan@mozilla.com",
+        "telemetry-alerts@mozilla.com",
     ]
 }
 

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -28,6 +28,7 @@ default_args = {
         "ascholtz@mozilla.com",
         "benwu@mozilla.com",
         "wichan@mozilla.com",
+        "telemetry-alerts@mozilla.com",
     ]
 }
 

--- a/dags/broken_site_report_ml.py
+++ b/dags/broken_site_report_ml.py
@@ -30,7 +30,7 @@ kberezina@mozilla.com
 
 default_args = {
     "owner": "kberezina@mozilla.com",
-    "email": ["kberezina@mozilla.com", "webcompat-internal@mozilla.org"],
+    "email": ["kberezina@mozilla.com", "webcompat-internal@mozilla.org", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
     "start_date": datetime(2023, 12, 21),
     "email_on_failure": True,

--- a/dags/catalyst.py
+++ b/dags/catalyst.py
@@ -26,6 +26,7 @@ default_args = {
     "owner": "dpalmeiro@mozilla.com",
     "email": [
         "dpalmeiro@mozilla.com",
+        "telemetry-alerts@mozilla.com",
     ],
     "depends_on_past": False,
     "start_date": datetime(2025, 5, 5),

--- a/dags/contextual_services_import.py
+++ b/dags/contextual_services_import.py
@@ -50,5 +50,6 @@ with DAG(
         email=[
             "cmorales@mozilla.com",
             "ctroy@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
     )

--- a/dags/eam_gmail_panopto_integration.py
+++ b/dags/eam_gmail_panopto_integration.py
@@ -108,7 +108,7 @@ def create_jira_ticket(context):
 
 default_args = {
     "owner": "jmoscon@mozilla.com",
-    "emails": ["jmoscon@mozilla.com"],
+    "email": ["jmoscon@mozilla.com", "telemetry-alerts@mozilla.com"],
     "start_date": datetime.datetime(2024, 1, 1),
     "retries": 3,
     # wait 5 min before retry

--- a/dags/eam_slack_channels.py
+++ b/dags/eam_slack_channels.py
@@ -109,7 +109,7 @@ def create_jira_ticket(context):
 
 default_args = {
     "owner": "jmoscon@mozilla.com",
-    "emails": ["jmoscon@mozilla.com"],
+    "email": ["jmoscon@mozilla.com", "telemetry-alerts@mozilla.com"],
     "start_date": datetime.datetime(2024, 1, 1),
     "retries": 3,
     # wait 5 min before retry

--- a/dags/eam_workday_docusign.py
+++ b/dags/eam_workday_docusign.py
@@ -109,7 +109,7 @@ def create_jira_ticket(context):
 
 default_args = {
     "owner": "jmoscon@mozilla.com",
-    "emails": ["jmoscon@mozilla.com"],
+    "email": ["jmoscon@mozilla.com", "telemetry-alerts@mozilla.com"],
     "start_date": datetime.datetime(2024, 1, 1),
     "retries": 3,
     # wait 5 min before retry

--- a/dags/eam_workday_everfi_integration.py
+++ b/dags/eam_workday_everfi_integration.py
@@ -109,7 +109,7 @@ def create_jira_ticket(context):
 
 default_args = {
     "owner": "jmoscon@mozilla.com",
-    "emails": ["jmoscon@mozilla.com"],
+    "email": ["jmoscon@mozilla.com", "telemetry-alerts@mozilla.com"],
     "start_date": datetime.datetime(2024, 1, 1),
     "retries": 3,
     # wait 5 min before retry

--- a/dags/eam_workday_netsuite.py
+++ b/dags/eam_workday_netsuite.py
@@ -116,7 +116,7 @@ def create_jira_ticket(context):
 
 default_args = {
     "owner": "jmoscon@mozilla.com",
-    "emails": ["jmoscon@mozilla.com"],
+    "email": ["jmoscon@mozilla.com", "telemetry-alerts@mozilla.com"],
     "start_date": datetime(2024, 1, 1),
     "retries": 3,
     # wait 5 min before retry

--- a/dags/experiment_auto_sizing.py
+++ b/dags/experiment_auto_sizing.py
@@ -17,7 +17,7 @@ from utils.tags import Tag
 
 default_args = {
     "owner": "mwilliams@mozilla.com",
-    "email": ["mwilliams@mozilla.com", "ascholtz@mozilla.com"],
+    "email": ["mwilliams@mozilla.com", "ascholtz@mozilla.com", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
     "start_date": datetime(2023, 4, 15),
     "email_on_failure": True,

--- a/dags/experiments_live.py
+++ b/dags/experiments_live.py
@@ -16,6 +16,7 @@ default_args = {
     "owner": "ascholtz@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2021, 1, 8),
+    "email": ["telemetry-alerts@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
 }

--- a/dags/extensions.py
+++ b/dags/extensions.py
@@ -18,7 +18,7 @@ default_args = {
     "owner": "kik@mozilla.com",
     "start_date": datetime.datetime(2025, 4, 13, 0, 0),
     "end_date": None,
-    "email": ["kik@mozilla.com"],
+    "email": ["kik@mozilla.com", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),
     "email_on_failure": True,

--- a/dags/fxci_metric_export.py
+++ b/dags/fxci_metric_export.py
@@ -69,5 +69,6 @@ with DAG(
         dag=dag,
         email=[
             "ahalberstadt@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
     )

--- a/dags/fxci_pulse_export.py
+++ b/dags/fxci_pulse_export.py
@@ -72,5 +72,6 @@ with DAG(
         dag=dag,
         email=[
             "ahalberstadt@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
     )

--- a/dags/jetstream.py
+++ b/dags/jetstream.py
@@ -26,6 +26,7 @@ default_args = {
     "email": [
         "ascholtz@mozilla.com",
         "mwilliams@mozilla.com",
+        "telemetry-alerts@mozilla.com",
     ],
     "depends_on_past": False,
     "start_date": datetime(2020, 3, 12),

--- a/dags/kpi_forecasting.py
+++ b/dags/kpi_forecasting.py
@@ -19,7 +19,7 @@ from utils.tags import Tag
 
 default_args = {
     "owner": "bochocki@mozilla.com",
-    "email": ["bochocki@mozilla.com", "jsilverman@mozilla.com"],
+    "email": ["bochocki@mozilla.com", "jsilverman@mozilla.com", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
     "start_date": datetime(2022, 3, 28),
     "email_on_failure": True,

--- a/dags/looker.py
+++ b/dags/looker.py
@@ -30,6 +30,7 @@ default_args = {
     "owner": "ascholtz@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2024, 5, 21),
+    "email": ["telemetry-alerts@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,

--- a/dags/looker_usage_analysis.py
+++ b/dags/looker_usage_analysis.py
@@ -23,6 +23,7 @@ default_args = {
     "owner": "ascholtz@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2025, 5, 30),
+    "email": ["telemetry-alerts@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,

--- a/dags/mad_server.py
+++ b/dags/mad_server.py
@@ -83,6 +83,7 @@ with DAG(
         email=[
             "dzeber@mozilla.com",
             "gleonard@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
         secrets=[amo_cred_issuer_secret, amo_cred_secret_secret],
     )
@@ -110,6 +111,7 @@ with DAG(
         email=[
             "dzeber@mozilla.com",
             "gleonard@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
     )
     new_data_eval = GKEPodOperator(
@@ -137,6 +139,7 @@ with DAG(
         email=[
             "dzeber@mozilla.com",
             "gleonard@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
     )
 

--- a/dags/operational_monitoring.py
+++ b/dags/operational_monitoring.py
@@ -49,7 +49,7 @@ with DAG(
         task_id="opmon_run",
         name="opmon_run",
         image=opmon_image,
-        email=["ascholtz@mozilla.com"],
+        email=["ascholtz@mozilla.com", "telemetry-alerts@mozilla.com"],
         arguments=[
             "--log_to_bigquery",
             "run",

--- a/dags/partybal.py
+++ b/dags/partybal.py
@@ -30,6 +30,7 @@ default_args = {
     "email": [
         "ascholtz@mozilla.com",
         "mwilliams@mozilla.com",
+        "telemetry-alerts@mozilla.com",
     ],
     "depends_on_past": False,
     "start_date": datetime(2021, 6, 21),
@@ -58,6 +59,7 @@ with DAG(
         email=[
             "ascholtz@mozilla.com",
             "mwilliams@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
         dag=dag,
     )

--- a/dags/play_store_export.py
+++ b/dags/play_store_export.py
@@ -49,5 +49,6 @@ with DAG(
         dag=dag,
         email=[
             "akomar@mozilla.com",
+            "telemetry-alerts@mozilla.com",
         ],
     )

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -60,6 +60,7 @@ default_args = {
     "owner": "akomar@mozilla.com",
     "depends_on_past": False,
     "start_date": datetime(2019, 10, 28),
+    "email": ["telemetry-alerts@mozilla.com"],
     "email_on_failure": True,
     "email_on_retry": True,
     "retries": 2,

--- a/dags/web_scraping.py
+++ b/dags/web_scraping.py
@@ -18,7 +18,7 @@ default_args = {
     "owner": "lmcfall@mozilla.com",
     "start_date": datetime.datetime(2025, 9, 1, 0, 0),
     "end_date": None,
-    "email": ["lmcfall@mozilla.com"],
+    "email": ["lmcfall@mozilla.com", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
     "retry_delay": datetime.timedelta(seconds=1800),
     "email_on_failure": True,

--- a/dags/webcompat_kb.py
+++ b/dags/webcompat_kb.py
@@ -29,7 +29,7 @@ kberezina@mozilla.com
 
 default_args = {
     "owner": "kberezina@mozilla.com",
-    "email": ["kberezina@mozilla.com", "webcompat-internal@mozilla.org"],
+    "email": ["kberezina@mozilla.com", "webcompat-internal@mozilla.org", "telemetry-alerts@mozilla.com"],
     "depends_on_past": False,
     "start_date": datetime(2023, 9, 26),
     "email_on_failure": True,

--- a/tests/dags/test_dag_validity.py
+++ b/tests/dags/test_dag_validity.py
@@ -1,3 +1,9 @@
+from airflow.models import DagBag
+from airflow.operators.empty import EmptyOperator
+
+from utils.tags import Tag
+
+
 def test_dag_validity(get_dag_bag):
     """
     Test all DAGs can be parsed.
@@ -52,3 +58,32 @@ def test_dag_tags_required(get_dag_bag):
         assert [
             tag for tag in dag.tags if required_tag_type in tag
         ], f"DAG: {dag_name}: Missing required tag type `{required_tag_type}`"
+
+
+def test_telemetry_alerts_email(get_dag_bag: DagBag):
+    """Check that telemetry-alerts@mozilla.com is being emailed unless the DAG has a `no_triage` tag."""
+    for dag_name, dag in get_dag_bag.dags.items():
+        if Tag.Triage.no_triage in dag.tags:
+            continue
+
+        default_email = dag.default_args.get("email", [])
+        if default_email:
+            assert "telemetry-alerts@mozilla.com" in default_email, (
+                f'DAG {dag_name}: either telemetry-alerts@mozilla.com should be included in `default_args["email"]`,'
+                f' or a "{Tag.Triage.no_triage}" tag should be added to the DAG.'
+            )
+
+        for task in dag.tasks:
+            if isinstance(task, EmptyOperator):
+                continue
+
+            if task.email:
+                assert "telemetry-alerts@mozilla.com" in task.email, (
+                    f"DAG {dag_name} task {task.task_id}: either telemetry-alerts@mozilla.com should be included in `email`,"
+                    f' or a "{Tag.Triage.no_triage}" tag should be added to the DAG.'
+                )
+            else:
+                assert default_email != [], (
+                    f'DAG {dag_name} task {task.task_id}: either `email` or `default_args["email"]` should be specified and include telemetry-alerts@mozilla.com,'
+                    f' or a "{Tag.Triage.no_triage}" tag should be added to the DAG.'
+                )

--- a/tests/dags/test_dag_validity.py
+++ b/tests/dags/test_dag_validity.py
@@ -62,14 +62,16 @@ def test_dag_tags_required(get_dag_bag):
 
 def test_telemetry_alerts_email(get_dag_bag: DagBag):
     """Check that telemetry-alerts@mozilla.com is being emailed unless the DAG has a `no_triage` tag."""
+    telemetry_alerts_email = "telemetry-alerts@mozilla.com"
+
     for dag_name, dag in get_dag_bag.dags.items():
         if Tag.Triage.no_triage in dag.tags:
             continue
 
         default_email = dag.default_args.get("email", [])
         if default_email:
-            assert "telemetry-alerts@mozilla.com" in default_email, (
-                f'DAG {dag_name}: either telemetry-alerts@mozilla.com should be included in `default_args["email"]`,'
+            assert telemetry_alerts_email in default_email, (
+                f'DAG {dag_name}: either {telemetry_alerts_email} should be included in `default_args["email"]`,'
                 f' or a "{Tag.Triage.no_triage}" tag should be added to the DAG.'
             )
 
@@ -78,12 +80,12 @@ def test_telemetry_alerts_email(get_dag_bag: DagBag):
                 continue
 
             if task.email:
-                assert "telemetry-alerts@mozilla.com" in task.email, (
-                    f"DAG {dag_name} task {task.task_id}: either telemetry-alerts@mozilla.com should be included in `email`,"
+                assert telemetry_alerts_email in task.email, (
+                    f"DAG {dag_name} task {task.task_id}: either {telemetry_alerts_email} should be included in `email`,"
                     f' or a "{Tag.Triage.no_triage}" tag should be added to the DAG.'
                 )
             else:
                 assert default_email != [], (
-                    f'DAG {dag_name} task {task.task_id}: either `email` or `default_args["email"]` should be specified and include telemetry-alerts@mozilla.com,'
+                    f'DAG {dag_name} task {task.task_id}: either `email` or `default_args["email"]` should be specified and include {telemetry_alerts_email},'
                     f' or a "{Tag.Triage.no_triage}" tag should be added to the DAG.'
                 )


### PR DESCRIPTION
## Description
This updates DAGs' email configs so that telemetry-alerts@mozilla.com is sent task failure notifications for all DAGs that haven't been assigned the `triage/no_triage` tag.

CC DAG owners: @ksy36, @dpalmeiro, @curtismorales, @JCMOSCON1976, @mikewilli, @scholtzan, @kik-kik, @ahal, @bochocki, @gleonard-m, @akkomar, @LiamMcFall

DAG owners, if you would rather not have data engineers triaging task failures in your DAGs and filing bugs for those, then please either reply now so I can update the DAG's config appropriately in this PR, or feel free to adjust your DAG configs later to assign them the `triage/no_triage` tag (if you import `Tag` from `utils.tags` you can reference `Tag.Triage.no_triage`) and remove telemetry-alerts@mozilla.com from the DAG's email config.

## Related Tickets & Documents
* DENG-9783: Ensure telemetry-alerts@mozilla.com is receiving Airflow alerts for all appropriate DAGs