### PR TITLE
chore(deps): Upgrade `airflow-provider-fivetran-async` to v2.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ apache-airflow-providers-postgres
 apache-airflow-providers-redis
 apache-airflow-providers-sftp
 apache-airflow-providers-slack
-airflow-provider-fivetran-async==2.0.2
+airflow-provider-fivetran-async==2.4.0
 
 # dbt integration
 apache-airflow-providers-dbt-cloud

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ aiohappyeyeballs==2.4.4
 aiohttp==3.11.11
 aiosignal==1.3.2
 aiosqlite==0.20.0
-airflow-provider-fivetran-async==2.0.2
+airflow-provider-fivetran-async==2.4.0
 alembic==1.14.1
 amqp==5.3.1
 annotated-types==0.7.0


### PR DESCRIPTION
## Description
Recently the `fivetran_stripe_task` in the [bqetl_subplat_hourly](https://workflow.telemetry.mozilla.org/dags/bqetl_subplat_hourly/grid) DAG has been getting stuck waiting indefinitely when the associated Fivetran Stripe connection sync fails, until someone manually triggers a resync in the Fivetran UI (CC @phil-lee70).

I'm hoping the following bug fixes in newer versions of the `airflow-provider-fivetran-async` package will mitigate that problem:

- [2.1.1](https://github.com/astronomer/airflow-provider-fivetran-async/releases/tag/2.1.1)
  - Ensure proper preparation of API call `kwargs` for synchronous methods in `FivetranHookAsync`
- [2.4.0](https://github.com/astronomer/airflow-provider-fivetran-async/releases/tag/2.4.0)
  - Retry on `ClientConnectionError`
  - Fix failure logic
  - Retry on broken connector

## Related Tickets & Documents
N/A
