### PR TITLE
chore(backfills): Set parallelism to 6 and set k8s memory request

### DIFF
--- a/dags/bqetl_backfill_initiate.py
+++ b/dags/bqetl_backfill_initiate.py
@@ -26,6 +26,7 @@ from airflow import DAG
 from airflow.decorators import task, task_group
 from airflow.providers.slack.notifications.slack import send_slack_notification
 from airflow.providers.slack.operators.slack import SlackAPIPostOperator
+from kubernetes.client import models as k8s
 
 from operators.gcp_container_operator import GKEPodOperator
 from utils.tags import Tag
@@ -58,9 +59,7 @@ def parse_table_name_from_backfill(backfill_entry: dict) -> Tuple[str, str]:
     backfill_table_id = (
         f"{dataset}__{table}_{backfill_entry['entry_date'].replace('-', '_')}"
     )
-    staging_location = (
-        f"{project}.backfills_staging_derived.{backfill_table_id}"
-    )
+    staging_location = f"{project}.backfills_staging_derived.{backfill_table_id}"
     return project, staging_location
 
 
@@ -116,7 +115,9 @@ with DAG(
 
         @task
         def prepare_pod_parameters(entry):
-            return [f"script/bqetl backfill initiate { entry['qualified_table_name'] } --copy-table-permissions"]
+            return [
+                f"script/bqetl backfill initiate { entry['qualified_table_name'] } --copy-table-permissions --parallelism=6"
+            ]
 
         process_backfill = GKEPodOperator(
             task_id="process_backfill",
@@ -125,6 +126,9 @@ with DAG(
             arguments=prepare_pod_parameters(backfill),
             image=DOCKER_IMAGE,
             reattach_on_restart=True,
+            container_resources=k8s.V1ResourceRequirements(
+                requests={"memory": "1024Mi"},
+            ),
             on_failure_callback=send_slack_notification(
                 text=prepare_slack_failure_message(backfill),
                 **SLACK_COMMON_ARGS,


### PR DESCRIPTION
## Description

The backfill pods can use several GB of memory ([monitoring](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P4D?pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesQuery%22:%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fmemory%2Fused_bytes%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metric.label.%5C%22memory_type%5C%22%3D%5C%22non-evictable%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22moz-fx-data-airflow-gke-prod%5C%22%20resource.label.%5C%22location%5C%22%3D%5C%22us-west1%5C%22%20resource.label.%5C%22cluster_name%5C%22%3D%5C%22workloads-prod-v1%5C%22%20resource.label.%5C%22namespace_name%5C%22%3D%5C%22default%5C%22%20resource.label.%5C%22pod_name%5C%22%3Dmonitoring.regex.full_match(%5C%22process-backfill-.*%5C%22)%22,%22aggregation%22:%7B%22perSeriesAligner%22:%22ALIGN_MEAN%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%5D,%22alignmentPeriod%22:%2260s%22%7D%7D%7D,%22plotType%22:%22LINE%22,%22targetAxis%22:%22Y1%22,%22minAlignmentPeriod%22:%2260s%22,%22legendTemplate%22:%22Used%22%7D%5D,%22chartOptions%22:%7B%22mode%22:%22COLOR%22,%22displayHorizontal%22:false%7D,%22thresholds%22:%5B%5D,%22yAxis%22:%7B%22scale%22:%22LINEAR%22%7D%7D%7D&project=moz-fx-data-airflow-gke-prod)) because it defaults to 16 queries at a time which starts 16 python subprocesses which then start their own subprocesses in the bq cli. Lowering parallelism should improve this without doing optimizations in bigquery-etl.  I think 6 is fine because more would likely be slot constrained.  Also setting a resource request to try to trigger scaling and prevent eviction
