### PR TITLE
[DISCO-4107] merino: add DAG for AMP live dataset access probe

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -325,6 +325,25 @@ with DAG(
     )
 
 
+# AMP live dataset access probe — notifications disabled, run once and re-trigger manually as needed.
+probe_args = {**default_args, "email_on_failure": False, "email_on_retry": False}
+
+with DAG(
+    "merino_amp_live_probe",
+    schedule_interval="@once",
+    doc_md=DOCS,
+    default_args=probe_args,
+    tags=tags,
+) as dag:
+    amp_live_probe_job = merino_job(
+        name="probe_amp_live_access",
+        arguments=[
+            "probe-amp-live-access",
+            "probe-amp-live-access",
+        ],
+    )
+
+
 # NOTE: Environment variable based settings for things like Elastic search URLs and credential sets, are NOT
 # included in Airflow declarations. These values need to be explicitly specified.
 


### PR DESCRIPTION
## Description
- This PR adds `merino_amp_live_probe` DAG that runs the new `probe-amp-live-access` merino job.
- Scheduled as `@once` which runs a single time on deploy to determing whether Airflow can access the unsanitized search term dataset used by the live keyword engagement query. Can also be re-triggered manually from the UI as needed.
- Email notifications disabled.


## Related Tickets & Documents
* [DISCO-4107](https://mozilla-hub.atlassian.net/browse/DISCO-4107)


<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[DISCO-4107]: https://mozilla-hub.atlassian.net/browse/DISCO-4107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ