### PR TITLE
Use new Thunderbird git repo in probe scraper

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -205,7 +205,7 @@ with DAG(
             ("phabricator", "https://github.com/mozilla-conduit/review"),
             (
                 "releases-comm-central",
-                "https://github.com/mozilla/releases-comm-central",
+                "https://github.com/thunderbird/thunderbird-desktop",
             ),
         )
     ]


### PR DESCRIPTION
## Description

Use the new Thunderbird git working repo in probe_scraper.py, as requested in mozilla/probe-scraper#1037