### PR TITLE
feat(secrets): Testing out restricted secrets in Looker DAG

### DIFF
--- a/dags/looker.py
+++ b/dags/looker.py
@@ -42,55 +42,55 @@ tags = [Tag.ImpactTier.tier_1]
 looker_repos_secret_git_ssh_key_b64 = Secret(
     deploy_type="env",
     deploy_target="GIT_SSH_KEY_BASE64",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_repos_secret_git_ssh_key_b64",
 )
 looker_api_client_id_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_id_prod",
 )
 looker_api_client_secret_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_secret_prod",
 )
 looker_api_client_id_staging = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_id_staging",
 )
 looker_api_client_secret_staging = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_secret_staging",
 )
 looker_client_id_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_id_prod",
 )
 looker_client_secret_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_secret_prod",
 )
 looker_pubsub_subscription_id = Secret(
     deploy_type="env",
     deploy_target="LOOKER_PUBSUB_SUBSCRIPTION_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="looker__looker_pubsub_subscription_id",
 )
 dataops_looker_github_secret_access_token = Secret(
     deploy_type="env",
     deploy_target="GITHUB_ACCESS_TOKEN",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__dataops_looker_github_secret_access_token",
 )
 


### PR DESCRIPTION
## Description

Testing out https://docs.google.com/document/d/18iktgFGfn2ElVlhkwVOoTaJtjS6Qc9u1swox8yj0Fdo/edit?tab=t.0 in Looker DAG. I set the secrets using mozcloud gsm (https://github.com/mozilla/mozcloud/pull/125).


## Related Tickets & Documents
* https://github.com/mozilla/dataservices-infra/pull/2136

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
