### PR TITLE
chore(broken_site_report): Remove telemetry-alerts from alert emails

### DIFF
--- a/dags/broken_site_report_ml.py
+++ b/dags/broken_site_report_ml.py
@@ -39,6 +39,7 @@ default_args = {
 
 tags = [
     Tag.ImpactTier.tier_2,
+    Tag.Triage.no_triage,
 ]
 
 every_fifteen_minutes = "*/15 * * * *"

--- a/dags/broken_site_report_ml.py
+++ b/dags/broken_site_report_ml.py
@@ -30,7 +30,7 @@ kberezina@mozilla.com
 
 default_args = {
     "owner": "kberezina@mozilla.com",
-    "email": ["kberezina@mozilla.com", "webcompat-internal@mozilla.org", "telemetry-alerts@mozilla.com"],
+    "email": ["kberezina@mozilla.com", "webcompat-internal@mozilla.org"],
     "depends_on_past": False,
     "start_date": datetime(2023, 12, 21),
     "email_on_failure": True,


### PR DESCRIPTION
## Description

This fails many times per day https://groups.google.com/a/mozilla.com/g/telemetry-alerts/search?q=webcompat_kb.webcompat_kb to the point where it's not useful signal
