### PR TITLE
fix: Enable catchup for the `jetstream` DAG

### DIFF
--- a/dags/jetstream.py
+++ b/dags/jetstream.py
@@ -42,6 +42,7 @@ with DAG(
     "jetstream",
     default_args=default_args,
     schedule_interval="0 4 * * *",
+    catchup=True,
     doc_md=__doc__,
     tags=tags,
 ) as dag:


### PR DESCRIPTION
## Description
We may opt to pause the [jetstream](https://workflow.telemetry.mozilla.org/dags/jetstream/grid) DAG (which has been taking upwards of 4 hours) to avoid interfering with ETL reruns for past days to recover from a data incident ([IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153)).

This PR enables catchup for that DAG so that if we do pause it, then any intermediate runs will get queued once it's unpaused.

## Related Tickets & Documents
* [IIM-153](https://mozilla-hub.atlassian.net/browse/IIM-153): Missing Equative Impressions (2026-04-17)

[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IIM-153]: https://mozilla-hub.atlassian.net/browse/IIM-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ