### PR TITLE
fix: Limit `copy_deduplicate` to one active run and enable catchup

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -63,6 +63,8 @@ tags = [Tag.ImpactTier.tier_1]
 with models.DAG(
     dag_name,
     schedule_interval="0 1 * * *",
+    max_active_runs=1,
+    catchup=True,
     doc_md=DOCS,
     default_args=default_args,
     tags=tags,


### PR DESCRIPTION
## Description
To recover from a data ingestion incident ([IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153)) we're going to need to rerun `copy_deduplicate` for multiple days, and we don't want more than one run active at a time because they're resource intensive.

## Related Tickets & Documents
* [IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153): Missing Equative Impressions (2026-04-17)

[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ