### PR TITLE
DENG-10902 run web scraping weekly and remove report task

### DIFF
--- a/dags/web_scraping.py
+++ b/dags/web_scraping.py
@@ -1,15 +1,14 @@
 import datetime
 
 from airflow import DAG
-from airflow.sensors.external_task import ExternalTaskMarker
 
 from operators.gcp_container_operator import GKEPodOperator
 
 docs = """
 ### web_scraping
 
-Scrapes a few websites on a monthly basis &
-loads data to GCS to be used in the monthly market intel bot report
+Scrapes a few websites on a weekly basis &
+loads data to GCS
 
 Owner: lmcfall@mozilla.com
 """
@@ -31,7 +30,7 @@ tags = ["impact/tier_3", "repo/telemetry-airflow"]
 with DAG(
     "web_scraping",
     default_args=default_args,
-    schedule_interval="0 15 2 * *",
+    schedule_interval="0 15 * * 2",
     doc_md=docs,
     tags=tags,
 ) as dag:
@@ -46,12 +45,3 @@ with DAG(
         image=f"us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/release_scraping:latest",
         gcp_conn_id="google_cloud_airflow_gke",
     )
-
-    # This marks a specific task in the downstream DAG so clears cascade there.
-    run_bqetl_market_intel_bot = ExternalTaskMarker(
-        task_id="run_bqetl_market_intel_bot",
-        external_dag_id="bqetl_market_intel_bot",
-        external_task_id="wait_for_read_release_data",
-    )
-
-    read_release_data >> run_bqetl_market_intel_bot


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
The PR makes the web scraping dag run weekly and deprecates the report building task as that is no longer needed with the new implementation of this project.

## Related Tickets & Documents
* DENG-10902

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
