### PR TITLE
fix: jetstream rerun config changed should recreate enrollments

### DIFF
--- a/dags/jetstream.py
+++ b/dags/jetstream.py
@@ -76,6 +76,8 @@ with DAG(
             "--log_to_bigquery",
             "rerun-config-changed",
             "--argo",
+            # need to recreate enrollments when the config changes
+            "--recreate-enrollments",
             # the Airflow cluster doesn't have Compute Engine API access so pass in IP
             # and certificate in order for the pod to connect to the Kubernetes cluster
             # running Jetstream


### PR DESCRIPTION
## Description

We should assume that a config change requires enrollments to be recomputed because there is currently no way to tell whether a given config changes something important for the enrollments or not (e.g., custom enrollments query, new segments).

## Related Tickets & Documents
* https://github.com/mozilla/metric-hub/issues/1550