### PR TITLE
fix(highwind): move the schedule off peak to 23:00 UTC

### DIFF
--- a/dags/highwind.py
+++ b/dags/highwind.py
@@ -51,28 +51,30 @@ UPSTREAM = [
         "clients_daily",
         "bqetl_main_summary",
         "telemetry_derived__clients_daily__v6",
-        timedelta(hours=9),
+        timedelta(hours=21),
     ),
     Upstream(
         "clients_last_seen",
         "bqetl_main_summary",
         "telemetry_derived__clients_last_seen__v2",
-        timedelta(hours=9),
+        timedelta(hours=21),
     ),
     Upstream(
         "search_clients_daily",
         "bqetl_search",
         "search_derived__search_clients_daily__v8",
-        timedelta(hours=8),
+        timedelta(hours=20),
     ),
 ]
 
 with DAG(
     "highwind",
     default_args=default_args,
-    # After bqetl_main_summary (02:00) and bqetl_search (03:00), far enough back that the sensors
-    # below are short in the ordinary case.
-    schedule_interval="0 11 * * *",
+    # Late enough that the upstreams below are done even on their slowest days, since
+    # search_clients_daily has finished as late as 19:00, and inside the quietest window on the
+    # shared analysis-and-etl reservation. A run's cost is fixed but its wall time is set by how
+    # many slots it can get, and 06:00 to 12:00 is where the neighbouring Jetstream load peaks.
+    schedule_interval="0 23 * * *",
     doc_md=__doc__,
     tags=TAGS,
     # A run writes the whole partition, so two overlapping runs would each scan everything and race
@@ -85,8 +87,9 @@ with DAG(
         # The image's ENTRYPOINT is python, so the arguments start at -m rather than repeating it.
         arguments=["-m", "highwind.main", "--date", "{{ ds }}"],
         image=IMAGE,
-        # Headroom rather than a real bound: a full run finishes well inside an hour. It is here so
-        # a pathological run cannot hold slots all the way to BigQuery's own six hour query limit.
+        # Headroom rather than a real bound: a full run takes well under two hours when it is not
+        # contending for slots. It is here so a pathological run cannot hold slots all the way to
+        # BigQuery's own six hour query limit.
         execution_timeout=timedelta(hours=4),
         dag=dag,
     )


### PR DESCRIPTION
## Description

Because

* Every run recomputes the same set of experiments, so its cost is fixed, but its wall time depends on how many slots it can get, and the 11:00 slot sits in the busiest window on the shared analysis-and-etl reservation.
* Wall time grew from about half an hour, to two hours, to over four across the first three runs, and the third exceeded execution_timeout and was killed having written nothing.
* 11:00 is also earlier than the upstreams reliably finish. Over 21 days search_clients_daily has a p95 of 13:19 and has run as late as 19:21, so the sensors can hold for hours.

This commit

* Moves the schedule to 23:00 UTC, the quietest hour the upstream dependencies allow, so a run contends for slots with far less neighbouring work.
* Recomputes each sensor's execution_delta for the new hour, so they still resolve to bqetl_main_summary at 02:00 and bqetl_search at 03:00.

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/EXP-7539


