### PR TITLE
fix(glam): enable catchup for glam_fog and glam_fenix

### DIFF
--- a/dags/glam_fenix.py
+++ b/dags/glam_fenix.py
@@ -78,6 +78,7 @@ with DAG(
     schedule_interval="0 2 * * *",
     doc_md=__doc__,
     tags=tags,
+    catchup=True,
 ) as dag:
     wait_for_copy_deduplicate = ExternalTaskSensor(
         task_id="wait_for_copy_deduplicate_all",

--- a/dags/glam_fog.py
+++ b/dags/glam_fog.py
@@ -58,6 +58,7 @@ with DAG(
     max_active_runs=1,
     schedule_interval="0 2 * * *",
     tags=tags,
+    catchup=True,
 ) as dag:
     wait_for_copy_deduplicate = ExternalTaskSensor(
         task_id="wait_for_copy_deduplicate_all",


### PR DESCRIPTION
## Description

Whenever these DAGs are paused then resumed, they need to catch up each missed day, in order.
 
## Related Tickets & Documents

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
