### PR TITLE
[DENG-4193] feat(secrets): Use restricted GSM secrets in all DAGs

### DIFF
--- a/dags/adm_dma_export.py
+++ b/dags/adm_dma_export.py
@@ -39,7 +39,7 @@ tags = [Tag.ImpactTier.tier_3]
 adm_sftp_secret = Secret(
     deploy_type="env",
     deploy_target="SFTP_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="adm_export_secret__sftp_password",
 )
 

--- a/dags/adm_export.py
+++ b/dags/adm_export.py
@@ -38,7 +38,7 @@ tags = [Tag.ImpactTier.tier_3]
 adm_sftp_secret = Secret(
     deploy_type="env",
     deploy_target="SFTP_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="adm_export_secret__sftp_password",
 )
 

--- a/dags/ads_incrementality.py
+++ b/dags/ads_incrementality.py
@@ -54,14 +54,14 @@ deploy_env = os.environ.get("ENVIRONMENT", "dev")
 hpke_private_key = Secret(
     deploy_type="env",
     deploy_target="DAP_PRIVATE_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="dap_ads_incr_hpke_private_key_" + deploy_env,
 )
 
 bearer_token = Secret(
     deploy_type="env",
     deploy_target="DAP_BEARER_TOKEN",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="dap_ads_incr_auth_token_" + deploy_env,
 )
 

--- a/dags/ads_newtab_attribution.py
+++ b/dags/ads_newtab_attribution.py
@@ -65,14 +65,14 @@ deploy_env = os.environ.get("ENVIRONMENT", "dev")
 hpke_private_key = Secret(
     deploy_type="env",
     deploy_target="DAP_PRIVATE_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="dap_ads_attr_hpke_private_key_" + deploy_env,
 )
 
 bearer_token = Secret(
     deploy_type="env",
     deploy_target="DAP_BEARER_TOKEN",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="dap_ads_attr_auth_token_" + deploy_env,
 )
 

--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -101,7 +101,7 @@ def should_run_deployment(dag_id: str, generate_sql: bool) -> bool:
 bigeye_api_key_secret = Secret(
     deploy_type="env",
     deploy_target="BIGEYE_API_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="bqetl_artifact_deployment__bigeye_api_key",
 )
 

--- a/dags/dap_collector_ppa_prod.py
+++ b/dags/dap_collector_ppa_prod.py
@@ -51,14 +51,14 @@ tags = [
 hpke_private_key = Secret(
     deploy_type="env",
     deploy_target="HPKE_PRIVATE_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="DAP_PPA_PROD_HPKE_PRIVATE_KEY",
 )
 
 auth_token = Secret(
     deploy_type="env",
     deploy_target="AUTH_TOKEN",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="DAP_PPA_PROD_AUTH_TOKEN",
 )
 

--- a/dags/eam_gmail_panopto_integration.py
+++ b/dags/eam_gmail_panopto_integration.py
@@ -122,7 +122,7 @@ def create_secret(deploy_target):
     return Secret(
         deploy_type="env",
         deploy_target=deploy_target,
-        secret="airflow-gke-secrets",
+        secret="airflow-gke-restricted-secrets",
         key=deploy_target,
     )
 

--- a/dags/eam_slack_channels.py
+++ b/dags/eam_slack_channels.py
@@ -122,14 +122,14 @@ tags = [Tag.ImpactTier.tier_3]
 SLACK_CHANNEL_TOKEN = Secret(
     deploy_type="env",
     deploy_target="SLACK_CHANNEL_TOKEN",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="SLACK_CHANNEL_TOKEN",
 )
 
 slack_service_account = Secret(
     deploy_type="env",
     deploy_target="slack_service_account",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="slack_service_account",
 )
 

--- a/dags/eam_workday_docusign.py
+++ b/dags/eam_workday_docusign.py
@@ -122,19 +122,19 @@ tags = [Tag.ImpactTier.tier_3]
 docusign_jwt = Secret(
     deploy_type="env",
     deploy_target="docusign_jwt",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="docusign_jwt",
 )
 DOCUSIGN_INTEG_WORKDAY_USERNAME = Secret(
     deploy_type="env",
     deploy_target="DOCUSIGN_INTEG_WORKDAY_USERNAME",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="DOCUSIGN_INTEG_WORKDAY_USERNAME",
 )
 DOCUSIGN_INTEG_WORKDAY_PASSWORD = Secret(
     deploy_type="env",
     deploy_target="DOCUSIGN_INTEG_WORKDAY_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="DOCUSIGN_INTEG_WORKDAY_PASSWORD",
 )
 

--- a/dags/eam_workday_everfi_integration.py
+++ b/dags/eam_workday_everfi_integration.py
@@ -122,25 +122,25 @@ tags = [Tag.ImpactTier.tier_3]
 EVERFI_INTEG_WORKDAY_USERNAME = Secret(
     deploy_type="env",
     deploy_target="EVERFI_INTEG_WORKDAY_USERNAME",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="EVERFI_INTEG_WORKDAY_USERNAME",
 )
 EVERFI_INTEG_WORKDAY_PASSWORD = Secret(
     deploy_type="env",
     deploy_target="EVERFI_INTEG_WORKDAY_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="EVERFI_INTEG_WORKDAY_PASSWORD",
 )
 EVERFI_USERNAME = Secret(
     deploy_type="env",
     deploy_target="EVERFI_USERNAME",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="EVERFI_USERNAME",
 )
 EVERFI_PASSWORD = Secret(
     deploy_type="env",
     deploy_target="EVERFI_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="EVERFI_PASSWORD",
 )
 

--- a/dags/eam_workday_netsuite.py
+++ b/dags/eam_workday_netsuite.py
@@ -129,28 +129,28 @@ tags = [Tag.ImpactTier.tier_3, Tag.Triage.record_only, Tag.Repo.airflow]
 NETSUITE_INTEG_WORKDAY_USERNAME = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_WORKDAY_USERNAME",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_WORKDAY_USERNAME",
 )
 
 NETSUITE_INTEG_WORKDAY_PASSWORD = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_WORKDAY_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_WORKDAY_PASSWORD",
 )
 
 NETSUITE_INTEG_WORKDAY_LISTING_OF_WORKERS_LINK = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_WORKDAY_LISTING_OF_WORKERS_LINK",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_WORKDAY_LISTING_OF_WORKERS_LINK",
 )
 
 NETSUITE_INTEG_WORKDAY_INTERNATIONAL_TRANSFER_LINK = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_WORKDAY_INTERNATIONAL_TRANSFER_LINK",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_WORKDAY_INTERNATIONAL_TRANSFER_LINK",
 )
 
@@ -158,42 +158,42 @@ NETSUITE_INTEG_WORKDAY_INTERNATIONAL_TRANSFER_LINK = Secret(
 NETSUITE_INTEG_NETSUITE_CONSUMER_KEY = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_NETSUITE_CONSUMER_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_NETSUITE_CONSUMER_KEY",
 )
 
 NETSUITE_INTEG_NETSUITE_CONSUMER_SECRET = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_NETSUITE_CONSUMER_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_NETSUITE_CONSUMER_SECRET",
 )
 
 NETSUITE_INTEG_NETSUITE_TOKEN_ID = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_NETSUITE_TOKEN_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_NETSUITE_TOKEN_ID",
 )
 
 NETSUITE_INTEG_NETSUITE_TOKEN_SECRET = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_NETSUITE_TOKEN_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_NETSUITE_TOKEN_SECRET",
 )
 
 NETSUITE_INTEG_NETSUITE_TOKEN_OAUTH_REALM = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_NETSUITE_TOKEN_OAUTH_REALM",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_NETSUITE_TOKEN_OAUTH_REALM",
 )
 
 NETSUITE_INTEG_NETSUITE_HOST = Secret(
     deploy_type="env",
     deploy_target="NETSUITE_INTEG_NETSUITE_HOST",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="NETSUITE_INTEG_NETSUITE_HOST",
 )
 

--- a/dags/fxci_metric_export.py
+++ b/dags/fxci_metric_export.py
@@ -35,13 +35,13 @@ secrets = [
     Secret(
         deploy_type="env",
         deploy_target="FXCI_ETL_STORAGE_CREDENTIALS",
-        secret="airflow-gke-secrets",
+        secret="airflow-gke-restricted-secrets",
         key="fxci_etl_secret__gcp-credentials",
     ),
     Secret(
         deploy_type="env",
         deploy_target="FXCI_ETL_MONITORING_CREDENTIALS",
-        secret="airflow-gke-secrets",
+        secret="airflow-gke-restricted-secrets",
         key="fxci_etl_secret__gcp-credentials",
     ),
 ]

--- a/dags/fxci_pulse_export.py
+++ b/dags/fxci_pulse_export.py
@@ -39,13 +39,13 @@ secrets = [
     Secret(
         deploy_type="env",
         deploy_target="FXCI_ETL_STORAGE_CREDENTIALS",
-        secret="airflow-gke-secrets",
+        secret="airflow-gke-restricted-secrets",
         key="fxci_etl_secret__gcp-credentials",
     ),
     Secret(
         deploy_type="env",
         deploy_target="FXCI_ETL_PULSE_PASSWORD",
-        secret="airflow-gke-secrets",
+        secret="airflow-gke-restricted-secrets",
         key="fxci_etl_secret__pulse-password",
     ),
 ]

--- a/dags/looker_usage_analysis.py
+++ b/dags/looker_usage_analysis.py
@@ -35,13 +35,13 @@ tags = [Tag.ImpactTier.tier_3]
 looker_client_id_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_id_prod",
 )
 looker_client_secret_prod = Secret(
     deploy_type="env",
     deploy_target="LOOKER_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__looker_api_client_secret_prod",
 )
 looker_instance_uri = "https://mozilla.cloud.looker.com"

--- a/dags/mad_server.py
+++ b/dags/mad_server.py
@@ -44,13 +44,13 @@ gcs_report_bucket = "mad-reports"
 amo_cred_issuer_secret = Secret(
     deploy_type="env",
     deploy_target="AMO_CRED_ISSUER",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="mad_server_secret__amo_cred_issuer",
 )
 amo_cred_secret_secret = Secret(
     deploy_type="env",
     deploy_target="AMO_CRED_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="mad_server_secret__amo_cred_secret",
 )
 

--- a/dags/merino_jobs.py
+++ b/dags/merino_jobs.py
@@ -82,28 +82,28 @@ tags = [
 elasticsearch_stage_apikey_secret = Secret(
     deploy_type="env",
     deploy_target="MERINO_JOBS__WIKIPEDIA_INDEXER__ES_API_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="merino_elasticsearch_secret__stage_api_key",
 )
 
 elasticsearch_prod_apikey_secret = Secret(
     deploy_type="env",
     deploy_target="MERINO_JOBS__WIKIPEDIA_INDEXER__ES_API_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="merino_elasticsearch_secret__prod_api_key",
 )
 
 polygon_prod_apikey_secret = Secret(
     deploy_type="env",
     deploy_target="MERINO_POLYGON__API_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="merino_polygon_secret__prod_api_key",
 )
 
 flightaware_prod_apikey_secret = Secret(
     deploy_type="env",
     deploy_target="MERINO_FLIGHTAWARE__API_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="merino_flightaware_secret__prod_api_key",
 )
 
@@ -117,7 +117,7 @@ sports_prod_sportsdata_apikey_secret = Secret(
     # In this case, we follow the `settings` model
     deploy_target="MERINO_PROVIDERS__SPORTS__SPORTSDATA__API_KEY",
     # Where is the secret stored in Kubernetes?
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     # finally, what is the name of the secret in the storage (Talk to DAGENG about this value)
     key="merino_providers__sports__sportsdata_api_key",
 )

--- a/dags/microsoft_store.py
+++ b/dags/microsoft_store.py
@@ -11,25 +11,25 @@ from utils.tags import Tag
 microsoft_client_id = Secret(
     deploy_type="env",
     deploy_target="MICROSOFT_CLIENT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="MICROSOFT_CLIENT_ID",
 )
 microsoft_client_secret = Secret(
     deploy_type="env",
     deploy_target="MICROSOFT_CLIENT_SECRET",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="MICROSOFT_CLIENT_SECRET",
 )
 microsoft_tenant_id = Secret(
     deploy_type="env",
     deploy_target="MICROSOFT_TENANT_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="MICROSOFT_TENANT_ID",
 )
 microsoft_store_app_list = Secret(
     deploy_type="env",
     deploy_target="MICROSOFT_STORE_APP_LIST",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="MICROSOFT_STORE_APP_LIST",
 )
 

--- a/dags/peopleintegration_workday_report.py
+++ b/dags/peopleintegration_workday_report.py
@@ -17,19 +17,19 @@ PROJECT = "moz-fx-data-bq-people"
 WORKDAY_USERNAME = Secret(
     deploy_type="env",
     deploy_target="WORKDAY_USERNAME",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="EVERFI_INTEG_WORKDAY_USERNAME",
 )
 WORKDAY_PASSWORD = Secret(
     deploy_type="env",
     deploy_target="WORKDAY_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="EVERFI_INTEG_WORKDAY_PASSWORD",
 )
 WORKDAY_QUERY_URI = Secret(
     deploy_type="env",
     deploy_target="WORKDAY_QUERY_URI",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="WORKDAY_QUERY_URI",
 )
 WORKDAY_BASE_URL = "https://services1.myworkday.com"

--- a/dags/peopleteam_monthly.py
+++ b/dags/peopleteam_monthly.py
@@ -25,13 +25,13 @@ QUERIES_IMAGE = (
 WORKDAY_USERNAME = Secret(
     deploy_type="env",
     deploy_target="HR_DASHBOARD_WORKDAY_USERNAME",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="HR_DASHBOARD_WORKDAY_USERNAME",
 )
 WORKDAY_PASSWORD = Secret(
     deploy_type="env",
     deploy_target="HR_DASHBOARD_WORKDAY_PASSWORD",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="HR_DASHBOARD_WORKDAY_PASSWORD",
 )
 

--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -72,19 +72,19 @@ tags = [Tag.ImpactTier.tier_1]
 aws_access_key_secret = Secret(
     deploy_type="env",
     deploy_target="AWS_ACCESS_KEY_ID",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__aws_access_key",
 )
 aws_secret_key_secret = Secret(
     deploy_type="env",
     deploy_target="AWS_SECRET_ACCESS_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__aws_secret_key",
 )
 mozilla_pipeline_schemas_secret_git_sshkey_b64 = Secret(
     deploy_type="env",
     deploy_target="MPS_SSH_KEY_BASE64",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="probe_scraper_secret__mozilla_pipeline_schemas_secret_git_sshkey_b64",
 )
 

--- a/dags/webcompat_kb.py
+++ b/dags/webcompat_kb.py
@@ -45,28 +45,28 @@ every_fifteen_minutes = "*/15 * * * *"
 bugzilla_token = Secret(
     deploy_type="env",
     deploy_target="BUGZILLA_API_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="webcompat_kb_secret__bugzilla_api_key",
 )
 
 github_token = Secret(
     deploy_type="env",
     deploy_target="GH_TOKEN",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="webcompat_kb_secret__gh_token",
 )
 
 hackbot_url = Secret(
     deploy_type="env",
     deploy_target="HACKBOT_URL",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="webcompat_kb_secret__hackbot_url",
 )
 
 hackbot_api_key = Secret(
     deploy_type="env",
     deploy_target="HACKBOT_API_KEY",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="webcompat_kb_secret__hackbot_api_key",
 )
 

--- a/utils/gcp.py
+++ b/utils/gcp.py
@@ -469,7 +469,7 @@ def bigquery_bigeye_check(
     bigeye_api_key = Secret(
         deploy_type="env",
         deploy_target="BIGEYE_API_KEY",
-        secret="airflow-gke-secrets",
+        secret="airflow-gke-restricted-secrets",
         key="bqetl_artifact_deployment__bigeye_api_key",
     )
 


### PR DESCRIPTION
## Description

This uses the new restricted GSM secrets in all Airflow DAGs, based on https://docs.google.com/document/d/18iktgFGfn2ElVlhkwVOoTaJtjS6Qc9u1swox8yj0Fdo/edit?tab=t.0

## Related Tickets & Documents
* DENG-4193

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
