### PR TITLE
Bug 2065102 - Run probe-scraper for Firefox Enterprise

### DIFF
--- a/dags/probe_scraper.py
+++ b/dags/probe_scraper.py
@@ -202,6 +202,7 @@ with DAG(
         )
         for name, url in (
             ("firefox", "https://github.com/mozilla-firefox/firefox"),
+            ("firefox-enterprise", "https://github.com/mozilla/enterprise-firefox"),
             ("phabricator", "https://github.com/mozilla-conduit/review"),
             (
                 "releases-comm-central",


### PR DESCRIPTION
## Description

Firefox Enterprise is in its own repo and has its own app ID. We need to run probe-scraper nightly on it.

## Related Tickets & Documents
* [2065102](https://bugzilla.mozilla.org/show_bug.cgi?id=2065102)

