### PR TITLE
fix(copy_dedupe): Avoid processing all tables if given empty only list

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -100,17 +100,19 @@ with models.DAG(
         container_resources=resources,
     )
 
-    # temporary test task with no downstream dependencies
-    copy_deduplicate_glean_v2_backfill = bigquery_etl_copy_deduplicate(
-        task_id="copy_deduplicate_glean_v2_backfill",
-        target_project_id="moz-fx-data-shared-prod",
-        billing_projects=("moz-fx-data-shared-prod",),
-        priority_weight=100,
-        parallelism=4,
-        only_tables=column_removal_backfill_tables_live,
-        column_removal_backfill_tables=column_removal_backfill_tables_live,
-        container_resources=resources,
-    )
+    # temporary test task with no downstream dependencies.
+    # Only created when there are tables left to backfill
+    if column_removal_backfill_tables_live:
+        copy_deduplicate_glean_v2_backfill = bigquery_etl_copy_deduplicate(
+            task_id="copy_deduplicate_glean_v2_backfill",
+            target_project_id="moz-fx-data-shared-prod",
+            billing_projects=("moz-fx-data-shared-prod",),
+            priority_weight=100,
+            parallelism=4,
+            only_tables=column_removal_backfill_tables_live,
+            column_removal_backfill_tables=column_removal_backfill_tables_live,
+            container_resources=resources,
+        )
 
     copy_deduplicate_sliced = bigquery_etl_copy_deduplicate(
         task_id="copy_deduplicate_sliced",

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -232,20 +232,24 @@ force_no_dml = GKEPodOperator(
     **common_task_args,
 )
 
-column_removal = GKEPodOperator(
-    task_id="column-removal",
-    name="shredder-column-removal",
-    arguments=[
-        *base_command,
-        "--parallelism=3",
-        "--billing-project=moz-fx-data-bq-batch-prod",
-        "--only",
-        *column_removal_backfill_tables,
-        "--column-removal-backfill-tables",
-        *column_removal_backfill_tables,
-    ],
-    container_resources=k8s.V1ResourceRequirements(
-        requests={"memory": "512Mi"},
-    ),
-    **common_task_args,
-)
+# Only created when there are tables left to backfill: --only and
+# --column-removal-backfill-tables both require at least one value, so an empty
+# list would make the pod exit on an argument parsing error.
+if column_removal_backfill_tables:
+    column_removal = GKEPodOperator(
+        task_id="column-removal",
+        name="shredder-column-removal",
+        arguments=[
+            *base_command,
+            "--parallelism=3",
+            "--billing-project=moz-fx-data-bq-batch-prod",
+            "--only",
+            *column_removal_backfill_tables,
+            "--column-removal-backfill-tables",
+            *column_removal_backfill_tables,
+        ],
+        container_resources=k8s.V1ResourceRequirements(
+            requests={"memory": "512Mi"},
+        ),
+        **common_task_args,
+    )

--- a/utils/gcp.py
+++ b/utils/gcp.py
@@ -315,6 +315,12 @@ def bigquery_etl_copy_deduplicate(
     :return: GKEPodOperator
     """
     kwargs["name"] = kwargs.get("name", task_id.replace("_", "-"))
+    # An empty only_tables list emits no --only args, which makes bqetl process every live table
+    # instead of none. Probably not intended, so fail.
+    if only_tables is not None and len(only_tables) == 0:
+        raise ValueError(
+            f"{task_id}: only_tables is empty; pass None to process all tables"
+        )
     table_qualifiers = []
     if only_tables:
         # bqetl expects multiple args as --only ... --only ...


### PR DESCRIPTION
## Description

follow-up to https://github.com/mozilla/telemetry-airflow/pull/2378. passing an empty list in `only_tables` to the copy_deduplicate function makes it do all tables
