### PR TITLE
chore(stable-editor): Use stable-table-editor SA for first_shutdown_ping

### DIFF
--- a/dags/copy_deduplicate.py
+++ b/dags/copy_deduplicate.py
@@ -213,6 +213,7 @@ with models.DAG(
         task_id="copy_deduplicate_first_shutdown_ping",
         target_project_id="moz-fx-data-shared-prod",
         billing_projects=("moz-fx-data-shared-prod",),
+        service_account_name="stable-table-editor",
         only_tables=[
             "telemetry_live.first_shutdown_use_counter_v4",
             "telemetry_live.first_shutdown_v5",


### PR DESCRIPTION
## Description

This is to test the new `stable-table-editor` SA on the `copy_deduplicate_first_shutdown_ping` before using it for other tasks that write to stable tables (https://github.com/mozilla/telemetry-airflow/pull/2424/changes). 

I created a new k8s service account via `kubectl create serviceaccount stable-table-editor -n default` and ran `kubectl annotate serviceaccount --namespace default stable-table-editor iam.gke.io/gcp-service-account=stable-table-editor@moz-fx-data-airflow-gke-prod.iam.gserviceaccount.com` so it can be referenced as `stable-table-editor` in the Airflow task definition.

Currently, both the default SA and `stable-table-editor` still have write access to stable tables.

<!-- 
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been 
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->
