### PR TITLE
chore: [DENG-11325] Update probe-scraper DAG to publish generated-schemas artifacts to GAR

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -322,6 +322,42 @@ with DAG(
 
     schema_generator.set_upstream(probe_scraper)
 
+    # Publish the generated schemas to Google Artifact Registry (GAR), both as a
+    # generic tarball and as a FROM-scratch OCI image.
+    #
+    # The publishing logic lives in jobs/publish_schemas_to_gar.sh.
+    publish_schemas_to_gar_script = (
+        "gs://moz-fx-data-prod-airflow-dataproc-artifacts/jobs/publish_schemas_to_gar.sh"
+    )
+
+    publish_schemas_to_gar = GKEPodOperator(
+        task_id="publish_schemas_to_gar",
+        name="publish-schemas-to-gar",
+        image="google/cloud-sdk:552.0.0-slim",
+        cmds=["bash", "-c"],
+        arguments=[
+            f"set -o pipefail; gcloud storage cat {publish_schemas_to_gar_script} | bash"
+        ],
+        env_vars={
+            "MPS_REPO_URL": "https://github.com/mozilla-services/mozilla-pipeline-schemas.git",
+            "MPS_BRANCH": "generated-schemas",
+            "GCP_PROJECT": "moz-fx-data-artifacts-prod",
+            "GAR_LOCATION": "us",
+            "GAR_REPOSITORY": "mozilla-pipeline-schemas-oci-artifacts",
+            "GENERIC_REPOSITORY": "mozilla-pipeline-schemas-generic-artifacts",
+            "GAR_IMAGE": "schemas",
+            "CRANE_VERSION": "v0.20.2",
+        },
+        email=[
+            "akomar@mozilla.com",
+            "dataops+alerts@mozilla.com",
+            "telemetry-alerts@mozilla.com",
+        ],
+        dag=dag,
+    )
+
+    publish_schemas_to_gar.set_upstream(schema_generator)
+
     probe_expiry_alerts = GKEPodOperator(
         task_id="probe-expiry-alerts",
         name="probe-expiry-alerts",

--- a/jobs/publish_schemas_to_gar.sh
+++ b/jobs/publish_schemas_to_gar.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Publish the generated mozilla-pipeline-schemas to Google Artifact Registry
+# (GAR), both as a generic tarball and as a FROM-scratch OCI image.
+#
+# Required environment variables (set by the probe_scraper DAG):
+#   MPS_REPO_URL, MPS_BRANCH, GCP_PROJECT, GAR_LOCATION, GAR_REPOSITORY,
+#   GENERIC_REPOSITORY, GAR_IMAGE, CRANE_VERSION
+
+set -euo pipefail
+
+# Ensure git/curl are available
+if ! command -v git >/dev/null || ! command -v curl >/dev/null; then
+  apt-get update
+  apt-get install -y --no-install-recommends git curl ca-certificates
+fi
+
+# Install crane for daemonless OCI image builds/pushes.
+curl -sSL "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+  | tar -xz -C /usr/local/bin crane
+
+workdir="$(mktemp -d)"
+
+# Clone the published schemas (public repo, HTTPS, no credentials needed)
+git clone --depth 1 --branch "${MPS_BRANCH}" "${MPS_REPO_URL}" "${workdir}/mozilla-pipeline-schemas"
+cd "${workdir}/mozilla-pipeline-schemas"
+short_ref="$(git rev-parse --short=10 HEAD)"
+
+# Build the schemas tarball (matches the deploy-artifacts.yml git archive)
+mkdir -p "${workdir}/image-context"
+git archive --format tgz --prefix mozilla-pipeline-schemas/ \
+  -o "${workdir}/image-context/schemas.tar.gz" HEAD schemas/
+
+# Upload the tarball to the generic Artifact Registry repository
+if ! gcloud artifacts generic upload \
+  --location="${GAR_LOCATION}" \
+  --project="${GCP_PROJECT}" \
+  --repository="${GENERIC_REPOSITORY}" \
+  --package="${GAR_IMAGE}" \
+  --version="${short_ref}" \
+  --source="${workdir}/image-context/schemas.tar.gz" 2> "${workdir}/upload_err.log"; then
+  if grep -qi "already exists" "${workdir}/upload_err.log"; then
+    echo "Generic artifact version ${short_ref} already exists, skipping upload."
+  else
+    cat "${workdir}/upload_err.log" >&2
+    exit 1
+  fi
+fi
+
+# Authenticate crane to GAR using the pod's workload-identity service account
+crane auth login -u oauth2accesstoken -p "$(gcloud auth print-access-token)" \
+  "${GAR_LOCATION}-docker.pkg.dev"
+
+# Build a FROM-scratch image containing /schemas.tar.gz and push it (tag + latest)
+cd "${workdir}/image-context"
+tar -cf layer.tar schemas.tar.gz
+image="${GAR_LOCATION}-docker.pkg.dev/${GCP_PROJECT}/${GAR_REPOSITORY}/${GAR_IMAGE}"
+crane append -f layer.tar -t "${image}:${short_ref}"
+crane tag "${image}:${short_ref}" latest

--- a/jobs/publish_schemas_to_gar.sh
+++ b/jobs/publish_schemas_to_gar.sh
@@ -47,13 +47,18 @@ if ! gcloud artifacts generic upload \
   fi
 fi
 
-# Authenticate crane to GAR using the pod's workload-identity service account
-crane auth login -u oauth2accesstoken -p "$(gcloud auth print-access-token)" \
-  "${GAR_LOCATION}-docker.pkg.dev"
-
-# Build a FROM-scratch image containing /schemas.tar.gz and push it (tag + latest)
-cd "${workdir}/image-context"
-tar -cf layer.tar schemas.tar.gz
+# Build and push the OCI image only if this ref hasn't been published yet
 image="${GAR_LOCATION}-docker.pkg.dev/${GCP_PROJECT}/${GAR_REPOSITORY}/${GAR_IMAGE}"
-crane append -f layer.tar -t "${image}:${short_ref}"
-crane tag "${image}:${short_ref}" latest
+if gcloud artifacts docker images describe "${image}:${short_ref}" >/dev/null 2>&1; then
+  echo "Image ${image}:${short_ref} already exists, skipping build/push."
+else
+  # Authenticate crane to GAR using the pod's workload-identity service account
+  crane auth login -u oauth2accesstoken -p "$(gcloud auth print-access-token)" \
+    "${GAR_LOCATION}-docker.pkg.dev"
+
+  # Build a FROM-scratch image containing /schemas.tar.gz and push it (tag + latest)
+  cd "${workdir}/image-context"
+  tar -cf layer.tar schemas.tar.gz
+  crane append -f layer.tar -t "${image}:${short_ref}"
+  crane tag "${image}:${short_ref}" latest
+fi


### PR DESCRIPTION
## Description

This is an alternative to https://github.com/mozilla-services/mozilla-pipeline-schemas/pull/873 to publish artifact to GAR from the probe-scraper DAG

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-11325

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
