### PR TITLE
feat(bqetl_artifact_deployment): Create and clean up BigQuery Sharing listings

### DIFF
--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -232,7 +232,7 @@ with DAG(
     clean_sharing = GKEPodOperator(
         task_id="clean_sharing",
         cmds=["bash", "-x", "-c"],
-        arguments=["script/bqetl sharing clean --location=US"],
+        arguments=["script/bqetl sharing clean"],
         image=docker_image,
     )
 

--- a/dags/bqetl_artifact_deployment.py
+++ b/dags/bqetl_artifact_deployment.py
@@ -213,6 +213,29 @@ with DAG(
         secrets=[bigeye_api_key_secret],
     )
 
+    # Set up BigQuery Sharing (exchanges, listings, subscriber grants) for
+    # `_shared` datasets that declare `external_sharing`. Sharing is created on
+    # the user-facing project (mozdata), so this must run after the `_shared`
+    # views have been published there by `publish_tables_and_views`.
+    publish_sharing = GKEPodOperator(
+        task_id="publish_sharing",
+        cmds=["bash", "-x", "-c"],
+        arguments=[
+            "script/bqetl sharing deploy '*' --project-id=moz-fx-data-shared-prod"
+        ],
+        image=docker_image,
+    )
+
+    # Remove BigQuery Sharing exchanges/listings that are no longer backed by an
+    # `external_sharing` config. Only bqetl-managed resources are deleted;
+    # manually-created exchanges/listings are left untouched.
+    clean_sharing = GKEPodOperator(
+        task_id="clean_sharing",
+        cmds=["bash", "-x", "-c"],
+        arguments=["script/bqetl sharing clean --location=US"],
+        image=docker_image,
+    )
+
     trigger_initialize = TriggerDagRunOperator(
         task_id="trigger_initialize",
         trigger_dag_id="bqetl_artifact_initialize",
@@ -243,6 +266,10 @@ with DAG(
     publish_tables_and_views.set_upstream(publish_static_tables)
     publish_metadata.set_upstream(publish_tables_and_views)
     publish_bigeye_monitors.set_upstream(publish_tables_and_views)
+    # Sharing runs after the `_shared` views are published to mozdata; cleanup
+    # of orphaned sharing resources runs after the deploy.
+    publish_sharing.set_upstream(publish_tables_and_views)
+    clean_sharing.set_upstream(publish_sharing)
     # trigger dryrun
     # doesn't block downstream tasks
     trigger_dryrun.set_upstream(publish_tables_and_views)


### PR DESCRIPTION
## Description

Depends on https://github.com/mozilla/bigquery-etl/pull/9750

Schedules the creation/cleanup of BigQuery Sharing (Analytic Hub) exchanges and listings.

Based on https://mozilla-hub.atlassian.net/browse/DENG-11315

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-11315

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
