### PR TITLE
feat(backfills): [DENG-4042] Add support for workgroup-restricted datasets

### DIFF
--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -92,7 +92,7 @@ with DAG(
 
         @task
         def prepare_pod_parameters(entry):
-            return [f"script/bqetl backfill complete { entry['qualified_table_name'] }"]
+            return [f"script/bqetl backfill complete { entry['qualified_table_name'] } --copy-table-permissions"]
 
         process_backfill = GKEPodOperator(
             task_id="process_backfill",

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -96,7 +96,7 @@ with DAG(
 
         @task
         def prepare_pod_parameters(entry):
-            return [f"script/bqetl backfill initiate { entry['qualified_table_name'] }"]
+            return [f"script/bqetl backfill initiate { entry['qualified_table_name'] } --copy-table-permissions"]
 
         process_backfill = GKEPodOperator(
             task_id="process_backfill",


### PR DESCRIPTION
## Description

Adds the argument added in https://github.com/mozilla/bigquery-etl/pull/9303 to copy permissions for backfill staging and bakup tables

## Related Tickets & Documents
* DENG-4042

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
