### PR TITLE
fix: Update external task markers in `copy_deduplicate` DAG

### DIFF
--- a/dags/bhr_collection.py
+++ b/dags/bhr_collection.py
@@ -52,7 +52,7 @@ with DAG(
     tags=tags,
 ) as dag:
     wait_for_bhr_ping = ExternalTaskSensor(
-        task_id="wait_for_copy_deduplicate",
+        task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         execution_delta=datetime.timedelta(hours=4),

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -137,8 +137,9 @@ with models.DAG(
         downstream_dependencies = {
             ("bhr_collection", "hour=5, minute=0"),
             ("dbt_daily", "hour=4, minute=0"),  # only on Sundays
-            ("glam_fenix", "hour=2, minute=0"),
-            ("glam_fog", "hour=2, minute=0"),
+            # TODO: Restore these GLAM task markers once we're done doing backfills for IIM-153.
+            #("glam_fenix", "hour=2, minute=0"),
+            #("glam_fog", "hour=2, minute=0"),
             ("bqetl_accounts_derived", "hour=2, minute=30"),
             ("bqetl_activity_stream", "hour=2, minute=0"),
             ("bqetl_amo_stats", "hour=3, minute=0"),

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -136,35 +136,63 @@ with models.DAG(
         # list of downstream dependencies consisting of external DAG name and execution delta
         downstream_dependencies = {
             ("bhr_collection", "hour=5, minute=0"),
+            ("dbt_daily", "hour=4, minute=0"),  # only on Sundays
             ("glam_fenix", "hour=2, minute=0"),
             ("glam_fog", "hour=2, minute=0"),
+            ("bqetl_accounts_derived", "hour=2, minute=30"),
             ("bqetl_activity_stream", "hour=2, minute=0"),
             ("bqetl_amo_stats", "hour=3, minute=0"),
+            ("bqetl_analytics_aggregations", "hour=4, minute=15"),
+            ("bqetl_analytics_tables", "hour=2, minute=0"),
+            ("bqetl_broken_reports_agg", "hour=6, minute=0"),
+            ("bqetl_client_attributes", "hour=19, minute=40"),
             ("bqetl_core", "hour=2, minute=0"),
+            ("bqetl_crashes", "hour=4, minute=0"),
             ("bqetl_ctxsvc_derived", "hour=3, minute=0"),
+            ("bqetl_default_browser_aggregates", "hour=22, minute=0"),
+            ("bqetl_desktop_engagement_model", "hour=5, minute=0"),
             ("bqetl_desktop_funnel", "hour=4, minute=0"),
+            ("bqetl_desktop_installs_v1", "hour=23, minute=55"),
+            ("bqetl_ech_adoption_rate", "hour=0, minute=0"),
             ("bqetl_event_rollup", "hour=3, minute=0"),
             ("bqetl_experiments_daily", "hour=3, minute=0"),
             ("bqetl_feature_usage", "hour=5, minute=0"),
-            ("bqetl_fenix_event_rollup", "hour=2, minute=0"),
+            ("bqetl_firefox_enterprise", "hour=6, minute=0"),
+            ("bqetl_firefox_installer_aggregates", "hour=15, minute=0"),
             ("bqetl_firefox_ios", "hour=4, minute=0"),
             ("bqetl_fog_decision_support", "hour=4, minute=0"),
+            ("bqetl_fx_health_ind_dashboard", "hour=16, minute=0"),
+            ("bqetl_generated_funnels", "hour=5, minute=0"),
+            ("bqetl_glean_usage", "hour=2, minute=0"),
             ("bqetl_internal_tooling", "hour=4, minute=0"),
             ("bqetl_internet_outages", "hour=7, minute=0"),
-            ("bqetl_messaging_system", "hour=2, minute=0"),
+            ("bqetl_ltv", "hour=0, minute=0"),
             ("bqetl_main_summary", "hour=2, minute=0"),
+            ("bqetl_marketing_analysis", "hour=12, minute=0"),
             ("bqetl_messaging_system", "hour=2, minute=0"),
             ("bqetl_mobile_activation", "hour=0, minute=0"),
+            ("bqetl_mobile_feature_usage", "hour=12, minute=0"),
+            ("bqetl_mobile_kpi_metrics", "hour=12, minute=0"),
             ("bqetl_mobile_search", "hour=2, minute=0"),
             ("bqetl_monitoring", "hour=2, minute=0"),
             ("bqetl_newtab", "hour=0, minute=0"),
+            ("bqetl_nimbus_feature_monitoring", "hour=3, minute=0"),
             ("bqetl_org_mozilla_fenix_derived", "hour=2, minute=0"),
             ("bqetl_org_mozilla_firefox_derived", "hour=2, minute=0"),
             ("bqetl_org_mozilla_focus_derived", "hour=2, minute=0"),
+            ("bqetl_pageload_v1", "hour=0, minute=0"),
+            ("bqetl_pocket", "hour=12, minute=0"),
             ("bqetl_public_data_json", "hour=5, minute=0"),
-            ("bqetl_search_terms_daily", "hour=3, minute=0"),
-            ("bqetl_sponsored_tiles_clients_daily", "hour=4, minute=0"),
+            ("bqetl_review_checker", "hour=0, minute=0"),
+            ("bqetl_rust_component_metrics", "hour=3, minute=0"),
+            ("bqetl_search_dashboard", "hour=5, minute=30"),
+            ("bqetl_search_terms_daily", "hour=8, minute=0"),
+            ("bqetl_serp", "hour=0, minute=0"),
+            ("bqetl_terms_of_use", "hour=6, minute=0"),
             ("bqetl_urlbar", "hour=3, minute=0"),
+            ("bqetl_usage_reporting", "hour=4, minute=0"),
+            ("bqetl_use_counter_analysis", "hour=8, minute=0"),
+            ("private_bqetl_ads", "hour=4, minute=0"),
         }
 
         for downstream_dependency in downstream_dependencies:
@@ -201,19 +229,20 @@ with models.DAG(
 
     with TaskGroup("main_ping_external") as main_ping_external:
         downstream_dependencies = {
+            ("firefox_public_data_report", "hour=1, minute=0"),  # only on Mondays
             ("graphics_telemetry", "hour=3, minute=0"),
-            ("glam", "hour=2, minute=0"),
             ("bqetl_addons", "hour=4, minute=0"),
             ("bqetl_amo_stats", "hour=3, minute=0"),
             ("bqetl_desktop_platform", "hour=3, minute=0"),
             ("bqetl_devtools", "hour=3, minute=0"),
             ("bqetl_experiments_daily", "hour=3, minute=0"),
             ("bqetl_fog_decision_support", "hour=4, minute=0"),
+            ("bqetl_fx_health_ind_dashboard", "hour=16, minute=0"),
             ("bqetl_internet_outages", "hour=7, minute=0"),
             ("bqetl_main_summary", "hour=2, minute=0"),
             ("bqetl_monitoring", "hour=2, minute=0"),
             ("bqetl_public_data_json", "hour=5, minute=0"),
-            ("bqetl_sponsored_tiles_clients_daily", "hour=4, minute=0"),
+            ("bqetl_search", "hour=3, minute=0"),
             ("bqetl_ssl_ratios", "hour=2, minute=0"),
         }
 
@@ -286,10 +315,14 @@ with models.DAG(
 
     with TaskGroup("event_events_external") as event_events_external:
         downstream_dependencies = {
+            ("catalyst", "hour=4, minute=0"),
             ("jetstream", "hour=4, minute=0"),
             ("bqetl_amo_stats", "hour=3, minute=0"),
+            ("bqetl_analytics_aggregations", "hour=4, minute=15"),
             ("bqetl_experiments_daily", "hour=3, minute=0"),
             ("bqetl_feature_usage", "hour=5, minute=0"),
+            ("bqetl_fx_cert_error_privacy_dashboard", "hour=16, minute=40"),
+            ("bqetl_fx_health_ind_dashboard", "hour=16, minute=0"),
             ("bqetl_main_summary", "hour=2, minute=0"),
         }
 
@@ -321,10 +354,14 @@ with models.DAG(
 
     with TaskGroup("bq_main_events_external") as bq_main_events_external:
         downstream_dependencies = {
+            ("catalyst", "hour=4, minute=0"),
             ("jetstream", "hour=4, minute=0"),
             ("bqetl_amo_stats", "hour=3, minute=0"),
+            ("bqetl_analytics_aggregations", "hour=4, minute=15"),
             ("bqetl_experiments_daily", "hour=3, minute=0"),
             ("bqetl_feature_usage", "hour=5, minute=0"),
+            ("bqetl_fx_cert_error_privacy_dashboard", "hour=16, minute=40"),
+            ("bqetl_fx_health_ind_dashboard", "hour=16, minute=0"),
             ("bqetl_main_summary", "hour=2, minute=0"),
         }
 
@@ -366,12 +403,20 @@ with models.DAG(
     with TaskGroup(
         "core_clients_first_seen_external"
     ) as core_clients_first_seen_external:
-        ExternalTaskMarker(
-            task_id="bqetl_core__wait_for_core_clients_first_seen",
-            external_dag_id="bqetl_core",
-            external_task_id="wait_for_telemetry_derived__core_clients_first_seen__v1",
-            execution_date="{{ execution_date.replace(hour=2, minute=0).isoformat() }}",
-        )
+        downstream_dependencies = {
+            ("bqetl_core", "hour=2, minute=0"),
+            ("bqetl_glean_usage", "hour=2, minute=0"),
+        }
+
+        for downstream_dependency in downstream_dependencies:
+            ExternalTaskMarker(
+                task_id=f"{downstream_dependency[0]}__wait_for_core_clients_first_seen",
+                external_dag_id=downstream_dependency[0],
+                external_task_id="wait_for_telemetry_derived__core_clients_first_seen__v1",
+                execution_date="{{ execution_date.replace("
+                + downstream_dependency[1]
+                + ").isoformat() }}",
+            )
 
         (
             telemetry_derived__core_clients_first_seen__v1

--- a/dags/dbt_daily.py
+++ b/dags/dbt_daily.py
@@ -47,7 +47,7 @@ with DAG(
     tags=tags,
 ) as dag:
     wait_for_copy_deduplicate = ExternalTaskSensor(
-        task_id="wait_for_copy_deduplicate",
+        task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         execution_delta=timedelta(hours=3),

--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -80,7 +80,7 @@ with DAG(
     tags=tags,
 ) as dag:
     wait_for_copy_deduplicate = ExternalTaskSensor(
-        task_id="wait_for_copy_deduplicate",
+        task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         execution_delta=timedelta(hours=1),

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -60,7 +60,7 @@ with DAG(
     tags=tags,
 ) as dag:
     wait_for_copy_deduplicate = ExternalTaskSensor(
-        task_id="wait_for_copy_deduplicate",
+        task_id="wait_for_copy_deduplicate_all",
         external_dag_id="copy_deduplicate",
         external_task_id="copy_deduplicate_all",
         execution_delta=timedelta(hours=1),


### PR DESCRIPTION
## Description
The external task markers in `copy_deduplicate` need to be updated to reflect current cross-DAG dependencies.

This is particularly important because we'll soon need to rerun `copy_deduplicate` and all downstream tasks for multiple days ([IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153)).

However, since we don't want to rerun the expensive GLAM ETLs for all of those days I'm including a kludge in this PR to temporarily remove the GLAM task markers from `copy_deduplicate` (which will be restored after the backfills are complete).

## Related Tickets & Documents
* [IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153): Missing Equative Impressions (2026-04-17)

[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ