### PR TITLE
[DENG-11101] Use private-bigquery-etl docker image

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -117,7 +117,7 @@ with DAG(
     render_template_as_native_obj=True,  # So boolean params get rendered as booleans.
 ) as dag:
     docker_image = (
-        "us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest"
+        "us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest"
     )
 
     skip_if_queued_runs_exist = ShortCircuitOperator(

--- a/dags/bqetl_artifact_initialize.py
+++ b/dags/bqetl_artifact_initialize.py
@@ -62,7 +62,7 @@ with DAG(
     params=params,
 ) as dag:
     docker_image = (
-        "us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest"
+        "us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest"
     )
 
     GKEPodOperator(

--- a/dags/bqetl_backfill.py
+++ b/dags/bqetl_backfill.py
@@ -206,7 +206,7 @@ def bqetl_backfill_dag():
         reattach_on_restart=True,
         task_id="bqetl_backfill",
         arguments=generate_backfill_command(),
-        image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest",
+        image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest",
         gcp_conn_id="google_cloud_airflow_gke",
     )
 

--- a/dags/bqetl_backfill_complete.py
+++ b/dags/bqetl_backfill_complete.py
@@ -27,7 +27,7 @@ SLACK_COMMON_ARGS = {
     "slack_conn_id": SLACK_CONNECTION_ID,
     "channel": AUTOMATION_SLACK_CHANNEL,
 }
-DOCKER_IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest"
+DOCKER_IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest"
 
 tags = [Tag.ImpactTier.tier_3]
 

--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -38,7 +38,7 @@ SLACK_COMMON_ARGS = {
     "slack_conn_id": SLACK_CONNECTION_ID,
     "channel": AUTOMATION_SLACK_CHANNEL,
 }
-DOCKER_IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest"
+DOCKER_IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest"
 
 tags = [Tag.ImpactTier.tier_3]
 

--- a/dags/bqetl_dryrun.py
+++ b/dags/bqetl_dryrun.py
@@ -58,7 +58,7 @@ with DAG(
     doc_md=__doc__,
     tags=tags,
 ) as dag:
-    docker_image = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest"
+    docker_image = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest"
 
     skip_if_queued_runs_exist = ShortCircuitOperator(
         task_id="skip_if_queued_runs_exist",

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -83,7 +83,7 @@ with DAG(
                 f"sql/moz-fx-data-shared-prod/microsoft_derived/{table}_v1/query.py",
                 "--date={{ macros.ds_add(ds, -3) }}",
             ],
-            image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest",
+            image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest",
             owner="mhirose@mozilla.com",
             email=["mhirose@mozilla.com", "telemetry-alerts@mozilla.com"],
         )

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -65,7 +65,7 @@ dag = DAG(
     doc_md=docs,
     tags=tags,
 )
-docker_image = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest"
+docker_image = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest"
 base_command = [
     "script/shredder_delete",
     "--state-table=moz-fx-data-shredder.shredder_state.shredder_state",

--- a/dags/shredder_backfill.py
+++ b/dags/shredder_backfill.py
@@ -98,7 +98,7 @@ def base_backfill_operator(dry_run):
         ],
         # target_tables will be rendered as a python list
         arguments="{{ params.target_tables }}",
-        image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest",
+        image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest",
         on_finish_action=OnFinishAction.DELETE_POD.value,
         reattach_on_restart=True,
     )

--- a/dags/socorro_import.py
+++ b/dags/socorro_import.py
@@ -120,7 +120,7 @@ with DAG(
         task_id="remove_socorro_crash_bq_table_partition",
         gcp_conn_id=bq_gcp_conn_id,
         name="remove_socorro_crash_bq_table_partition",
-        image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest",
+        image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest",
         arguments=["bq", "rm", "-f", "--table", table_name],
     )
 

--- a/utils/gcp.py
+++ b/utils/gcp.py
@@ -19,7 +19,7 @@ from utils.dataproc import get_dataproc_parameters
 
 GCP_PROJECT_ID = "moz-fx-data-airflow-gke-prod"
 DATAPROC_PROJECT_ID = "airflow-dataproc"
-BIGQUERY_ETL_DOCKER_IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest"
+BIGQUERY_ETL_DOCKER_IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest"
 
 
 def export_to_parquet(

--- a/utils/glam_subdags/generate_query.py
+++ b/utils/glam_subdags/generate_query.py
@@ -7,7 +7,7 @@ def generate_and_run_glean_queries(
     destination_project_id,
     destination_dataset_id="glam_etl",
     source_project_id="moz-fx-data-shared-prod",
-    docker_image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest",
+    docker_image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest",
     env_vars=None,
     **kwargs,
 ):
@@ -53,7 +53,7 @@ def generate_and_run_glean_task(
     destination_project_id,
     destination_dataset_id="glam_etl",
     source_project_id="moz-fx-data-shared-prod",
-    docker_image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/bigquery-etl/bigquery-etl:latest",
+    docker_image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest",
     env_vars=None,
     min_sample_id = 0,
     max_sample_id = 99,


### PR DESCRIPTION
## Description

See https://mozilla-hub.atlassian.net/browse/DENG-11101

The private-bigquery-etl CI is now publishing images to GAR. This means the image URL has changed to us-docker.pkg.dev/moz-fx-data-artifacts-prod/private-bigquery-etl/private-bigquery-etl:latest

Needs to be merged with https://github.com/mozilla/bigquery-etl/pull/9459 which removes the GAR publishing via bigquery-etl

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
