### PR TITLE
feat(copy_deduplicate): Post task retry/failure alerts to the `#data-platform-alerts` Slack channel (DENG-10850)

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -12,6 +12,7 @@ from utils.gcp import (
     bigquery_etl_query,
 )
 from utils.glean_v2_backfill import column_removal_backfill_tables_live
+from utils.slack import TaskFailureSlackNotifier, TaskRetrySlackNotifier
 from utils.tags import Tag
 
 DOCS = """\
@@ -59,6 +60,7 @@ default_args = {
 
 dag_name = "copy_deduplicate"
 tags = [Tag.ImpactTier.tier_1]
+alerts_slack_channel = "#data-platform-alerts"
 
 with models.DAG(
     dag_name,
@@ -98,6 +100,8 @@ with models.DAG(
             ],
         ],
         container_resources=resources,
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     # temporary test task with no downstream dependencies.
@@ -125,6 +129,8 @@ with models.DAG(
             "firefox_desktop_live.metrics_v1",
         ],
         container_resources=resources,
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     # EmptyOperator is used instead of a task group to maintain compatibility with downstream sensors
@@ -181,6 +187,8 @@ with models.DAG(
             "telemetry-alerts@mozilla.com",
             "akomarzewski@mozilla.com",
         ],
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     with TaskGroup("main_ping_external") as main_ping_external:
@@ -220,6 +228,8 @@ with models.DAG(
         priority_weight=50,
         parallelism=1,
         owner="akomarzewski@mozilla.com",
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     with TaskGroup("first_shutdown_ping_external") as first_shutdown_ping_external:
@@ -255,6 +265,8 @@ with models.DAG(
         priority_weight=100,
         parallelism=1,
         owner="akomarzewski@mozilla.com",
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     event_events = bigquery_etl_query(
@@ -266,6 +278,8 @@ with models.DAG(
         priority_weight=90,
         owner="akomarzewski@mozilla.com",
         arguments=("--schema_update_option=ALLOW_FIELD_ADDITION",),
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     with TaskGroup("event_events_external") as event_events_external:
@@ -304,6 +318,8 @@ with models.DAG(
         owner="akomarzewski@mozilla.com",
         dag=dag,
         arguments=("--schema_update_option=ALLOW_FIELD_ADDITION",),
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     with TaskGroup("bq_main_events_external") as bq_main_events_external:
@@ -351,6 +367,8 @@ with models.DAG(
         date_partition_parameter="submission_date",
         depends_on_past=True,
         dag=dag,
+        on_retry_callback=TaskRetrySlackNotifier(alerts_slack_channel),
+        on_failure_callback=TaskFailureSlackNotifier(alerts_slack_channel),
     )
 
     with TaskGroup(

--- a/utils/slack.py
+++ b/utils/slack.py
@@ -1,33 +1,10 @@
-from airflow.models import Variable
 from airflow.providers.slack.notifications.slack import SlackNotifier
-from airflow.providers.slack.operators.slack import SlackAPIPostOperator
-
-SLACK_CHANNEL = "#airflow-alerts"
 
 DAG_LINK_TEMPLATE = "{{ conf.get('webserver', 'base_url') }}/dags/{{ ti.dag_id }}/grid"
 TASK_LINK_TEMPLATE = DAG_LINK_TEMPLATE + "?task_id={{ ti.task_id }}"
 TASK_INSTANCE_LINK_TEMPLATE = (
     TASK_LINK_TEMPLATE + "&amp;dag_run_id={{ run_id | urlencode }}"
 )
-
-
-def if_task_fails_alert_slack(context):
-    failed_alert = SlackAPIPostOperator(
-        task_id="slack_failed",
-        channel=SLACK_CHANNEL,
-        token=Variable.get("slack_secret_token"),
-        text="""
-            :red_circle: Task Failed.
-            *Task*: {task}
-            *Dag*: {dag}
-            *Date*: {ds}
-            """.format(
-            task=context.get("task_instance").task_id,
-            dag=context.get("task_instance").dag_id,
-            ds=context.get("ds"),
-        ),
-    )
-    return failed_alert.execute(context=context)
 
 
 class AirflowBotSlackNotifier(SlackNotifier):

--- a/utils/slack.py
+++ b/utils/slack.py
@@ -1,7 +1,14 @@
 from airflow.models import Variable
+from airflow.providers.slack.notifications.slack import SlackNotifier
 from airflow.providers.slack.operators.slack import SlackAPIPostOperator
 
 SLACK_CHANNEL = "#airflow-alerts"
+
+DAG_LINK_TEMPLATE = "{{ conf.get('webserver', 'base_url') }}/dags/{{ ti.dag_id }}/grid"
+TASK_LINK_TEMPLATE = DAG_LINK_TEMPLATE + "?task_id={{ ti.task_id }}"
+TASK_INSTANCE_LINK_TEMPLATE = (
+    TASK_LINK_TEMPLATE + "&amp;dag_run_id={{ run_id | urlencode }}"
+)
 
 
 def if_task_fails_alert_slack(context):
@@ -21,3 +28,53 @@ def if_task_fails_alert_slack(context):
         ),
     )
     return failed_alert.execute(context=context)
+
+
+class AirflowBotSlackNotifier(SlackNotifier):
+    """Slack notifier that will post as @Airflow-bot.
+
+    * @Airflow-bot should be added to the channel being posted to.
+    """
+
+    def __init__(self, *, channel: str, text: str, **kwargs):
+        super().__init__(
+            slack_conn_id="slack_airflow_bot",
+            username="Airflow-bot",
+            channel=channel,
+            text=text,
+            **kwargs,
+        )
+
+
+class TaskRetrySlackNotifier(AirflowBotSlackNotifier):
+    """@Airflow-bot Slack notifier about task retries, intended to be used as a task retry callback.
+
+    * This notifier uses templates, so it shouldn't be shared between tasks.
+    * @Airflow-bot should be added to the channel being posted to.
+    """
+
+    def __init__(self, channel: str):
+        super().__init__(
+            channel=channel,
+            text=(
+                "⚠️ `{{ ti.task_id }}` in the `{{ ti.dag_id }}` DAG is "
+                f"<{TASK_INSTANCE_LINK_TEMPLATE}|retrying>."
+            ),
+        )
+
+
+class TaskFailureSlackNotifier(AirflowBotSlackNotifier):
+    """@Airflow-bot Slack notifier about task failures, intended to be used as a task failure callback.
+
+    * This notifier uses templates, so it shouldn't be shared between tasks.
+    * @Airflow-bot should be added to the channel being posted to.
+    """
+
+    def __init__(self, channel: str):
+        super().__init__(
+            channel=channel,
+            text=(
+                "🛑 `{{ ti.task_id }}` in the `{{ ti.dag_id }}` DAG "
+                f"<{TASK_INSTANCE_LINK_TEMPLATE}|failed>."
+            ),
+        )


### PR DESCRIPTION
## Description
So the Data Platform Engineering team is proactively notified about [copy_deduplicate](https://workflow.telemetry.mozilla.org/dags/copy_deduplicate/grid) DAG issues.

In the process I also added some reusable Slack notifier classes, and removed an outdated/unused `if_task_fails_alert_slack` function.

## Related Tickets & Documents
* DENG-10850: Institute DE coverage policies/processes for telemetry ingestion services