### PR TITLE
chore(looker): [DENG-11448] Run task to enable Looker API key creation for new users

### DIFF
--- a/dags/looker.py
+++ b/dags/looker.py
@@ -267,6 +267,22 @@ with DAG(
         **airflow_gke_prod_kwargs,
     )
 
+    enable_api_keys = GKEPodOperator(
+        task_id="enable_api_keys",
+        arguments=[
+            "python",
+            "-m",
+            "looker_utils.main",
+            "enable-api-keys",
+        ],
+        image="us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/looker-utils:latest",
+        env_vars={
+            "LOOKER_INSTANCE_URI": "https://mozilla.cloud.looker.com",
+        },
+        secrets=[looker_client_id_prod, looker_client_secret_prod],
+        **airflow_gke_prod_kwargs,
+    )
+
     lookml_generator_staging >> lookml_generator_prod
     lookml_generator_prod >> validate_content_spectacles >> delete_outdated_branches
     (


### PR DESCRIPTION
Depends on https://github.com/mozilla/docker-etl/pull/567

## Description

Schedules enabling Looker API key creation for all users. Looker doesn't have a global setting to enable API key creation for everyone, so this task uses the API to enable it per user daily. 
There have been more an more requests of users for API keys to use the Looker MCP.

## Related Tickets & Documents
* [DENG-11448](https://mozilla-hub.atlassian.net/browse/DENG-11448)

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->


[DENG-11448]: https://mozilla-hub.atlassian.net/browse/DENG-11448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ