### PR TITLE
fix(highwind): drop the execution timeout

### DIFF
--- a/dags/highwind.py
+++ b/dags/highwind.py
@@ -85,9 +85,10 @@ with DAG(
         # The image's ENTRYPOINT is python, so the arguments start at -m rather than repeating it.
         arguments=["-m", "highwind.main", "--date", "{{ ds }}"],
         image=IMAGE,
-        # Headroom rather than a real bound: a full run finishes well inside an hour. It is here so
-        # a pathological run cannot hold slots all the way to BigQuery's own six hour query limit.
-        execution_timeout=timedelta(hours=4),
+        # No execution_timeout. A run's cost is fixed but its wall time is set by how many slots it
+        # can get on the shared reservation, so the only timeout that would not kill a healthy run
+        # on a contended day is one long enough to be no bound at all. BigQuery's own six hour limit
+        # per query is what stops a run hanging indefinitely.
         dag=dag,
     )
 


### PR DESCRIPTION
## Description

Because

* The timeout fired on a healthy run. A run recomputes the same set of experiments every day, so its work is fixed, but its wall time is set by how many slots it can get on the shared analysis-and-etl reservation.
* Two of the three parallel metric queries were still executing when it fired, so a day's results were lost to the bound rather than to any failure, and nothing was written.
* Any timeout that would not kill a healthy run on a contended day is long enough not to be a bound, and BigQuery's own six hour limit per query already stops a run hanging indefinitely.

This commit

* Removes execution_timeout from the highwind task.


## Related Tickets & Documents
https://mozilla-hub.atlassian.net/browse/EXP-7540