### PR TITLE
chore(stable-write): Use stable-write SA in shredder and copy_dedupe

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mozilla/dataplatform-wg

--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -82,6 +82,7 @@ with models.DAG(
         task_id="copy_deduplicate_all_base",
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
+        service_account_name="stable-table-editor",
         priority_weight=100,
         parallelism=10,
         # Any table listed here under except_tables _must_ have a corresponding
@@ -111,6 +112,7 @@ with models.DAG(
             task_id="copy_deduplicate_glean_v2_backfill",
             target_project_id="moz-fx-data-shared-prod",
             billing_projects=("moz-fx-data-shared-prod",),
+            service_account_name="stable-table-editor",
             priority_weight=100,
             parallelism=4,
             only_tables=column_removal_backfill_tables_live,
@@ -122,6 +124,7 @@ with models.DAG(
         task_id="copy_deduplicate_sliced",
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
+        service_account_name="stable-table-editor",
         priority_weight=100,
         parallelism=5,
         hourly=True,
@@ -175,6 +178,7 @@ with models.DAG(
         task_id="copy_deduplicate_main_ping",
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
+        service_account_name="stable-table-editor",
         only_tables=[
             "telemetry_live.main_use_counter_v4",
             "telemetry_live.main_v5",
@@ -221,6 +225,7 @@ with models.DAG(
         task_id="copy_deduplicate_first_shutdown_ping",
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
+        service_account_name="stable-table-editor",
         only_tables=[
             "telemetry_live.first_shutdown_use_counter_v4",
             "telemetry_live.first_shutdown_v5",
@@ -261,6 +266,7 @@ with models.DAG(
         task_id="copy_deduplicate_event_ping",
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
+        service_account_name="stable-table-editor",
         only_tables=["telemetry_live.event_v4"],
         priority_weight=100,
         parallelism=1,

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -95,6 +95,7 @@ common_task_args = {
 telemetry_main = GKEPodOperator(
     task_id="telemetry_main",
     name="shredder-telemetry-main",
+    service_account_name="stable-table-editor",
     arguments=[
         *base_command,
         "--parallelism=2",
@@ -110,6 +111,7 @@ telemetry_main = GKEPodOperator(
 telemetry_main_use_counter = GKEPodOperator(
     task_id="telemetry_main_use_counter",
     name="shredder-telemetry-main-use-counter",
+    service_account_name="stable-table-editor",
     arguments=[
         *base_command,
         "--parallelism=2",
@@ -126,6 +128,7 @@ telemetry_main_use_counter = GKEPodOperator(
 flat_rate = GKEPodOperator(
     task_id="all",
     name="shredder-all",
+    service_account_name="stable-table-editor",
     arguments=[
         *base_command,
         "--parallelism={{ var.value.get('shredder_all_parallelism', 3) }}",
@@ -195,6 +198,7 @@ with_sampling = GKEPodOperator(
 desktop_metrics = GKEPodOperator(
     task_id="desktop-metrics",
     name="shredder-desktop-metrics",
+    service_account_name="stable-table-editor",
     arguments=[
         *base_command,
         "--parallelism={{ var.value.get('shredder_desktop_metrics_parallelism', 2) }}",
@@ -239,6 +243,7 @@ if column_removal_backfill_tables:
     column_removal = GKEPodOperator(
         task_id="column-removal",
         name="shredder-column-removal",
+        service_account_name="stable-table-editor",
         arguments=[
             *base_command,
             "--parallelism=3",

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -95,8 +95,7 @@ common_task_args = {
 # everything else combined
 telemetry_main = GKEPodOperator(
     task_id="telemetry_main",
-    name="shredder-telemetry-main",
-    service_account_name="stable-table-editor",
+    name="shredder-telemetry-main"
     arguments=[
         *base_command,
         "--parallelism=2",
@@ -111,8 +110,7 @@ telemetry_main = GKEPodOperator(
 
 telemetry_main_use_counter = GKEPodOperator(
     task_id="telemetry_main_use_counter",
-    name="shredder-telemetry-main-use-counter",
-    service_account_name="stable-table-editor",
+    name="shredder-telemetry-main-use-counter"
     arguments=[
         *base_command,
         "--parallelism=2",
@@ -128,8 +126,7 @@ telemetry_main_use_counter = GKEPodOperator(
 # everything else
 flat_rate = GKEPodOperator(
     task_id="all",
-    name="shredder-all",
-    service_account_name="stable-table-editor",
+    name="shredder-all"
     arguments=[
         *base_command,
         "--parallelism={{ var.value.get('shredder_all_parallelism', 3) }}",
@@ -198,8 +195,7 @@ with_sampling = GKEPodOperator(
 
 desktop_metrics = GKEPodOperator(
     task_id="desktop-metrics",
-    name="shredder-desktop-metrics",
-    service_account_name="stable-table-editor",
+    name="shredder-desktop-metrics"
     arguments=[
         *base_command,
         "--parallelism={{ var.value.get('shredder_desktop_metrics_parallelism', 2) }}",
@@ -244,7 +240,6 @@ if column_removal_backfill_tables:
     column_removal = GKEPodOperator(
         task_id="column-removal",
         name="shredder-column-removal",
-        service_account_name="stable-table-editor",
         arguments=[
             *base_command,
             "--parallelism=3",

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -86,6 +86,7 @@ common_task_args = {
     "on_finish_action": OnFinishAction.DELETE_POD.value,
     "reattach_on_restart": True,
     "dag": dag,
+    "service_account_name": "stable-table-editor",
 }
 
 # handle telemetry main and main use counter separately to ensure they run continuously

--- a/dags/shredder.py
+++ b/dags/shredder.py
@@ -95,7 +95,7 @@ common_task_args = {
 # everything else combined
 telemetry_main = GKEPodOperator(
     task_id="telemetry_main",
-    name="shredder-telemetry-main"
+    name="shredder-telemetry-main",
     arguments=[
         *base_command,
         "--parallelism=2",
@@ -110,7 +110,7 @@ telemetry_main = GKEPodOperator(
 
 telemetry_main_use_counter = GKEPodOperator(
     task_id="telemetry_main_use_counter",
-    name="shredder-telemetry-main-use-counter"
+    name="shredder-telemetry-main-use-counter",
     arguments=[
         *base_command,
         "--parallelism=2",
@@ -126,7 +126,7 @@ telemetry_main_use_counter = GKEPodOperator(
 # everything else
 flat_rate = GKEPodOperator(
     task_id="all",
-    name="shredder-all"
+    name="shredder-all",
     arguments=[
         *base_command,
         "--parallelism={{ var.value.get('shredder_all_parallelism', 3) }}",
@@ -195,7 +195,7 @@ with_sampling = GKEPodOperator(
 
 desktop_metrics = GKEPodOperator(
     task_id="desktop-metrics",
-    name="shredder-desktop-metrics"
+    name="shredder-desktop-metrics",
     arguments=[
         *base_command,
         "--parallelism={{ var.value.get('shredder_desktop_metrics_parallelism', 2) }}",


### PR DESCRIPTION
## Description

Depends on https://github.com/mozilla/dataservices-infra/pull/2261

This is to update the `copy_dedupe` and `shredder` DAGs to use the SA that has dedicated write access to stable tables.

## Related Tickets & Documents
* proposal: https://docs.google.com/document/d/1KhWaH-o7EDG1PaOR7JKrGWyP8hmdtodCQRino-PKbA0/edit?tab=t.0

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
