### PR TITLE
chore: [DENG-10877] Remove fenix_nightly and fennec_aurora from column_remov…

### DIFF
--- a/utils/glean_v2_backfill.py
+++ b/utils/glean_v2_backfill.py
@@ -1,18 +1,19 @@
 # For https://mozilla-hub.atlassian.net/browse/DENG-8494
 # Should match https://github.com/mozilla/mozilla-schema-generator/blob/main/mozilla_schema_generator/configs/glean_v2_allowlist.yaml
+# commented entries mean table has been swapped
 column_removal_backfill_tables = [
-    "org_mozilla_fenix_nightly_stable.metrics_v1",
-    "org_mozilla_fenix_nightly_stable.sync_v1",
-    "org_mozilla_fenix_nightly_stable.first_session_v1",
-    "org_mozilla_fenix_nightly_stable.adjust_attribution_v1",
-    "org_mozilla_fenix_nightly_stable.health_v1",
-    "org_mozilla_fenix_nightly_stable.captcha_detection_v1",
-    "org_mozilla_fennec_aurora_stable.metrics_v1",
-    "org_mozilla_fennec_aurora_stable.sync_v1",
-    "org_mozilla_fennec_aurora_stable.captcha_detection_v1",
-    "org_mozilla_fennec_aurora_stable.first_session_v1",
-    "org_mozilla_fennec_aurora_stable.health_v1",
-    "org_mozilla_fennec_aurora_stable.adjust_attribution_v1",
+    # "org_mozilla_fenix_nightly_stable.metrics_v1",
+    # "org_mozilla_fenix_nightly_stable.sync_v1",
+    # "org_mozilla_fenix_nightly_stable.first_session_v1",
+    # "org_mozilla_fenix_nightly_stable.adjust_attribution_v1",
+    # "org_mozilla_fenix_nightly_stable.health_v1",
+    # "org_mozilla_fenix_nightly_stable.captcha_detection_v1",
+    # "org_mozilla_fennec_aurora_stable.metrics_v1",
+    # "org_mozilla_fennec_aurora_stable.sync_v1",
+    # "org_mozilla_fennec_aurora_stable.captcha_detection_v1",
+    # "org_mozilla_fennec_aurora_stable.first_session_v1",
+    # "org_mozilla_fennec_aurora_stable.health_v1",
+    # "org_mozilla_fennec_aurora_stable.adjust_attribution_v1",
 ]
 
 # live dataset tables to be used with copy_deduplicate


### PR DESCRIPTION
…al_backfill

## Description

With https://github.com/mozilla/mozilla-schema-generator/pull/315, these tables should be able to be copy_deduplicated normally. Will test after merge

## Related Tickets & Documents
* DENG-10877

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
