### PR TITLE
(fix)merino: fix typo in command name

### DIFF
--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -338,7 +338,7 @@ with DAG(
     amp_live_probe_job = merino_job(
         name="probe_amp_live_access",
         arguments=[
-            "probe-amp-live-access",
+            "probe_amp_live_access",
             "probe-amp-live-access",
         ],
     )


### PR DESCRIPTION
## Description

This PR updates command name to match what is defined in merino

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
