### PR TITLE
docs(backfills): Add details on when each backfill dag should be used

### DIFF
--- a/dags/backfill.py
+++ b/dags/backfill.py
@@ -56,6 +56,14 @@ def generate_bash_command(params: dict) -> str:
 doc_md = """
 # Backfill DAG
 
+Trigger this DAG to re-run, or clear the state of, the tasks of an existing
+Airflow DAG over a date range. It targets a `dag_name` (and optional
+`task_regex`), not a BigQuery table.
+
+To backfill a bigquery-etl table, this is usually not the DAG you want. Use
+[`bqetl_backfill_initiate`](/dags/bqetl_backfill_initiate/grid) instead.
+This DAG should only be used for non-bqetl DAGs and tasks.
+
 #### Use with caution
 
 #### Some tips/notes:

--- a/dags/bqetl_backfill.py
+++ b/dags/bqetl_backfill.py
@@ -12,14 +12,28 @@ doc_md = """
 
 #### Use with caution: This will overwrite the dates and tables you choose!
 
+This DAG triggers the `bqetl query backfill` command in bigquery-etl. This is not the managed
+backfill feature. It overwrites the chosen dates in production directly with no staging or
+review step.
+
+For most backfills, prefer [`bqetl_backfill_initiate`](/dags/bqetl_backfill_initiate/grid),
+which stages results for validation before they reach production. There are very few cases where
+this dag should be used. Ask in slack in #data-platform-infra-wg if you're unsure which to use.
+
 #### Some tips/notes:
 * Date formats are 2020-03-01
 * Try with dryrun=True first
-* Read the associated CLI command in bqetl: https://github.com/mozilla/bigquery-etl/blob/7a36416554193c853bb562b34dda6270462acd66/bigquery_etl/cli/query.py#L679
+* Read the associated CLI command in bqetl: https://github.com/mozilla/bigquery-etl/blob/06ffa03088a4f76efdd4bccf2e346b0b2869aee2/bigquery_etl/cli/query.py#L729
 
 #### Owner
-frank@mozilla.com
+bewu@mozilla.com
 """
+
+default_args = {
+    "email": ["benwu@mozilla.com", "telemetry-alerts@mozilla.com"],
+    "email_on_failure": True,
+    "email_on_retry": False,
+}
 
 
 @dag(
@@ -30,6 +44,7 @@ frank@mozilla.com
     start_date=datetime.datetime(2023, 10, 18),
     dagrun_timeout=datetime.timedelta(days=4),
     tags=[Tag.ImpactTier.tier_3, Tag.Triage.no_triage],
+    default_args=default_args,
     render_template_as_native_obj=True,
     params={
         "table_name": Param(

--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -1,4 +1,13 @@
-"""DAG for completing registered bigquery-etl backfills."""
+"""
+DAG for completing registered bigquery-etl backfills.
+
+This is the last step of the bigquery-etl backfill flow, following
+[`bqetl_backfill_initiate`](/dags/bqetl_backfill_initiate/grid).
+
+Runs hourly and shouldn't be triggered manually. Once you've validated the staged data from
+`bqetl_backfill_initiate` and set the backfill entry's status to `Complete`,
+this DAG swaps the staged data into production, keeping a 30-day backup.
+"""
 
 from datetime import datetime
 

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -1,4 +1,23 @@
-"""DAG for initiating registered bigquery-etl backfills."""
+"""
+DAG for initiating registered bigquery-etl backfills.
+
+This is the recommended way to backfill a bigquery-etl table. Results are staged for validation in
+the `moz-fx-data-shared-prod.backfills_staging_derived` dataset before they replace production data.
+
+Runs hourly and shouldn't be triggered manually. Register the backfill in
+[bigquery-etl](https://github.com/mozilla/bigquery-etl) by adding a
+`backfill.yaml` entry next to the query and getting it merged. After that:
+
+1. This DAG picks up entries with status `Initiate` and runs the
+   backfill into a staging table in `moz-fx-data-shared-prod.backfills_staging_derived`,
+   then notifies the watchers in Slack.
+2. Validate the staging data and set the entry's status to `Complete`.
+3. [`bqetl_backfill_complete`](/dags/bqetl_backfill_complete/grid) (hourly)
+   swaps the validated data into production, keeping a 30-day backup.
+
+See the bigquery-etl backfill documentation for details:
+https://mozilla.github.io/bigquery-etl/cookbooks/backfilling_a_table/
+"""
 
 from datetime import datetime
 from typing import Tuple


### PR DESCRIPTION
## Description

Add some descriptions for the purpose of each of the backfill dags and point to `bqetl_backfill_initiate` as the preferred one. Doing this instead of removing `bqetl_backfill.py` and `backfill.py` because they still have uses, although `bqetl_backfill` might not anymore.

## Related Tickets & Documents
* DENG-987