### PR TITLE
feat(secrets): Restricted secrets in Looker DAG

### DIFF
--- a/dags/looker.py
+++ b/dags/looker.py
@@ -42,55 +42,55 @@ tags = [Tag.ImpactTier.tier_1]
 looker_repos_secret_git_ssh_key_b64 = Secret(
     deploy_type="env",
     deploy_target="GIT_SSH_KEY_BASE64",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_repos_secret_git_ssh_key_b64",
 )
 looker_api_client_id_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_id_prod",
 )
 looker_api_client_secret_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_secret_prod",
 )
 looker_api_client_id_staging = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_id_staging",
 )
 looker_api_client_secret_staging = Secret(
     deploy_type="env",
     deploy_target="LOOKER_API_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_secret_staging",
 )
 looker_client_id_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_id_prod",
 )
 looker_client_secret_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_secret_prod",
 )
 looker_pubsub_subscription_id = Secret(
     deploy_type="env",
     deploy_target="LOOKER_PUBSUB_SUBSCRIPTION_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="looker__looker_pubsub_subscription_id",
 )
 dataops_looker_github_secret_access_token = Secret(
     deploy_type="env",
     deploy_target="GITHUB_ACCESS_TOKEN",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__dataops_looker_github_secret_access_token",
 )
 


### PR DESCRIPTION
Brings back new restricted secrets in Looker DAG now that `ExternalSecret` resource was configured and synced (https://mozilla.slack.com/archives/C01E8GDG80N/p1783608160357409?thread_ts=1783534559.263169&cid=C01E8GDG80N)

Tested successfully in dev env: https://dev.telemetry-airflow.nonprod.dataservices.mozgcp.net/dags/looker/grid?tab=logs&dag_run_id=manual__2026-01-14T17%3A53%3A21.274652%2B00%3A00&task_id=disable_exited_employees