### PR TITLE
feat(highwind): Add DAG to schedule the Highwind experiment analysis job

### DIFF
--- a/dags/highwind.py
+++ b/dags/highwind.py
@@ -1,0 +1,103 @@
+"""
+See [highwind in the docker-etl repository](https://github.com/mozilla/docker-etl/tree/main/jobs/highwind).
+
+Highwind is a proof of concept for Nimbus experiment analysis. It aggregates per-branch sufficient
+statistics for Firefox Desktop guardrail metrics in BigQuery, then computes CUPED-adjusted
+sequential confidence intervals from them. One run is a full recompute of every live Firefox
+Desktop experiment: it reads the experiment mirror, aggregates each metric over windows anchored to
+each analysis unit's own enrollment, and writes results to the `highwind_poc` dataset in
+`moz-fx-data-experiments` plus one JSON blob per experiment.
+
+It runs alongside Jetstream and replaces nothing.
+"""
+
+from collections import namedtuple
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.sensors.external_task import ExternalTaskSensor
+
+from operators.gcp_container_operator import GKEPodOperator
+from utils.constants import ALLOWED_STATES, FAILED_STATES
+from utils.tags import Tag
+
+default_args = {
+    "owner": "jkerim@mozilla.com",
+    "email": ["jkerim@mozilla.com", "telemetry-alerts@mozilla.com"],
+    "depends_on_past": False,
+    "start_date": datetime(2026, 9, 3),
+    "email_on_failure": True,
+    "email_on_retry": False,
+    # A run recomputes every live experiment, so a retry costs a second full run's worth of
+    # scanning. The job already isolates per-experiment failures and exits non-zero only when every
+    # experiment failed, which is not a condition a retry fixes.
+    "retries": 0,
+}
+
+TAGS = [Tag.ImpactTier.tier_3]
+IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/highwind:latest"
+
+Upstream = namedtuple("Upstream", ["name", "dag_id", "task_id", "execution_delta"])
+
+# The tables the job reads, and how far ahead of this DAG each one's task is scheduled. The sensors
+# wait on the specific tasks rather than on a fixed offset from the schedule, so a slow upstream run
+# delays this one instead of being read half-written.
+UPSTREAM = [
+    Upstream(
+        "clients_daily",
+        "bqetl_main_summary",
+        "telemetry_derived__clients_daily__v6",
+        timedelta(hours=9),
+    ),
+    Upstream(
+        "clients_last_seen",
+        "bqetl_main_summary",
+        "telemetry_derived__clients_last_seen__v2",
+        timedelta(hours=9),
+    ),
+    Upstream(
+        "search_clients_daily",
+        "bqetl_search",
+        "search_derived__search_clients_daily__v8",
+        timedelta(hours=8),
+    ),
+]
+
+with DAG(
+    "highwind",
+    default_args=default_args,
+    # After bqetl_main_summary (02:00) and bqetl_search (03:00), far enough back that the sensors
+    # below are short in the ordinary case.
+    schedule_interval="0 11 * * *",
+    doc_md=__doc__,
+    tags=TAGS,
+    # A run writes the whole partition, so two overlapping runs would each scan everything and race
+    # to write the same rows.
+    max_active_runs=1,
+    catchup=False,
+) as dag:
+    highwind = GKEPodOperator(
+        task_id="highwind",
+        # The image's ENTRYPOINT is python, so the arguments start at -m rather than repeating it.
+        arguments=["-m", "highwind.main", "--date", "{{ ds }}"],
+        image=IMAGE,
+        # Headroom rather than a real bound: a full run finishes well inside an hour. It is here so
+        # a pathological run cannot hold slots all the way to BigQuery's own six hour query limit.
+        execution_timeout=timedelta(hours=4),
+        dag=dag,
+    )
+
+    for upstream in UPSTREAM:
+        wait_for_upstream = ExternalTaskSensor(
+            task_id=f"wait_for_{upstream.name}",
+            external_dag_id=upstream.dag_id,
+            external_task_id=upstream.task_id,
+            execution_delta=upstream.execution_delta,
+            check_existence=True,
+            mode="reschedule",
+            allowed_states=ALLOWED_STATES,
+            failed_states=FAILED_STATES,
+            pool="DATA_ENG_EXTERNALTASKSENSOR",
+        )
+
+        wait_for_upstream >> highwind

--- a/dags/highwind.py
+++ b/dags/highwind.py
@@ -23,7 +23,11 @@ from utils.tags import Tag
 
 default_args = {
     "owner": "jkerim@mozilla.com",
-    "email": ["jkerim@mozilla.com", "telemetry-alerts@mozilla.com"],
+    "email": [
+        "jkerim@mozilla.com",
+        "ykhurana@mozilla.com",
+        "telemetry-alerts@mozilla.com",
+    ],
     "depends_on_past": False,
     "start_date": datetime(2026, 9, 3),
     "email_on_failure": True,
@@ -34,7 +38,7 @@ default_args = {
     "retries": 0,
 }
 
-TAGS = [Tag.ImpactTier.tier_3]
+TAGS = [Tag.ImpactTier.tier_3, Tag.Triage.no_triage]
 IMAGE = "us-docker.pkg.dev/moz-fx-data-artifacts-prod/docker-etl/highwind:latest"
 
 Upstream = namedtuple("Upstream", ["name", "dag_id", "task_id", "execution_delta"])


### PR DESCRIPTION
## Description

Schedules the Highwind proof of concept ([mozilla/docker-etl#578](https://github.com/mozilla/docker-etl/pull/578)), which computes CUPED-adjusted sequential confidence intervals for live Firefox Desktop experiments from per-branch sufficient statistics aggregated in BigQuery. It runs alongside Jetstream and replaces nothing.

Because

* The Highwind proof of concept job lands in docker-etl, which publishes its container image, and nothing schedules that image.
* A run has to wait on the specific upstream tables it reads rather than on a fixed offset, since it aggregates `clients_daily`, `clients_last_seen` and `search_clients_daily`.

This commit

* Adds a daily DAG running the highwind docker-etl image for one run date.
* Waits on the three upstream bqetl tasks the job reads, via `ExternalTaskSensor`.
* Caps the DAG at one active run and disables retries, since a run is a full recompute of every live experiment.

Two things worth a reviewer's attention.

**The permissions are not in place yet.** The job writes tables to the `highwind_poc` dataset in `moz-fx-data-experiments`, and one JSON blob per experiment to `gs://mozanalysis/highwind/`. No DAG in this repo sets `service_account_name`, so the pod runs as the default identity on `workloads-prod-v1`, which needs `bigquery.tables.create` plus write on that dataset, and write on that bucket prefix. If someone can point me at the right identity I will request the grant. Until it lands the task fails at the write step, so this should not be unpaused on merge.

**Retries are off deliberately.** A run recomputes every live experiment, so a retry is a second full run's worth of scanning, and the job already isolates per-experiment failures and exits non-zero only when every experiment failed. Happy to add them back if the house style is to keep them regardless.

## Related Tickets & Documents

* [EXP-7482](https://mozilla-hub.atlassian.net/browse/EXP-7482) (this DAG)
* [EXP-7390](https://mozilla-hub.atlassian.net/browse/EXP-7390) (Highwind proof of concept epic)
* [mozilla/docker-etl#578](https://github.com/mozilla/docker-etl/pull/578) (the job this schedules)


[EXP-7482]: https://mozilla-hub.atlassian.net/browse/EXP-7482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ